### PR TITLE
refactor(native): remove dead MON_* runtime knobs (stage-1)

### DIFF
--- a/Quick_Start.ipynb
+++ b/Quick_Start.ipynb
@@ -268,7 +268,6 @@
     "os.environ.setdefault(\"MON_NATIVE_CALLBACK\", \"1\")\n",
     "os.environ.setdefault(\"MON_NATIVE_BUILDER\", \"1\")\n",
     "os.environ.setdefault(\"MON_NATIVE_BATCH\", \"0\")\n",
-    "os.environ.setdefault(\"MON_NATIVE_AUTOCLEAR\", \"0\")\n",
     "\n",
     "if not torch.cuda.is_available():\n",
     "    raise RuntimeError(\"CUDA required; skip this section if not available.\")\n"

--- a/benchmark/scripts/debug_monitoring.py
+++ b/benchmark/scripts/debug_monitoring.py
@@ -8,7 +8,6 @@ os.environ["MON_NATIVE_TO_CPU"] = "1"
 os.environ["MON_NATIVE_CALLBACK"] = "1"
 os.environ["MON_NATIVE_BUILDER"] = "1"
 os.environ["MON_NATIVE_BATCH"] = "0"
-os.environ["MON_NATIVE_AUTOCLEAR"] = "1"
 
 import torch
 print("[DEBUG] torch imported")

--- a/benchmark/scripts/hf_monitoring_generate.py
+++ b/benchmark/scripts/hf_monitoring_generate.py
@@ -148,13 +148,6 @@ def main() -> None:
     os.environ.setdefault("MON_NATIVE_PINPOOL", "1")
     os.environ.setdefault("MON_NATIVE_HOST_COPY_THREADS", "5")
 
-    if args.no_db:
-        # No DB path: disable auto-cleanup; we'll clear once after the run.
-        os.environ["MON_NATIVE_AUTOCLEAR"] = "0"
-    else:
-        # Prevent native backend from clearing futures before host_engine consumes them.
-        os.environ["MON_NATIVE_AUTOCLEAR"] = "0"
-
     if not torch.cuda.is_available():
         raise RuntimeError("Monitoring benchmark requires CUDA + native backend.")
 

--- a/docs/dev_log/2026_02_25_issue18_env_audit_stage1.md
+++ b/docs/dev_log/2026_02_25_issue18_env_audit_stage1.md
@@ -1,0 +1,63 @@
+# Issue #18 Stage-1: Runtime Env Audit and Dead Code Removal
+
+Date: 2026-02-25  
+Issue: https://github.com/ProjectDMX/DMI/issues/18
+
+## Scope
+
+Stage-1 is intentionally small:
+- Audit runtime `MON_*` knobs in native-engine paths.
+- Remove knobs that are read but have no behavioral effect.
+
+No runtime behavior redesign in this PR.
+
+## Removed Dead Knobs
+
+The following knobs were removed because they had no effective consumers:
+- `MON_NATIVE_AUTOCLEAR`
+- `MON_NATIVE_STEP_STATS`
+- `MON_NATIVE_PINPOOL_SLOTS_PER_BIN`
+- `MON_NATIVE_PIN_THRESH_BYTES`
+
+## Code Paths Cleaned
+
+- Native fields removed:
+  - `auto_cleanup_`
+  - `stats_step_log_`
+  - `pinpool_slots_per_bin_`
+  - `pinpool_thresh_bytes_`
+- Native env reads removed from `engine_core.cpp`.
+- Test/example/benchmark/no-op env assignments removed.
+- Quick-start notebook no longer sets `MON_NATIVE_AUTOCLEAR`.
+
+## Out of Scope
+
+Still kept (runtime-relevant today):
+- `MON_NATIVE_TO_CPU`, `MON_NATIVE_PINNED`, `MON_NATIVE_PINPOOL`, `MON_NATIVE_PINPOOL_BINS_KB`
+- `MON_NATIVE_HOST_COPY_THREADS`, `MON_NATIVE_HOST_COPY_QUEUE_SIZE`
+- `MON_NATIVE_PINNED_INDEX`
+- `MON_NATIVE_BATCH`, `MON_NATIVE_BUILDER`, `MON_NATIVE_CALLBACK`
+
+Build-time knobs remain unchanged in `_native_engine.py`.
+
+## Short PR Description (English)
+
+```markdown
+## Summary
+Stage-1 cleanup for Issue #18: removed runtime `MON_*` knobs that were dead (read but not used).
+
+## Removed
+- MON_NATIVE_AUTOCLEAR
+- MON_NATIVE_STEP_STATS
+- MON_NATIVE_PINPOOL_SLOTS_PER_BIN
+- MON_NATIVE_PIN_THRESH_BYTES
+
+## Changes
+- Deleted unused native fields and `getenv(...)` reads.
+- Removed no-op env settings from tests/examples/benchmark scripts.
+- Kept all runtime-relevant knobs unchanged.
+
+## Validation
+- Grep confirms no runtime references to the four removed knobs in code paths.
+- Existing native test paths remain intact.
+```

--- a/example/gpt2_generate_with_monitoring_db.py
+++ b/example/gpt2_generate_with_monitoring_db.py
@@ -70,8 +70,6 @@ def main() -> None:
     os.environ.setdefault("MON_NATIVE_CALLBACK", "1")
     os.environ.setdefault("MON_NATIVE_BUILDER", "1")
     os.environ.setdefault("MON_NATIVE_BATCH", "0")
-    # Prevent native backend from clearing futures before host_engine consumes them.
-    os.environ.setdefault("MON_NATIVE_AUTOCLEAR", "0")
 
     if not torch.cuda.is_available():
         raise RuntimeError("This example requires CUDA + native backend.")

--- a/monitoring/csrc/engine_core.cpp
+++ b/monitoring/csrc/engine_core.cpp
@@ -30,14 +30,6 @@ NativeMonitoringEngine::Impl::Impl(int64_t queue_size,
   if (const char* v = std::getenv("MON_NATIVE_PINNED")) {
     use_pinned_ = (*v != '0');
   }
-  if (const char* v = std::getenv("MON_NATIVE_AUTOCLEAR")) {
-    auto_cleanup_ = (*v != '0');
-  }
-  if (const char* v = std::getenv("MON_NATIVE_STEP_STATS")) {
-    stats_step_log_ = (*v != '0');
-  } else if (const char* v = std::getenv("MON_ENGINE_STATS")) {
-    stats_step_log_ = (*v != '0');
-  }
 
   // Configure pinned pool (enabled only when pinned offload is in use)
   enable_pinpool_ = false;
@@ -73,17 +65,9 @@ NativeMonitoringEngine::Impl::Impl(int64_t queue_size,
                                8ull * 1024ull * 1024ull};
       }
     }
-    if (const char* v = std::getenv("MON_NATIVE_PINPOOL_SLOTS_PER_BIN")) {
-      int slots = std::atoi(v);
-      if (slots > 0) pinpool_slots_per_bin_ = slots;
-    }
     if (const char* v = std::getenv("MON_NATIVE_PINPOOL_MAX_MB")) {
       size_t mb = static_cast<size_t>(std::strtoull(v, nullptr, 10));
       if (mb > 0) pinpool_max_bytes_ = mb * 1024ull * 1024ull;
-    }
-    if (const char* v = std::getenv("MON_NATIVE_PIN_THRESH_BYTES")) {
-      size_t th = static_cast<size_t>(std::strtoull(v, nullptr, 10));
-      if (th > 0) pinpool_thresh_bytes_ = th;
     }
   }
 

--- a/monitoring/csrc/native_engine_internal.h
+++ b/monitoring/csrc/native_engine_internal.h
@@ -218,7 +218,6 @@ struct NativeMonitoringEngine::Impl {
   // D2H offload controls
   bool move_to_cpu_{false};
   bool use_pinned_{true};
-  bool auto_cleanup_{true};
 
   // Pinned memory pool (for stable GPU->CPU offload throughput)
   struct PinnedBlock {
@@ -231,10 +230,8 @@ struct NativeMonitoringEngine::Impl {
 
   // Pool controls and state
   bool enable_pinpool_{false};
-  size_t pinpool_thresh_bytes_{64 * 1024}; // small tensors fallback to pageable
   size_t pinpool_max_bytes_{512ull * 1024ull * 1024ull}; // total pool cap
   std::vector<size_t> pinpool_bins_bytes_; // capacity bins in bytes (ascending)
-  int pinpool_slots_per_bin_{8};
 
   // Storage
   std::mutex pool_mutex_;
@@ -346,7 +343,6 @@ struct NativeMonitoringEngine::Impl {
   std::atomic<int64_t> stats_submit_us_{0};
   std::atomic<int64_t> stats_process_us_{0};
   std::atomic<int64_t> stats_callback_us_{0};
-  bool stats_step_log_{false};
 };
 
 }  // namespace monitoring

--- a/tests/test_cpp_future_result.py
+++ b/tests/test_cpp_future_result.py
@@ -45,7 +45,6 @@ def test_cpp_future_result_with_end_step_flow(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
     monkeypatch.setenv("MON_NATIVE_PINNED", "1")
     monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-    monkeypatch.setenv("MON_NATIVE_AUTOCLEAR", "0")
 
     engine = MonitoringEngine(async_enabled=True)
     device = torch.device("cuda")
@@ -104,7 +103,6 @@ def test_cpp_backendfuture_result_does_not_block_engine_close(
     monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
     monkeypatch.setenv("MON_NATIVE_PINNED", "1")
     monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-    monkeypatch.setenv("MON_NATIVE_AUTOCLEAR", "0")
 
     engine = MonitoringEngine(async_enabled=True)
     device = torch.device("cuda")

--- a/tests/test_generate_with_monitoring.py
+++ b/tests/test_generate_with_monitoring.py
@@ -95,7 +95,6 @@ def test_generate_and_forward_collect_cpp_futures_and_consume_results(monkeypatc
     monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
     monkeypatch.setenv("MON_NATIVE_PINNED", "1")
     monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-    monkeypatch.setenv("MON_NATIVE_AUTOCLEAR", "0")
     monkeypatch.setenv("MON_NATIVE_BUILDER", "1")
     monkeypatch.setenv("MON_NATIVE_CALLBACK", "1")
     monkeypatch.setenv("MON_NATIVE_BATCH", "0")

--- a/tests/validate_request_id_pipeline.py
+++ b/tests/validate_request_id_pipeline.py
@@ -276,7 +276,6 @@ def main() -> None:
     os.environ.setdefault("MON_NATIVE_PINNED", "1")
     os.environ.setdefault("MON_NATIVE_PINPOOL", "1")
     os.environ.setdefault("MON_NATIVE_HOST_COPY_THREADS", "4")
-    os.environ.setdefault("MON_NATIVE_AUTOCLEAR", "0")
 
     prompts = _load_prompts(args.prompts)
     device = torch.device(args.device)


### PR DESCRIPTION
## Summary
Stage-1 cleanup for Issue #18: removed runtime MON_* knobs that were dead (read but not used).

## Removed
- MON_NATIVE_AUTOCLEAR
- MON_NATIVE_STEP_STATS
- MON_NATIVE_PINPOOL_SLOTS_PER_BIN
- MON_NATIVE_PIN_THRESH_BYTES

## Changes
- Deleted unused native fields and getenv(...) reads.
- Removed no-op env settings from tests/examples/benchmark scripts.
- Kept runtime-relevant knobs unchanged.

## Validation
- Grep confirms no runtime references to the four removed knobs in monitored code paths.
- Native test paths remain unchanged in logic.

Refs #18