### PR TITLE
refactor: finalize runtime config cleanup for issue #18

### DIFF
--- a/Quick_Start.ipynb
+++ b/Quick_Start.ipynb
@@ -250,8 +250,8 @@
    "id": "9686af0a",
    "metadata": {},
    "source": [
-    "### 1) Environment variables and CUDA check\n",
-    "Set native backend flags and ensure CUDA is available.\n"
+    "### 1) Runtime check and CUDA check\n",
+    "Native runtime flags are now config-driven; here we only verify CUDA availability.\n"
    ]
   },
   {
@@ -263,11 +263,6 @@
    "source": [
     "import os\n",
     "import torch\n",
-    "\n",
-    "os.environ.setdefault(\"MON_NATIVE_TO_CPU\", \"1\")\n",
-    "os.environ.setdefault(\"MON_NATIVE_CALLBACK\", \"1\")\n",
-    "os.environ.setdefault(\"MON_NATIVE_BUILDER\", \"1\")\n",
-    "os.environ.setdefault(\"MON_NATIVE_BATCH\", \"0\")\n",
     "\n",
     "if not torch.cuda.is_available():\n",
     "    raise RuntimeError(\"CUDA required; skip this section if not available.\")\n"

--- a/README.md
+++ b/README.md
@@ -235,13 +235,11 @@ Optional DB overrides:
 
 ## Run Benchmark
 
-## Environment Variables for Benchmarks
+## Benchmark Runtime Config
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MON_NATIVE_CALLBACK` | `1` | Use C++ callbacks (faster) |
-| `MON_NATIVE_BATCH` | `1` | Batch hook submissions |
-| `MON_NATIVE_TO_CPU` | `1` | Enable async GPU→CPU transfer |
+- Runtime env toggles under `MON_NATIVE_*` are removed.
+- Use `MonitoringConfig` for runtime tuning (`advance.*`) and debug behavior (`debug`).
+- For benchmark scripts that expose it, use `--nvtx` to enable debug/NVTX (`MonitoringConfig.debug=True`).
 
 ### Args
 ```bash
@@ -257,10 +255,10 @@ Compares multiple inference approaches (TransformerLens, HuggingFace, HookedGPT2
 
 
 # Basic run
-MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 MON_NATIVE_BATCH=1 python -m benchmark.tests.profile_decode_qwen3 --batch-size 1 --steps 1 --warmup 1 --collect-hidden --collect-attention --no-profile --dtype fp16
+python -m benchmark.tests.profile_decode_qwen3 --batch-size 1 --steps 1 --warmup 1 --collect-hidden --collect-attention --no-profile --dtype fp16
 
 # With nsight profiling
-MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 TL_ENABLE_NVTX=1 nsys profile --output=your_results_path/xxx --force-overwrite=true --trace=cuda,nvtx,osrt --sample=cpu --sampling-period=1000000 --cpuctxsw=process-tree --cuda-memory-usage=false  python benchmark/tests/profile_decode.py. --profile-dir your_results_dir/xxx. --batch-size 64  --decode-steps 64  --collect-hidden  --collect-attention  --steps 1  --warmup 1  --no-profile
+nsys profile --output=your_results_path/xxx --force-overwrite=true --trace=cuda,nvtx,osrt --sample=cpu --sampling-period=1000000 --cpuctxsw=process-tree --cuda-memory-usage=false python -m benchmark.tests.profile_decode --profile-dir your_results_dir/xxx --batch-size 64 --decode-steps 64 --collect-hidden --collect-attention --steps 1 --warmup 1 --no-profile --nvtx
 
 **Tested configurations:**
 - `transformer_lens` / `transformer_lens_cache` - Original TransformerLens
@@ -272,7 +270,7 @@ MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 TL_ENABLE_NVTX=1 nsys profile --output
 Tests different MonitoringConfig settings (full capture vs sampled):
 
 ```bash
-MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 MON_NATIVE_BATCH=1 python benchmark/tests/hf_modified_async_config_benchmark.py --batch-size 64 --steps 1 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention
+python benchmark/tests/hf_modified_async_config_benchmark.py --batch-size 64 --steps 1 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention
 ```
 
 ### hf_modified_async_config_token_stride_benchmark.py - Token Stride Impact
@@ -280,7 +278,7 @@ MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 MON_NATIVE_BATCH=1 python benchmark/te
 Measures performance impact of different `step_stride` values:
 
 ```bash
-MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 MON_NATIVE_BATCH=1 python benchmark/tests/hf_modified_async_config_token_stride_benchmark.py --batch-size 64 --steps 1 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention
+python benchmark/tests/hf_modified_async_config_token_stride_benchmark.py --batch-size 64 --steps 1 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention
 ```
 
 Tests strides: `[1, 10, 30, 400]` - higher stride = fewer captures = faster
@@ -290,7 +288,7 @@ Tests strides: `[1, 10, 30, 400]` - higher stride = fewer captures = faster
 Measures performance impact of different `request_stride` values:
 
 ```bash
-MON_NATIVE_TO_CPU=1 MON_NATIVE_CALLBACK=1 MON_NATIVE_BATCH=1 python benchmark/tests/hf_modified_async_config_request_stride_benchmark.py --batch-size 64 --steps 10 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention —no-profile
+python benchmark/tests/hf_modified_async_config_request_stride_benchmark.py --batch-size 64 --steps 10 --warmup 1 --decode-steps 64 --collect-hidden --collect-attention --no-profile
 ```
 
 Tests strides: `[1, 2, 5, 100]` - higher stride = skip more requests -->

--- a/benchmark/run_bench.py
+++ b/benchmark/run_bench.py
@@ -138,7 +138,6 @@ def main() -> None:
     base_env = os.environ.copy()
     if args.nvtx:
         base_env["BENCH_NVTX"] = "1"
-        base_env.setdefault("TL_ENABLE_NVTX", "1")
 
     if args.monitor_mem:
         procs = _start_monitors(

--- a/benchmark/scripts/debug_monitoring.py
+++ b/benchmark/scripts/debug_monitoring.py
@@ -1,13 +1,5 @@
 """Debug script to identify where monitoring hangs."""
-import os
 import sys
-
-# Enable debug output
-os.environ["MON_ENGINE_DEBUG"] = "1"
-os.environ["MON_NATIVE_TO_CPU"] = "1"
-os.environ["MON_NATIVE_CALLBACK"] = "1"
-os.environ["MON_NATIVE_BUILDER"] = "1"
-os.environ["MON_NATIVE_BATCH"] = "0"
 
 import torch
 print("[DEBUG] torch imported")
@@ -31,6 +23,7 @@ def main():
     cfg = MonitoringConfig(
         hooks=HookSelection(mode="full"),
         schedule=CaptureSchedule(capture_prefill=True, capture_decode=True),
+        debug=True,
     )
     engine = MonitoringEngine(
         async_enabled=True,

--- a/benchmark/scripts/hf_monitoring_generate.py
+++ b/benchmark/scripts/hf_monitoring_generate.py
@@ -13,6 +13,7 @@ from transformers.models.gpt2_p.modeling_gpt2 import HookedGPT2LMHeadModel
 from transformers.models.qwen3_p.modeling_qwen3 import HookedQwen3ForCausalLM
 
 from monitoring import (
+    AdvanceConfig,
     ClickHouseClientConfig,
     EnqueuePolicy,
     HostEngineConfig,
@@ -109,9 +110,9 @@ def _build_ingress_policy() -> EnqueuePolicy:
     return p
 
 
-def _build_host_config(db_cfg: ClickHouseClientConfig) -> HostEngineConfig:
+def _build_host_config(db_cfg: ClickHouseClientConfig, *, debug: bool = False) -> HostEngineConfig:
     # Stage 1: wait on BackendFuture + parse payloads
-    stage_one = StageConfig.process_future(parallelism=1, name="process_future")
+    stage_one = StageConfig.process_future(parallelism=1, name="process_future", debug=bool(debug))
     # Stage 2: insert into ClickHouse
     stage_two = StageConfig.clickhouse_insert(db_cfg, parallelism=1, name="clickhouse_insert")
 
@@ -138,16 +139,6 @@ def main() -> None:
     args = parser.parse_args()
     model_id = _resolve_model_id(args.model)
 
-    # Native backend must be enabled for MonitoringEngine + (optional) DB futures.
-    os.environ.setdefault("MON_NATIVE_TO_CPU", "1")
-    os.environ.setdefault("MON_NATIVE_CALLBACK", "1")
-    os.environ.setdefault("MON_NATIVE_BUILDER", "1")
-    os.environ.setdefault("MON_NATIVE_BATCH", "0")
-    # Enable pinned and memcpy pool.
-    os.environ.setdefault("MON_NATIVE_PINNED", "1")
-    os.environ.setdefault("MON_NATIVE_PINPOOL", "1")
-    os.environ.setdefault("MON_NATIVE_HOST_COPY_THREADS", "5")
-
     if not torch.cuda.is_available():
         raise RuntimeError("Monitoring benchmark requires CUDA + native backend.")
 
@@ -167,12 +158,14 @@ def main() -> None:
             cap_ratio=0.8,
             driver_guard_mb=1024,
         ),
+        advance=AdvanceConfig(host_copy_threads=0),
+        debug=os.environ.get("BENCH_NVTX", "0") == "1",
     )
 
     host_cfg = None
     if not args.no_db:
         db_cfg = _build_db_config()
-        host_cfg = _build_host_config(db_cfg)
+        host_cfg = _build_host_config(db_cfg, debug=bool(cfg.debug))
 
     engine = MonitoringEngine(
         async_enabled=True,

--- a/benchmark/tests/hf_modified_async_only.py
+++ b/benchmark/tests/hf_modified_async_only.py
@@ -225,10 +225,6 @@ def run_decode_loop(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        import os
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     dtype = map_dtype(args.dtype)
 
@@ -466,7 +462,7 @@ def main() -> None:
     if not args.no_profile:
         print(f"\nProfiler traces written under: {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled (MonitoringConfig.debug=True).")
 
 
 if __name__ == "__main__":

--- a/benchmark/tests/hf_modified_lmhead_async_only.py
+++ b/benchmark/tests/hf_modified_lmhead_async_only.py
@@ -223,10 +223,6 @@ def run_decode_loop(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        import os
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     dtype = map_dtype(args.dtype)
 

--- a/benchmark/tests/hf_modified_no_cache.py
+++ b/benchmark/tests/hf_modified_no_cache.py
@@ -170,10 +170,6 @@ def run_decode_loop(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        import os
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     dtype = map_dtype(args.dtype)
 
@@ -343,7 +339,7 @@ def main() -> None:
     if not args.no_profile:
         print(f"\nProfiler traces written under: {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled (MonitoringConfig.debug=True).")
 
 
 if __name__ == "__main__":

--- a/benchmark/tests/hf_modified_sync_only.py
+++ b/benchmark/tests/hf_modified_sync_only.py
@@ -160,10 +160,6 @@ def run_decode_loop(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        import os
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     dtype = map_dtype(args.dtype)
 
@@ -328,7 +324,7 @@ def main() -> None:
     if not args.no_profile:
         print(f"\nProfiler traces written under: {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled (MonitoringConfig.debug=True).")
 
 
 if __name__ == "__main__":

--- a/benchmark/tests/profile_decode.py
+++ b/benchmark/tests/profile_decode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -70,7 +69,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--nvtx",
         action="store_true",
-        help="Enable NVTX annotations inside TransformerLens hooks (sets TL_ENABLE_NVTX=1)",
+        help="Enable NVTX annotations inside TransformerLens hooks (enables MonitoringConfig.debug)",
     )
     parser.add_argument(
         "--collect-hidden",
@@ -532,9 +531,6 @@ def setup_hf_decode_hook(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     hf_dtype = map_hf_dtype(args.dtype)
     tl_dtype = map_tl_dtype(args.dtype)
@@ -573,7 +569,7 @@ def main() -> None:
         cache_dtype=cache_dtype,
         queue_size=args.engine_queue_size,
         delay_steps=args.engine_delay_steps,
-        config=MonitoringConfig(),
+        config=MonitoringConfig(debug=args.nvtx),
     )
     hf_hooked_model.monitoring_engine = None
     engine_init_ms = 0.0
@@ -1127,12 +1123,10 @@ def main() -> None:
         print("\nProfiler traces written under:")
         print(f"  {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled for TransformerLens decode hooks (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled for TransformerLens decode hooks (MonitoringConfig.debug=True).")
 
-    # If engine stats are enabled, also print hook-side stats even for sync baselines.
     try:
-        import os as _os
-        if bool(int(_os.environ.get("MON_ENGINE_STATS", "0"))):
+        if args.nvtx:
             from monitoring.hook_points import get_monitoring_hook_stats
             _hook_stats = get_monitoring_hook_stats()
             if _hook_stats:

--- a/benchmark/tests/profile_decode_qwen3.py
+++ b/benchmark/tests/profile_decode_qwen3.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import gc
-import os
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -70,7 +69,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--nvtx",
         action="store_true",
-        help="Enable NVTX annotations inside hook points (sets TL_ENABLE_NVTX=1)",
+        help="Enable NVTX annotations inside hook points (enables MonitoringConfig.debug)",
     )
     parser.add_argument(
         "--collect-hidden",
@@ -535,9 +534,6 @@ def setup_hf_decode_hook(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     hf_dtype = map_hf_dtype(args.dtype)
 
@@ -957,7 +953,7 @@ def main() -> None:
         cache_dtype=cache_dtype,
         queue_size=args.engine_queue_size,
         delay_steps=args.engine_delay_steps,
-        config=MonitoringConfig(),
+        config=MonitoringConfig(debug=args.nvtx),
     )
     hf_hooked_model.monitoring_engine = None
     engine_init_ms = 0.0
@@ -1075,12 +1071,10 @@ def main() -> None:
         print("\nProfiler traces written under:")
         print(f"  {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled for hook point decode paths (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled for hook point decode paths (MonitoringConfig.debug=True).")
 
-    # If engine stats are enabled, also print hook-side stats even for sync baselines.
     try:
-        import os as _os
-        if bool(int(_os.environ.get("MON_ENGINE_STATS", "0"))):
+        if args.nvtx:
             from monitoring.hook_points import get_monitoring_hook_stats
             _hook_stats = get_monitoring_hook_stats()
             if _hook_stats:

--- a/benchmark/tests/profile_inference.py
+++ b/benchmark/tests/profile_inference.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple, Union
 
@@ -54,7 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--nvtx",
         action="store_true",
-        help="Enable NVTX annotations inside TransformerLens hooks (sets TL_ENABLE_NVTX=1)",
+        help="Enable NVTX annotations inside TransformerLens hooks (enables MonitoringConfig.debug)",
     )
     parser.add_argument(
         "--collect-hidden",
@@ -265,9 +264,6 @@ def profile_async_model(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     hf_dtype = map_hf_dtype(args.dtype)
     tl_dtype = map_tl_dtype(args.dtype)
@@ -276,6 +272,7 @@ def main() -> None:
     from transformers.models.gpt2_p.modeling_gpt2 import HookedGPT2Model
     from transformer_lens import HookedTransformer
     from monitoring import MonitoringEngine
+    from monitoring.config import MonitoringConfig
 
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     if tokenizer.pad_token is None:
@@ -321,6 +318,7 @@ def main() -> None:
         cache_dtype=cache_dtype,
         queue_size=args.engine_queue_size,
         delay_steps=args.engine_delay_steps,
+        config=MonitoringConfig(debug=args.nvtx),
     )
     hf_hooked_model.monitoring_engine = None
 
@@ -841,7 +839,7 @@ def main() -> None:
         print("\nProfiler traces written under:")
         print(f"  {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled for TransformerLens hooks (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled for TransformerLens hooks (MonitoringConfig.debug=True).")
 
 
 if __name__ == "__main__":

--- a/benchmark/tests/profile_prefill.py
+++ b/benchmark/tests/profile_prefill.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -64,7 +63,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--nvtx",
         action="store_true",
-        help="Enable NVTX annotations inside TransformerLens hooks (sets TL_ENABLE_NVTX=1)",
+        help="Enable NVTX annotations inside TransformerLens hooks (enables MonitoringConfig.debug)",
     )
     parser.add_argument(
         "--collect-hidden",
@@ -501,9 +500,6 @@ def setup_hf_decode_hook(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     hf_dtype = map_hf_dtype(args.dtype)
     tl_dtype = map_tl_dtype(args.dtype)
@@ -542,7 +538,7 @@ def main() -> None:
         cache_dtype=cache_dtype,
         queue_size=args.engine_queue_size,
         delay_steps=args.engine_delay_steps,
-        config=MonitoringConfig(),
+        config=MonitoringConfig(debug=args.nvtx),
     )
     hf_hooked_model.monitoring_engine = None
     engine_init_ms = 0.0
@@ -953,11 +949,10 @@ def main() -> None:
         print("\nProfiler traces written under:")
         print(f"  {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled for TransformerLens prefill hooks (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled for TransformerLens prefill hooks (MonitoringConfig.debug=True).")
 
     try:
-        import os as _os
-        if bool(int(_os.environ.get("MON_ENGINE_STATS", "0"))):
+        if args.nvtx:
             from monitoring.hook_points import get_monitoring_hook_stats
             _hook_stats = get_monitoring_hook_stats()
             if _hook_stats:

--- a/benchmark/tests/profile_prefill_qwen3.py
+++ b/benchmark/tests/profile_prefill_qwen3.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import gc
-import os
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -64,7 +63,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--nvtx",
         action="store_true",
-        help="Enable NVTX annotations inside hook points (sets TL_ENABLE_NVTX=1)",
+        help="Enable NVTX annotations inside hook points (enables MonitoringConfig.debug)",
     )
     parser.add_argument(
         "--collect-hidden",
@@ -522,9 +521,6 @@ def setup_hf_decode_hook(
 def main() -> None:
     args = parse_args()
 
-    if args.nvtx:
-        os.environ.setdefault("TL_ENABLE_NVTX", "1")
-
     device = pick_device(args.device)
     hf_dtype = map_hf_dtype(args.dtype)
 
@@ -944,7 +940,7 @@ def main() -> None:
         cache_dtype=cache_dtype,
         queue_size=args.engine_queue_size,
         delay_steps=args.engine_delay_steps,
-        config=MonitoringConfig(),
+        config=MonitoringConfig(debug=args.nvtx),
     )
     hf_hooked_model.monitoring_engine = None
     engine_init_ms = 0.0
@@ -1062,12 +1058,10 @@ def main() -> None:
         print("\nProfiler traces written under:")
         print(f"  {traces_path.resolve()}")
     if args.nvtx and device.type == "cuda":
-        print("NVTX annotations enabled for hook point prefill paths (set TL_ENABLE_NVTX=1).")
+        print("NVTX annotations enabled for hook point prefill paths (MonitoringConfig.debug=True).")
 
-    # If engine stats are enabled, also print hook-side stats even for sync baselines.
     try:
-        import os as _os
-        if bool(int(_os.environ.get("MON_ENGINE_STATS", "0"))):
+        if args.nvtx:
             from monitoring.hook_points import get_monitoring_hook_stats
             _hook_stats = get_monitoring_hook_stats()
             if _hook_stats:

--- a/docs/dev_log/2026_02_25_issue18_runtime_env_inventory_cn.md
+++ b/docs/dev_log/2026_02_25_issue18_runtime_env_inventory_cn.md
@@ -1,0 +1,334 @@
+# Issue #18 阶段二前置：Runtime 环境变量盘点（中文）
+
+日期：2026-02-25  
+分支基线：`HF_Prometheus` @ `f8123edc3`
+
+## 1. 目的与范围
+
+本文只回答一件事：**当前还在生效的 runtime 环境变量有哪些、各自控制什么行为**。  
+不包含编译期变量的迁移方案（编译期开关单列在附录）。
+
+## 2. 当前 Runtime 环境变量总表
+
+### 2.1 Python 引擎/Hook 侧
+
+| 变量 | 默认值 | 读取时机 | 作用 | 代码位置 |
+|---|---:|---|---|---|
+| `MON_ENGINE_DEBUG` | `0` | `MonitoringEngine.__init__`；`close()` 再读一次 | 打印 Python 侧调试日志（submit/start/end/close 等） | `monitoring/engine.py:81`, `monitoring/engine.py:747` |
+| `MON_NATIVE_BATCH` | `0` | `MonitoringEngine.__init__` | 启用 SoA 聚合路径，`end_step` 走 `submit_step_soa` | `monitoring/engine.py:170`, `monitoring/engine.py:592` |
+| `MON_NATIVE_BUILDER` | `1` | `MonitoringEngine.__init__` | 启用 C++ builder/append 路径分流 | `monitoring/engine.py:172`, `monitoring/hook_points.py:962` |
+| `MON_NATIVE_CALLBACK` | `1` | `MonitoringEngine.__init__` | 启用全局 native callback 路径（减少 Python hook 开销） | `monitoring/engine.py:174`, `monitoring/hook_points.py:966` |
+| `MON_ENGINE_STATS` | `0` | `MonitoringEngine.__init__`；`hook_points` 模块导入时 | 引擎端统计输出；同时可触发 hook 统计 | `monitoring/engine.py:178`, `monitoring/hook_points.py:34` |
+| `MON_HOOK_STATS` | `0` | `hook_points` 模块导入时 | 仅 hook 侧统计（不依赖 engine stats） | `monitoring/hook_points.py:34-35` |
+| `MON_ENGINE_SLICE_STATS` | `0` | `task` 模块导入时 | 统计 slice 模式分布（identity/int/slice/array） | `monitoring/task.py:20` |
+| `TL_ENABLE_NVTX` | `0` | 混合：部分导入时，部分运行时多处重读 | 控制 Python 侧 NVTX range 标记 | `monitoring/hook_points.py:33`, `monitoring/engine.py:236/566/853` |
+
+### 2.2 Native C++ 运行时（D2H/内存/拷贝）
+
+| 变量 | 默认值 | 读取时机 | 作用 | 代码位置 |
+|---|---:|---|---|---|
+| `MON_NATIVE_TO_CPU` | `0`(off) | Native engine 构造时 | 开启 GPU->CPU offload | `monitoring/csrc/engine_core.cpp:27-29` |
+| `MON_NATIVE_PINNED` | `1` | Native engine 构造时 | D2H 时优先使用 pinned memory | `monitoring/csrc/engine_core.cpp:30-32` |
+| `MON_NATIVE_PINPOOL` | 自动（当 `TO_CPU=1` 且 `PINNED=1` 时默认开） | Native engine 构造时 | pinned pool 总开关 | `monitoring/csrc/engine_core.cpp:42-46` |
+| `MON_NATIVE_PINPOOL_BINS_KB` | `256,512,1024,2048,4096,8192` | Native engine 构造时 | 自定义 pool bin 桶大小（KB） | `monitoring/csrc/engine_core.cpp:47-67` |
+| `MON_NATIVE_PINPOOL_MAX_MB` | `512` | Native engine 构造时 | pool 总容量上限（MB） | `monitoring/csrc/engine_core.cpp:68-71` + `monitoring/csrc/native_engine_internal.h:233` |
+| `MON_NATIVE_HOST_COPY_THREADS` | `0` | Native engine 构造时 | host copy 线程池并行度（`>0` 启用线程池） | `monitoring/csrc/engine_core.cpp:75-88` |
+| `MON_NATIVE_HOST_COPY_QUEUE_SIZE` | `512` | Native engine 构造时（仅在线程池启用时） | host copy 队列深度 | `monitoring/csrc/engine_core.cpp:80-83`, `monitoring/csrc/native_engine_internal.h:277` |
+| `MON_NATIVE_PINNED_INDEX` | `0` | 每次 array slice 时读取 | array 索引构造是否走 pinned staging | `monitoring/csrc/engine_core.cpp:646-648` |
+
+## 3. 已在 Stage-1 删除的无效 Runtime 变量
+
+以下变量已移除（原因：读到后不影响行为）：
+
+- `MON_NATIVE_AUTOCLEAR`
+- `MON_NATIVE_STEP_STATS`
+- `MON_NATIVE_PINPOOL_SLOTS_PER_BIN`
+- `MON_NATIVE_PIN_THRESH_BYTES`
+
+参考：`docs/dev_log/2026_02_25_issue18_env_audit_stage1.md`
+
+## 4. 当前实现的注意点（对后续重构有影响）
+
+1. 读取时机不一致：
+- `MON_HOOK_STATS`、`MON_ENGINE_SLICE_STATS` 在模块导入时冻结；
+- 部分 `TL_ENABLE_NVTX` 在运行时重读；
+- 大多数 `MON_NATIVE_*` 在 native engine 构造时读取一次。
+
+2. 同一变量跨层生效路径不同：
+- `MON_ENGINE_STATS` 同时影响 engine 侧统计和 hook 侧统计开关来源。
+
+3. 路径分流复杂度仍高：
+- `MON_NATIVE_BATCH` / `MON_NATIVE_BUILDER` / `MON_NATIVE_CALLBACK` 组合决定四种不同数据路径。
+
+## 5. 阶段二建议（简版）
+
+1. 先收敛“读取时机”：尽量改成 engine 构造期单点确定。  
+2. 把长期默认值路径固化，减少组合开关。  
+3. 把确实需要在线调参的少量参数迁入 `MonitoringConfig`。  
+4. 最后再做 `MON_NATIVE_*` 运行时代码零读取的验收 grep。
+
+## 5.1 已确认决策：清除 `MON_NATIVE_BATCH`
+
+结论：`MON_NATIVE_BATCH` 进入“清除”范围，不再作为长期 runtime 开关保留。  
+要求是**删变量 + 删相关代码路径**，不能只移除 env 读取。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. Python 分支与聚合缓存
+- `monitoring/engine.py` 中 `_native_batch_enabled` 与 `self._native_batch` 相关逻辑。
+- `end_step()` 中 `submit_step_soa` 分支（SoA 分支整体删除）。
+
+2. Hook 侧 SoA 聚合路径
+- `monitoring/hook_points.py` 中 `native_batch_active` 分支及 SoA 聚合字典构建逻辑。
+
+3. Native 接口与绑定
+- `monitoring/csrc/native_engine.h/.cpp` 与 `monitoring/csrc/bindings.cpp` 中 `submit_step_soa` 暴露接口。
+- `monitoring/csrc/api_submit.cpp` 中 `submit_step_soa` 实现。
+
+4. 测试与脚本
+- 删除/更新所有设置 `MON_NATIVE_BATCH` 的测试、example、benchmark 启动脚本。
+- 回归验证覆盖默认路径（`builder + callback`）与非 native fallback 路径。
+
+## 5.2 已确认决策：清除 `MON_NATIVE_BUILDER` 与 `MON_NATIVE_CALLBACK`（行为固定为 `true`）
+
+结论：`MON_NATIVE_BUILDER` 与 `MON_NATIVE_CALLBACK` 也进入“清除”范围。  
+最终行为固定为：
+
+- `native_builder_enabled = true`
+- `native_callback_enabled = true`
+
+要求是**删变量 + 删分支**，不保留“可关闭”路径。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. Python 引擎配置读取
+- 删除 `monitoring/engine.py` 中 `_native_builder_enabled` / `_native_callback_enabled` 的 env 读取。
+- 改为常量语义（构造后固定 true），并清理相关条件判断。
+
+2. Hook 分支收敛
+- 删除 `monitoring/hook_points.py` 中 `native_builder_python`、`native_using and ... not native_builder_python` 等分流分支。
+- 保留并强化默认主路径：`native_callback_active`（全局 callback + collect futures）。
+- 纯 Python fallback（无 native backend）保留。
+
+3. 旧接口路径评估与移除
+- 评估并清理仅用于 `builder/callback` 关闭场景的路径（如 Python 侧 `add_task` 回填分支）。
+- 保留当前主路径实际依赖的 native 接口。
+
+4. 测试与脚本
+- 删除/更新所有设置 `MON_NATIVE_BUILDER`、`MON_NATIVE_CALLBACK` 的测试、example、benchmark 启动脚本。
+- 测试矩阵从“组合开关”改为“默认主路径 + 无 native fallback”。
+
+## 5.3 已确认决策：清除 `MON_ENGINE_DEBUG`（仅保留 C++ backend）
+
+结论：由于后续明确只使用 C++ native backend，`MON_ENGINE_DEBUG` 不再保留。  
+该变量只影响 Python 侧 `print` 调试日志，不影响核心功能。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. Python 引擎调试分支
+- 删除 `monitoring/engine.py` 中 `MON_ENGINE_DEBUG` 读取（包括 `__init__` 与 `close()` 里的重复读取）。
+- 删除 `_debug` 相关打印分支。
+
+2. Python fallback 相关日志/路径
+- 在“仅 C++ backend”策略下，清理 `_PythonBackend` 调试路径与不再需要的 fallback 分支。
+- 对于关键错误（如 host submit 失败）改为固定告警/异常，不依赖 debug 开关。
+
+3. 测试与脚本
+- 删除设置 `MON_ENGINE_DEBUG` 的调试脚本入口（或改为配置级 debug，非 env）。
+
+## 5.4 已确认决策：清除 `MON_HOOK_STATS`、`MON_ENGINE_SLICE_STATS`；保留 `MON_ENGINE_STATS`、`TL_ENABLE_NVTX` 但收敛为 `MonitoringConfig.debug`
+
+结论（基于“仅 C++ backend”后续方向）：
+
+- 直接清除：`MON_HOOK_STATS`、`MON_ENGINE_SLICE_STATS`
+- 保留能力但去 env：`MON_ENGINE_STATS`、`TL_ENABLE_NVTX`，收敛为 `MonitoringConfig.debug` 单一开关
+
+理由：
+
+1. `MON_HOOK_STATS` 与 `MON_ENGINE_SLICE_STATS` 都是 Python 侧统计入口，且在模块导入期读取，行为隐式且不稳定；在只保留 C++ backend 的方向下价值低于维护成本。  
+2. `MON_ENGINE_STATS` 与 `TL_ENABLE_NVTX` 仍有调试价值，但更适合作为显式配置项，而不是 runtime env 分散读取。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. 删除两个待清理变量的读取与分支
+- 删除 `monitoring/hook_points.py` 中 `MON_HOOK_STATS` 的读取与统计开关分支。
+- 删除 `monitoring/task.py` 中 `MON_ENGINE_SLICE_STATS` 的读取与统计累积分支。
+
+2. 收敛 debug 配置
+- 在配置层使用 `MonitoringConfig.debug: bool` 作为唯一调试开关：
+  - `debug=true`：等价开启 stats + NVTX
+  - `debug=false`：等价关闭 stats + NVTX
+- 由 `MonitoringEngine` 构造期一次性读取 `MonitoringConfig.debug`，避免运行时多处 `os.getenv`。
+
+3. 代码清洁目标
+- 删除与 `MON_HOOK_STATS`、`MON_ENGINE_SLICE_STATS` 相关的死代码与无效测试设置。
+- 验收标准：runtime 代码中不再出现这两个变量名（`rg` 全仓为 0）。
+
+## 5.5 已确认决策：清除 `MON_NATIVE_TO_CPU`、`MON_NATIVE_PINNED`、`MON_NATIVE_PINPOOL`（行为固定为 `true`）
+
+结论：
+
+- 这三个 runtime env 变量都进入“清除”范围：
+  - `MON_NATIVE_TO_CPU`
+  - `MON_NATIVE_PINNED`
+  - `MON_NATIVE_PINPOOL`
+- 目标行为固定为：
+  - `to_cpu_enabled = true`
+  - `pinned_enabled = true`
+  - `pinned_pool_enabled = true`
+
+要求是**删变量 + 删分支 + 删回退路径**，不保留“关闭 offload / pinned / pinpool”的运行时开关。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. Native 构造期 env 读取与默认值逻辑
+- 删除 `monitoring/csrc/engine_core.cpp` 中对上述三变量的 `getenv` 读取。
+- 删除 `MON_NATIVE_PINPOOL` “自动默认”推导逻辑（`to_cpu && pinned`）并改为固定开启。
+
+2. 相关条件分支与回退路径
+- 清理仅在 `to_cpu/pinned/pinpool` 关闭时才会走到的分支。
+- 确保 D2H 路径统一落到“pinned + pinpool”主路径，避免保留死分支。
+
+3. 脚本与测试
+- 删除测试、example、benchmark 中对上述三变量的设置。
+- 回归验证主路径稳定性（包含大张量传输与高并发 copy 场景）。
+
+4. 验收标准
+- runtime 代码中不再出现这三个变量名（`rg` 全仓为 0）。
+
+## 5.6 已确认决策：保留 `MON_NATIVE_PINPOOL_BINS_KB`、`MON_NATIVE_PINPOOL_MAX_MB` 功能，但迁入 Config（默认值不变）
+
+结论：
+
+- 这两个参数的功能保留，不删除：
+  - `MON_NATIVE_PINPOOL_BINS_KB`
+  - `MON_NATIVE_PINPOOL_MAX_MB`
+- 但不再作为 runtime env 读取入口，迁移为显式配置项 `MonitoringConfig.advance.*`。
+- 默认值维持当前实现：
+  - `pinpool_bins_kb = [256, 512, 1024, 2048, 4096, 8192]`
+  - `pinpool_max_mb = 512`
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. 配置层
+- 新增对应配置字段并提供上述默认值。
+- 在 `MonitoringEngine` 构造阶段将配置透传给 native backend（单点设置，避免分散读取）。
+
+2. Native 层
+- 删除 `engine_core.cpp` 中这两个变量的 `getenv` 解析。
+- 保留现有 pool bin / max cap 逻辑本身，只改参数来源。
+
+3. 脚本与测试
+- 删除 benchmark/example/test 中对这两个 env 的设置方式（若存在）。
+- 改为通过 config 传参；新增至少一组“自定义 bins/max”回归用例。
+
+4. 验收标准
+- runtime 代码中不再出现 `MON_NATIVE_PINPOOL_BINS_KB`、`MON_NATIVE_PINPOOL_MAX_MB`（`rg` 全仓为 0）。
+
+## 5.7 已确认决策：`MON_NATIVE_HOST_COPY_THREADS` 迁入 Config（默认值 `0`）
+
+结论：
+
+- `MON_NATIVE_HOST_COPY_THREADS` 功能保留，但从 runtime env 迁移到配置项。
+- 默认值保持当前语义：`host_copy_threads = 0`（即默认不启用 host-copy 线程池）。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. 配置层
+- 新增/补齐 `host_copy_threads` 配置字段，默认 `0`。
+- 在 `MonitoringEngine` 构造期透传到 native backend，避免 C++ 层直接读取该 env。
+
+2. Native 层
+- 删除 `engine_core.cpp` 中 `MON_NATIVE_HOST_COPY_THREADS` 的 `getenv` 读取与解析入口。
+- 保留线程池实现与行为，仅改参数来源。
+
+3. 脚本与测试
+- 删除 benchmark/example/test 中通过 env 配置 `MON_NATIVE_HOST_COPY_THREADS` 的方式（若存在）。
+- 增加配置驱动的回归：`0`（关闭）与 `>0`（开启）两组场景。
+
+4. 验收标准
+- runtime 代码中不再出现 `MON_NATIVE_HOST_COPY_THREADS`（`rg` 全仓为 0）。
+
+## 5.8 已确认决策：清除 `MON_NATIVE_PINNED_INDEX`
+
+结论：
+
+- `MON_NATIVE_PINNED_INDEX` 进入“清除”范围，不再保留为 runtime env 开关。
+- 该变量只影响 `SliceMode::Array` 的索引构造路径（pinned staging vs 直接 device index），与当前主采样路径（step/request stride）无直接耦合。
+
+要求是**删变量 + 删分支**，保留单一路径实现（`SliceMode::Array` 统一使用直接 device index 构造）。
+
+需要一并清理的实现面（后续 PR 落地）：
+
+1. Native `apply_slice` 分支收敛
+- 删除 `monitoring/csrc/engine_core.cpp` 中 `MON_NATIVE_PINNED_INDEX` 的 `getenv` 读取。
+- 删除 `pin_index` 条件分支，保留一条 `index_select` 实现路径。
+
+2. 脚本与测试
+- 清理所有设置 `MON_NATIVE_PINNED_INDEX` 的脚本/测试（若存在）。
+- 补充 array-slice 回归用例，确保功能与结果一致（仅性能路径简化）。
+
+3. 验收标准
+- runtime 代码中不再出现 `MON_NATIVE_PINNED_INDEX`（`rg` 全仓为 0）。
+
+---
+
+## 6. PR 模板（English）
+
+```markdown
+## Summary
+This PR removes legacy runtime env toggles and consolidates runtime controls into `MonitoringConfig`.
+
+## Final Design
+- `MonitoringConfig.debug: bool` is the only debug switch.
+  - `debug=true`: enable both engine stats and NVTX.
+  - `debug=false`: disable both.
+- `AdvanceConfig` is introduced under `MonitoringConfig` for runtime tuning:
+  - `pinpool_bins_kb` (default: `[256, 512, 1024, 2048, 4096, 8192]`)
+  - `pinpool_max_mb` (default: `512`)
+  - `host_copy_threads` (default: `0`)
+  - `host_copy_queue_size` (default: `512`)
+
+## Removed Runtime Env Vars
+- `MON_NATIVE_BATCH`
+- `MON_NATIVE_BUILDER`
+- `MON_NATIVE_CALLBACK`
+- `MON_ENGINE_DEBUG`
+- `MON_HOOK_STATS`
+- `MON_ENGINE_SLICE_STATS`
+- `MON_NATIVE_TO_CPU`
+- `MON_NATIVE_PINNED`
+- `MON_NATIVE_PINPOOL`
+- `MON_NATIVE_PINNED_INDEX`
+
+## Migrated from Env to Config
+- `MON_ENGINE_STATS` + `TL_ENABLE_NVTX` -> `MonitoringConfig.debug`
+- `MON_NATIVE_PINPOOL_BINS_KB` -> `MonitoringConfig.advance.pinpool_bins_kb`
+- `MON_NATIVE_PINPOOL_MAX_MB` -> `MonitoringConfig.advance.pinpool_max_mb`
+- `MON_NATIVE_HOST_COPY_THREADS` -> `MonitoringConfig.advance.host_copy_threads`
+- `MON_NATIVE_HOST_COPY_QUEUE_SIZE` -> `MonitoringConfig.advance.host_copy_queue_size`
+
+## Fixed Runtime Behavior
+- Native builder path is always enabled.
+- Native callback path is always enabled.
+- D2H offload is always enabled.
+- Pinned memory path is always enabled.
+- Pin pool is always enabled.
+
+## Cleanup Guarantees
+- Remove all associated env reads and dead branches across Python/C++ paths.
+- Update benchmark/example/test scripts to use config, not env.
+- Verify removed env names are absent from runtime code via repository grep.
+
+## Additional Changes (for Review)
+- Host pipeline log noise is now debug-gated:
+  - `worker X in future_process introduced ... tensor copies due to non-contiguous`
+  - only prints when `process_future(debug=true)`.
+- `StageConfig.process_future(...)` adds optional `debug: bool = false`.
+  - backward compatible by default (silent unless debug is enabled).
+- Host pipeline builders in benchmark/example/validation scripts now pass debug from `MonitoringConfig.debug`.
+- README and Quick Start examples are updated to remove old runtime env usage and reflect config-driven runtime/debug setup.
+
+## Issue Link
+Part of #18
+```

--- a/example/gpt2_generate_with_monitoring_db.py
+++ b/example/gpt2_generate_with_monitoring_db.py
@@ -51,8 +51,8 @@ def _build_ingress_policy() -> EnqueuePolicy:
     return p
 
 
-def _build_host_config(db_cfg: ClickHouseClientConfig) -> HostEngineConfig:
-    stage_one = StageConfig.process_future(parallelism=1, name="process_future")
+def _build_host_config(db_cfg: ClickHouseClientConfig, *, debug: bool = False) -> HostEngineConfig:
+    stage_one = StageConfig.process_future(parallelism=1, name="process_future", debug=bool(debug))
     stage_two = StageConfig.clickhouse_insert(db_cfg, parallelism=1, name="clickhouse_insert")
 
     stage_one.input_queue = _build_queue_config(high_watermark_items=400)
@@ -65,12 +65,6 @@ def _build_host_config(db_cfg: ClickHouseClientConfig) -> HostEngineConfig:
     return HostEngineConfig(stages=[stage_one, stage_two])
 
 def main() -> None:
-    # Native backend must be enabled for DB futures.
-    os.environ.setdefault("MON_NATIVE_TO_CPU", "1")
-    os.environ.setdefault("MON_NATIVE_CALLBACK", "1")
-    os.environ.setdefault("MON_NATIVE_BUILDER", "1")
-    os.environ.setdefault("MON_NATIVE_BATCH", "0")
-
     if not torch.cuda.is_available():
         raise RuntimeError("This example requires CUDA + native backend.")
 
@@ -84,7 +78,7 @@ def main() -> None:
     )
 
     db_cfg = _build_db_config()
-    host_cfg = _build_host_config(db_cfg)
+    host_cfg = _build_host_config(db_cfg, debug=bool(cfg.debug))
     engine = MonitoringEngine(
         async_enabled=True,
         config=cfg,

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,7 +1,7 @@
 """Monitoring engine package for asynchronous hook processing."""
 
 from .engine import MonitoringEngine, HostEngineConfig
-from .config import CaptureSchedule, HookSelection, MonitoringConfig, NativePartialSealConfig
+from .config import AdvanceConfig, CaptureSchedule, HookSelection, MonitoringConfig, NativePartialSealConfig
 from .task import CacheFuture, MonitoringTask
 
 _NATIVE_EXPORTS = (
@@ -30,6 +30,7 @@ __all__ = [
     "CaptureSchedule",
     "HookSelection",
     "NativePartialSealConfig",
+    "AdvanceConfig",
     "MonitoringConfig",
     *_NATIVE_EXPORTS,
 ]

--- a/monitoring/_native_engine.py
+++ b/monitoring/_native_engine.py
@@ -140,9 +140,22 @@ def create_engine(
     queue_size: int,
     cache_dtype: Optional[torch.dtype],
     delay_steps: int,
+    *,
+    pinpool_bins_kb: list[int] | tuple[int, ...] = (256, 512, 1024, 2048, 4096, 8192),
+    pinpool_max_mb: int = 512,
+    host_copy_threads: int = 0,
+    host_copy_queue_size: int = 512,
 ):
     module = _load_extension()
-    return module.create_engine(queue_size, cache_dtype, delay_steps)
+    return module.create_engine(
+        queue_size,
+        cache_dtype,
+        delay_steps,
+        pinpool_bins_kb,
+        pinpool_max_mb,
+        host_copy_threads,
+        host_copy_queue_size,
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/monitoring/config.py
+++ b/monitoring/config.py
@@ -135,12 +135,36 @@ class NativePartialSealConfig:
 
 
 @dataclass
+class AdvanceConfig:
+    """Advanced native runtime controls."""
+
+    pinpool_bins_kb: Sequence[int] = (256, 512, 1024, 2048, 4096, 8192)
+    pinpool_max_mb: int = 512
+    host_copy_threads: int = 0
+    host_copy_queue_size: int = 512
+
+    def __post_init__(self) -> None:
+        bins = tuple(int(v) for v in self.pinpool_bins_kb if int(v) > 0)
+        if not bins:
+            raise ValueError("pinpool_bins_kb must contain at least one positive integer.")
+        if self.pinpool_max_mb <= 0:
+            raise ValueError("pinpool_max_mb must be > 0.")
+        if self.host_copy_threads < 0:
+            raise ValueError("host_copy_threads must be >= 0.")
+        if self.host_copy_queue_size <= 0:
+            raise ValueError("host_copy_queue_size must be > 0.")
+        self.pinpool_bins_kb = bins
+
+
+@dataclass
 class MonitoringConfig:
     """Bundle hook selection and capture schedule for the monitoring engine."""
 
     hooks: HookSelection = field(default_factory=HookSelection)
     schedule: CaptureSchedule = field(default_factory=CaptureSchedule)
     native_partial_seal: NativePartialSealConfig = field(default_factory=NativePartialSealConfig)
+    advance: AdvanceConfig = field(default_factory=AdvanceConfig)
+    debug: bool = False
 
     def as_dict(self) -> dict[str, object]:
         """Return a JSON-friendly representation for native backend handoff."""
@@ -168,4 +192,11 @@ class MonitoringConfig:
                 "cap_ratio": self.native_partial_seal.cap_ratio,
                 "driver_guard_mb": self.native_partial_seal.driver_guard_mb,
             },
+            "advance": {
+                "pinpool_bins_kb": list(self.advance.pinpool_bins_kb),
+                "pinpool_max_mb": self.advance.pinpool_max_mb,
+                "host_copy_threads": self.advance.host_copy_threads,
+                "host_copy_queue_size": self.advance.host_copy_queue_size,
+            },
+            "debug": bool(self.debug),
         }

--- a/monitoring/csrc/api_submit.cpp
+++ b/monitoring/csrc/api_submit.cpp
@@ -15,13 +15,11 @@ py::dict NativeMonitoringEngine::Impl::get_stats() {
   d["submit_us"] = stats_submit_us_.load(std::memory_order_relaxed);
   d["process_us"] = stats_process_us_.load(std::memory_order_relaxed);
   d["callback_us"] = stats_callback_us_.load(std::memory_order_relaxed);
-  if (enable_pinpool_) {
-    d["pool_hits"] = stats_pool_hits_.load(std::memory_order_relaxed);
-    d["pool_misses"] = stats_pool_misses_.load(std::memory_order_relaxed);
-    d["pool_high_watermark_bytes"] = stats_pool_high_watermark_bytes_.load(std::memory_order_relaxed);
-    d["pool_fallbacks"] = stats_pool_fallbacks_.load(std::memory_order_relaxed);
-    d["host_memcpy_mb"] = static_cast<double>(stats_memcpy_bytes_.load(std::memory_order_relaxed)) / (1024.0 * 1024.0);
-  }
+  d["pool_hits"] = stats_pool_hits_.load(std::memory_order_relaxed);
+  d["pool_misses"] = stats_pool_misses_.load(std::memory_order_relaxed);
+  d["pool_high_watermark_bytes"] = stats_pool_high_watermark_bytes_.load(std::memory_order_relaxed);
+  d["pool_fallbacks"] = stats_pool_fallbacks_.load(std::memory_order_relaxed);
+  d["host_memcpy_mb"] = static_cast<double>(stats_memcpy_bytes_.load(std::memory_order_relaxed)) / (1024.0 * 1024.0);
   d["pending_notifies"] = stats_pending_notifies_.load(std::memory_order_relaxed);
   d["inflight_bytes"] = inflight_bytes_.load(std::memory_order_relaxed);
   d["cap_enabled"] = congestion_cap_enabled_;
@@ -204,152 +202,6 @@ std::vector<int64_t> NativeMonitoringEngine::Impl::submit_step(int64_t step_id,
   stats_total_tasks_.fetch_add(static_cast<int64_t>(tokens.size()), std::memory_order_relaxed);
   auto t1 = std::chrono::steady_clock::now();
   auto us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-  stats_submit_us_.fetch_add(static_cast<int64_t>(us), std::memory_order_relaxed);
-  mon_nvtx_pop();
-  return tokens;
-}
-
-std::vector<int64_t> NativeMonitoringEngine::Impl::submit_step_soa(int64_t step_id,
-                                                                   const py::dict& spec,
-                                                                   std::optional<uint64_t> stream_handle) {
-  mon_nvtx_push("MonEng::submit_step_soa");
-  auto t0 = std::chrono::steady_clock::now();
-  StepWork work;
-  work.step_id = step_id;
-  work.final_chunk = true;
-
-  // Required fields
-  auto tensors = spec["tensors"].cast<py::list>();
-  auto slice_dims = spec["slice_dims"].cast<py::list>();
-  auto remove_batch = spec["remove_batch"].cast<py::list>();
-  auto can_slice = spec["can_slice"].cast<py::list>();
-  auto slice_modes = spec["slice_modes"].cast<py::list>();
-
-  // Optional fields
-  py::list int_values, slice_starts, slice_stops, slice_steps, indices, target_devices;
-  if (spec.contains("int_values")) int_values = spec["int_values"].cast<py::list>();
-  if (spec.contains("slice_starts")) slice_starts = spec["slice_starts"].cast<py::list>();
-  if (spec.contains("slice_stops")) slice_stops = spec["slice_stops"].cast<py::list>();
-  if (spec.contains("slice_steps")) slice_steps = spec["slice_steps"].cast<py::list>();
-  if (spec.contains("indices")) indices = spec["indices"].cast<py::list>();
-  if (spec.contains("target_devices")) target_devices = spec["target_devices"].cast<py::list>();
-
-  size_t n = tensors.size();
-  TORCH_CHECK(slice_dims.size() == n && remove_batch.size() == n && can_slice.size() == n && slice_modes.size() == n,
-              "submit_step_soa: mismatched list sizes");
-
-  std::vector<int64_t> tokens;
-  tokens.reserve(n);
-  work.tasks.reserve(n);
-
-  for (size_t i = 0; i < n; ++i) {
-    TaskSpec ts;
-    ts.tensor = tensors[i].cast<at::Tensor>();
-    ts.slice_dim = slice_dims[i].cast<int64_t>();
-    ts.remove_batch_dim = remove_batch[i].cast<bool>();
-    ts.can_slice = can_slice[i].cast<bool>();
-
-    int mode = slice_modes[i].cast<int>();
-    switch (mode) {
-      case 0: // identity
-        ts.slice.mode = SliceMode::Identity; break;
-      case 1: // int
-        ts.slice.mode = SliceMode::Int;
-        if (int_values && int_values.size() == n) ts.slice.int_value = int_values[i].cast<int64_t>();
-        break;
-      case 2: { // slice
-        ts.slice.mode = SliceMode::Range;
-        if (slice_starts && slice_starts.size() == n) {
-          py::object o = slice_starts[i]; if (!o.is_none()) ts.slice.start = o.cast<int64_t>();
-        }
-        if (slice_stops && slice_stops.size() == n) {
-          py::object o = slice_stops[i]; if (!o.is_none()) ts.slice.stop = o.cast<int64_t>();
-        }
-        if (slice_steps && slice_steps.size() == n) {
-          py::object o = slice_steps[i]; if (!o.is_none()) ts.slice.step = o.cast<int64_t>();
-        }
-        break;
-      }
-      case 3: { // array
-        ts.slice.mode = SliceMode::Array;
-        if (indices && indices.size() == n) {
-          py::object obj = indices[i];
-          if (py::isinstance<py::tuple>(obj)) {
-            auto tup = obj.cast<py::tuple>();
-            ts.slice.indices.reserve(tup.size());
-            for (auto it : tup) ts.slice.indices.push_back(it.cast<int64_t>());
-          } else if (py::isinstance<py::list>(obj)) {
-            ts.slice.indices = obj.cast<std::vector<int64_t>>();
-          }
-        }
-        break;
-      }
-      default:
-        ts.slice.mode = SliceMode::Identity; break;
-    }
-
-    if (target_devices && target_devices.size() == n) {
-      py::object dev = target_devices[i];
-      if (!dev.is_none()) ts.target_device = dev.cast<c10::Device>();
-    }
-
-    int64_t token = next_token_++;
-    tokens.push_back(token);
-
-    auto slot = std::make_shared<ResultSlot>();
-    {
-      std::lock_guard<std::mutex> lock(slots_mutex_);
-      slots_.emplace(token, std::move(slot));
-    }
-
-    TaskEntry entry;
-    entry.spec = std::move(ts);
-    entry.token = token;
-    work.bytes += estimate_task_bytes(entry.spec);
-    work.tasks.emplace_back(std::move(entry));
-  }
-
-  if (work.tasks.empty()) {
-    if (stream_handle.has_value()) {
-      cudaEvent_t event;
-      C10_CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-      cudaStream_t stream = reinterpret_cast<cudaStream_t>(*stream_handle);
-      C10_CUDA_CHECK(cudaEventRecord(event, stream));
-      C10_CUDA_CHECK(cudaEventSynchronize(event));
-      C10_CUDA_CHECK(cudaEventDestroy(event));
-    }
-     mon_nvtx_pop();
-    return tokens;
-  }
-
-  if (stream_handle.has_value()) {
-    cudaEvent_t event;
-    C10_CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-    cudaStream_t stream = reinterpret_cast<cudaStream_t>(*stream_handle);
-    C10_CUDA_CHECK(cudaEventRecord(event, stream));
-    work.event = event;
-  }
-
-  py::gil_scoped_release release;
-
-  pending_tasks_.fetch_add(static_cast<int64_t>(work.tasks.size()), std::memory_order_relaxed);
-
-  std::vector<StepWork> ready;
-  {
-    std::lock_guard<std::mutex> lock(staging_mutex_);
-    sealed_steps_.emplace_back(std::move(work));
-    while (static_cast<int64_t>(sealed_steps_.size()) > delay_steps_) {
-      ready.emplace_back(std::move(sealed_steps_.front()));
-      sealed_steps_.pop_front();
-    }
-  }
-
-  for (auto& item : ready) dispatch_step(std::move(item));
-
-  auto t1 = std::chrono::steady_clock::now();
-  auto us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-  stats_total_steps_.fetch_add(1, std::memory_order_relaxed);
-  stats_total_tasks_.fetch_add(static_cast<int64_t>(n), std::memory_order_relaxed);
   stats_submit_us_.fetch_add(static_cast<int64_t>(us), std::memory_order_relaxed);
   mon_nvtx_pop();
   return tokens;

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -10,12 +10,23 @@ namespace monitoring {
 
 std::shared_ptr<NativeMonitoringEngine> create_engine(int64_t queue_size,
                                                       py::object cache_dtype,
-                                                      int64_t delay_steps) {
+                                                      int64_t delay_steps,
+                                                      const std::vector<int64_t>& pinpool_bins_kb,
+                                                      int64_t pinpool_max_mb,
+                                                      int64_t host_copy_threads,
+                                                      int64_t host_copy_queue_size) {
   std::optional<at::ScalarType> dtype;
   if (!cache_dtype.is_none()) {
     dtype = cache_dtype.cast<at::ScalarType>();
   }
-  return std::make_shared<NativeMonitoringEngine>(queue_size, dtype, delay_steps);
+  return std::make_shared<NativeMonitoringEngine>(
+      queue_size,
+      dtype,
+      delay_steps,
+      pinpool_bins_kb,
+      pinpool_max_mb,
+      host_copy_threads,
+      host_copy_queue_size);
 }
 
 }  // namespace monitoring
@@ -62,9 +73,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("collect_step_futures_into",
            &monitoring::NativeMonitoringEngine::collect_step_futures_into,
            py::arg("step_id"), py::arg("cache"))
-      .def("submit_step_soa", &monitoring::NativeMonitoringEngine::submit_step_soa,
-           py::arg("step_id"), py::arg("spec"),
-           py::arg("stream_handle") = std::optional<uint64_t>())
       .def("add_task", &monitoring::NativeMonitoringEngine::add_task,
            py::arg("step_id"), py::arg("task"))
       .def("seal_step", &monitoring::NativeMonitoringEngine::seal_step,
@@ -101,7 +109,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("called_from_cpp") = false);
 
   m.def("create_engine", &monitoring::create_engine,
-        py::arg("queue_size"), py::arg("cache_dtype"), py::arg("delay_steps"));
+        py::arg("queue_size"),
+        py::arg("cache_dtype"),
+        py::arg("delay_steps"),
+        py::arg("pinpool_bins_kb") = std::vector<int64_t>{256, 512, 1024, 2048, 4096, 8192},
+        py::arg("pinpool_max_mb") = 512,
+        py::arg("host_copy_threads") = 0,
+        py::arg("host_copy_queue_size") = 512);
 
 
   // ---- ClickHouseClientConfig (config only; stage is C++-only) ----
@@ -250,19 +264,21 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       // Stage 1: ProcessFuture
       .def_static(
           "process_future",
-          [](int parallelism, std::string name) {
+          [](int parallelism, std::string name, bool debug) {
             StageConfig cfg;
             cfg.name = std::move(name);
             cfg.parallelism = parallelism;
             cfg.process_fn = [](std::vector<dmx_host::dmx_host_queue_item> batch, QueueT* next_q) {
               return dmx_host::ProcessFutureStage::ProcessFn<QueueT>(std::move(batch), next_q);
             };
+            cfg.thread_init_config = debug;
             cfg.thread_init = &dmx_host::ProcessFutureStage::ThreadInitAny;
             cfg.thread_cleanup = &dmx_host::ProcessFutureStage::ThreadCleanupAny;
             return cfg;
           },
           py::arg("parallelism") = 1,
-          py::arg("name") = "process_future")
+          py::arg("name") = "process_future",
+          py::arg("debug") = false)
       // Stage 2: ClickHouse insert (this is where thread_init_config matters)
       .def_static(
           "clickhouse_insert",

--- a/monitoring/csrc/engine_core.cpp
+++ b/monitoring/csrc/engine_core.cpp
@@ -3,7 +3,6 @@
 #include "native_engine_internal.h"
 #include "engine_utils.h"
 #include "nvtx_shim.h"
-#include <cstdlib>
 #include <cstdio>
 #include <limits>
 
@@ -18,73 +17,47 @@ namespace monitoring {
 
 NativeMonitoringEngine::Impl::Impl(int64_t queue_size,
                                    std::optional<at::ScalarType> cache_dtype,
-                                   int64_t delay_steps)
+                                   int64_t delay_steps,
+                                   const std::vector<int64_t>& pinpool_bins_kb,
+                                   int64_t pinpool_max_mb,
+                                   int64_t host_copy_threads,
+                                   int64_t host_copy_queue_size)
     : max_queue_size_(queue_size > 0 ? static_cast<size_t>(queue_size) : 0),
       cache_stream_(at::cuda::getStreamFromPool(/*isHighPriority=*/false)),
       cache_dtype_(cache_dtype),
       delay_steps_(delay_steps > 0 ? delay_steps : 0) {
-  // Runtime controls for D2H offload (single-stream version)
-  if (const char* v = std::getenv("MON_NATIVE_TO_CPU")) {
-    move_to_cpu_ = (*v == '1');
-  }
-  if (const char* v = std::getenv("MON_NATIVE_PINNED")) {
-    use_pinned_ = (*v != '0');
-  }
-
-  // Configure pinned pool (enabled only when pinned offload is in use)
-  enable_pinpool_ = false;
-  if (use_pinned_ && move_to_cpu_) {
-    // Default bins (bytes)
-    pinpool_bins_bytes_ = {256ull * 1024ull, 512ull * 1024ull, 1024ull * 1024ull,
-                           2ull * 1024ull * 1024ull, 4ull * 1024ull * 1024ull,
-                           8ull * 1024ull * 1024ull};
-    // Parse env vars
-    if (const char* v = std::getenv("MON_NATIVE_PINPOOL")) {
-      enable_pinpool_ = (*v != '0');
-    } else {
-      enable_pinpool_ = true; // default on when pinned offload is used
-    }
-    if (const char* v = std::getenv("MON_NATIVE_PINPOOL_BINS_KB")) {
-      // format: 256,512,1024,2048
-      pinpool_bins_bytes_.clear();
-      std::string s(v);
-      size_t start = 0;
-      while (start < s.size()) {
-        size_t comma = s.find(',', start);
-        std::string tok = (comma == std::string::npos) ? s.substr(start) : s.substr(start, comma - start);
-        if (!tok.empty()) {
-          size_t kb = static_cast<size_t>(std::strtoull(tok.c_str(), nullptr, 10));
-          if (kb > 0) pinpool_bins_bytes_.push_back(kb * 1024ull);
-        }
-        if (comma == std::string::npos) break;
-        start = comma + 1;
-      }
-      if (pinpool_bins_bytes_.empty()) {
-        pinpool_bins_bytes_ = {256ull * 1024ull, 512ull * 1024ull, 1024ull * 1024ull,
-                               2ull * 1024ull * 1024ull, 4ull * 1024ull * 1024ull,
-                               8ull * 1024ull * 1024ull};
+  // D2H offload + pinned + pinpool are now fixed-on behavior.
+  pinpool_bins_bytes_ = {256ull * 1024ull, 512ull * 1024ull, 1024ull * 1024ull,
+                         2ull * 1024ull * 1024ull, 4ull * 1024ull * 1024ull,
+                         8ull * 1024ull * 1024ull};
+  if (!pinpool_bins_kb.empty()) {
+    pinpool_bins_bytes_.clear();
+    for (int64_t kb : pinpool_bins_kb) {
+      if (kb > 0) {
+        pinpool_bins_bytes_.push_back(static_cast<size_t>(kb) * 1024ull);
       }
     }
-    if (const char* v = std::getenv("MON_NATIVE_PINPOOL_MAX_MB")) {
-      size_t mb = static_cast<size_t>(std::strtoull(v, nullptr, 10));
-      if (mb > 0) pinpool_max_bytes_ = mb * 1024ull * 1024ull;
+    if (pinpool_bins_bytes_.empty()) {
+      pinpool_bins_bytes_ = {256ull * 1024ull, 512ull * 1024ull, 1024ull * 1024ull,
+                             2ull * 1024ull * 1024ull, 4ull * 1024ull * 1024ull,
+                             8ull * 1024ull * 1024ull};
     }
+  }
+  if (pinpool_max_mb > 0) {
+    pinpool_max_bytes_ = static_cast<size_t>(pinpool_max_mb) * 1024ull * 1024ull;
   }
 
   // Host-copy pool configuration (optional parallel memcpy)
-  if (const char* v = std::getenv("MON_NATIVE_HOST_COPY_THREADS")) {
-    host_copy_threads_ = std::atoi(v);
-    if (host_copy_threads_ > 0) {
-      enable_host_copy_pool_ = true;
-      host_copy_pool_ = std::make_unique<HostCopyThreadPool>();
-      if (const char* qv = std::getenv("MON_NATIVE_HOST_COPY_QUEUE_SIZE")) {
-        size_t q = static_cast<size_t>(std::strtoull(qv, nullptr, 10));
-        if (q > 0) host_copy_pool_->max_queue_size_ = q;
-      }
-      // Spawn workers
-      for (int i = 0; i < host_copy_threads_; ++i) {
-        host_copy_pool_->workers_.emplace_back(&NativeMonitoringEngine::Impl::host_copy_worker, this);
-      }
+  host_copy_threads_ = host_copy_threads > 0 ? static_cast<int>(host_copy_threads) : 0;
+  if (host_copy_threads_ > 0) {
+    enable_host_copy_pool_ = true;
+    host_copy_pool_ = std::make_unique<HostCopyThreadPool>();
+    if (host_copy_queue_size > 0) {
+      host_copy_pool_->max_queue_size_ = static_cast<size_t>(host_copy_queue_size);
+    }
+    // Spawn workers
+    for (int i = 0; i < host_copy_threads_; ++i) {
+      host_copy_pool_->workers_.emplace_back(&NativeMonitoringEngine::Impl::host_copy_worker, this);
     }
   }
   worker_ = std::thread(&NativeMonitoringEngine::Impl::worker_loop, this);
@@ -320,7 +293,7 @@ void NativeMonitoringEngine::Impl::process_step(StepWork&& work) {
       bool needs_sync = result.device().is_cpu() && entry.spec.tensor.defined() && entry.spec.tensor.is_cuda();
       any_sync = any_sync || needs_sync;
       int64_t blk_id = -1;
-      if (enable_pinpool_ && result.defined() && result.device().is_cpu()) {
+      if (result.defined() && result.device().is_cpu()) {
         blk_id = find_pool_block_id(result.data_ptr());
       }
       results.push_back(PendingResult{std::move(result), entry.token, blk_id, needs_sync});
@@ -424,40 +397,22 @@ at::Tensor NativeMonitoringEngine::Impl::run_task(const TaskSpec& spec) {
   if (cache_dtype_.has_value() && tensor.scalar_type() != *cache_dtype_) {
     tensor = tensor.to(*cache_dtype_, /*non_blocking=*/true, /*copy=*/false);
   }
-  // Optional D2H offload on current cache stream
-  bool want_cpu = move_to_cpu_;
-  if (spec.target_device.has_value() && spec.target_device->is_cpu()) {
-    want_cpu = true;
-  }
-  if (want_cpu && tensor.is_cuda()) {
-    if (use_pinned_) {
-      // Always prefer pinned destinations for D2H, regardless of size.
-      size_t nbytes = static_cast<size_t>(tensor.nbytes());
-      at::ScalarType dt = tensor.scalar_type();
-      if (enable_pinpool_) {
-        // Try the pinned pool first (no size threshold)
-        auto got = acquire_pinned_block(nbytes, dt);
-        if (got.first.defined()) {
-          at::Tensor dst = got.first.view(tensor.sizes());
-          dst.copy_(tensor, /*non_blocking=*/true);
-          return dst;
-        }        
-        // Pool could not provide a block (capacity/pressure) — fall back to direct pinned alloc
-        auto opts = tensor.options().device(torch::kCPU).pinned_memory(true);
-        at::Tensor dst = at::empty_like(tensor, opts);
-        dst.copy_(tensor, /*non_blocking=*/true);
-        tensor = dst;
-      } else {
-        // Pool disabled — allocate pinned destination directly
-        auto opts = tensor.options().device(torch::kCPU).pinned_memory(true);
-        at::Tensor dst = at::empty_like(tensor, opts);
-        dst.copy_(tensor, /*non_blocking=*/true);
-        tensor = dst;
-      }
-    } else {
-      // Pinned off not requested — keep legacy pageable transfer
-      tensor = tensor.to(torch::kCPU, /*non_blocking=*/true, /*copy=*/true);
+  // D2H offload is fixed-on with pinned pool + pinned fallback.
+  if (tensor.is_cuda()) {
+    size_t nbytes = static_cast<size_t>(tensor.nbytes());
+    at::ScalarType dt = tensor.scalar_type();
+    // Try the pinned pool first (no size threshold).
+    auto got = acquire_pinned_block(nbytes, dt);
+    if (got.first.defined()) {
+      at::Tensor dst = got.first.view(tensor.sizes());
+      dst.copy_(tensor, /*non_blocking=*/true);
+      return dst;
     }
+    // Pool could not provide a block (capacity/pressure) — direct pinned alloc.
+    auto opts = tensor.options().device(torch::kCPU).pinned_memory(true);
+    at::Tensor dst = at::empty_like(tensor, opts);
+    dst.copy_(tensor, /*non_blocking=*/true);
+    tensor = dst;
   }
   return tensor;
 }
@@ -478,8 +433,6 @@ size_t NativeMonitoringEngine::Impl::pick_bin_bytes(size_t nbytes) {
 }
 
 std::pair<at::Tensor, int64_t> NativeMonitoringEngine::Impl::acquire_pinned_block(size_t nbytes, at::ScalarType dtype) {
-  if (!enable_pinpool_) return {at::Tensor(), -1};
-
   size_t cap = pick_bin_bytes(nbytes);
   at::Tensor view;
   int64_t blk_id = -1;
@@ -640,26 +593,9 @@ at::Tensor NativeMonitoringEngine::Impl::apply_slice(at::Tensor tensor, const Sl
       }
     }
     case SliceMode::Array: {
-      // Optional: build index path using pinned host staging to produce
-      // "Memcpy HtoD (Pinned)" instead of pageable in profilers.
-      bool pin_index = false;
-      if (const char* v = std::getenv("MON_NATIVE_PINNED_INDEX")) {
-        pin_index = (*v != '0');
-      }
-      if (pin_index) {
-        // Create a temporary CPU Long tensor from indices, then copy into
-        // a pinned host buffer and transfer to device non-blocking.
-        at::Tensor tmp = torch::tensor(spec.indices, torch::TensorOptions().dtype(torch::kLong));
-        auto host_opts = torch::TensorOptions().dtype(torch::kLong).device(torch::kCPU).pinned_memory(true);
-        at::Tensor idx_host = at::empty_like(tmp, host_opts);
-        idx_host.copy_(tmp, /*non_blocking=*/false);
-        at::Tensor idx = idx_host.to(tensor.device(), /*non_blocking=*/true, /*copy=*/true);
-        return tensor.index_select(dim, idx);
-      } else {
-        auto options = torch::TensorOptions().dtype(torch::kLong).device(tensor.device());
-        at::Tensor idx = torch::tensor(spec.indices, options);
-        return tensor.index_select(dim, idx);
-      }
+      auto options = torch::TensorOptions().dtype(torch::kLong).device(tensor.device());
+      at::Tensor idx = torch::tensor(spec.indices, options);
+      return tensor.index_select(dim, idx);
     }
   }
   return tensor;

--- a/monitoring/csrc/future_process.cpp
+++ b/monitoring/csrc/future_process.cpp
@@ -7,12 +7,17 @@
 namespace dmx_host {
 thread_local int worker_id;
 thread_local int contiguous_introduced_copy = 0;
+thread_local bool contiguous_copy_debug_log = false;
 
-void ProcessFutureStage::ThreadInit(int thread_idx){
+void ProcessFutureStage::ThreadInit(int thread_idx, bool debug_log){
     worker_id = thread_idx;
     contiguous_introduced_copy = 0;
+    contiguous_copy_debug_log = debug_log;
 }
 void ProcessFutureStage::ThreadCleanup() noexcept{
+    if (!contiguous_copy_debug_log) {
+        return;
+    }
     std::cout << "worker " << worker_id
               << " in future_process introduced "
               << contiguous_introduced_copy

--- a/monitoring/csrc/future_process.h
+++ b/monitoring/csrc/future_process.h
@@ -8,7 +8,7 @@ namespace dmx_host{
 
 class ProcessFutureStage final {
  public:
-  static void ThreadInit(int thread_idx);
+  static void ThreadInit(int thread_idx, bool debug_log);
   static void ThreadCleanup() noexcept;
 
   template <typename QueueT>
@@ -16,7 +16,11 @@ class ProcessFutureStage final {
 
   // Engine-compatible wrappers:
   static inline void ThreadInitAny(int thread_idx, const std::any& cfg_any) {
-    ThreadInit(thread_idx);
+    bool debug_log = false;
+    if (const bool* debug_ptr = std::any_cast<bool>(&cfg_any)) {
+      debug_log = *debug_ptr;
+    }
+    ThreadInit(thread_idx, debug_log);
   }
 
   static inline void ThreadCleanupAny() noexcept { ThreadCleanup(); }

--- a/monitoring/csrc/native_engine.cpp
+++ b/monitoring/csrc/native_engine.cpp
@@ -8,8 +8,19 @@ namespace py = pybind11;
 
 NativeMonitoringEngine::NativeMonitoringEngine(int64_t queue_size,
                                                std::optional<at::ScalarType> cache_dtype,
-                                               int64_t delay_steps)
-    : impl_(std::make_unique<Impl>(queue_size, cache_dtype, delay_steps)) {}
+                                               int64_t delay_steps,
+                                               const std::vector<int64_t>& pinpool_bins_kb,
+                                               int64_t pinpool_max_mb,
+                                               int64_t host_copy_threads,
+                                               int64_t host_copy_queue_size)
+    : impl_(std::make_unique<Impl>(
+          queue_size,
+          cache_dtype,
+          delay_steps,
+          pinpool_bins_kb,
+          pinpool_max_mb,
+          host_copy_threads,
+          host_copy_queue_size)) {}
 
 NativeMonitoringEngine::~NativeMonitoringEngine() {
   close();
@@ -50,12 +61,6 @@ void NativeMonitoringEngine::set_partial_seal_config(bool enabled,
                                                      double cap_ratio,
                                                      int64_t driver_guard_mb) {
   impl_->set_partial_seal_config(enabled, chunk_bytes, cap_enabled, cap_ratio, driver_guard_mb);
-}
-
-std::vector<int64_t> NativeMonitoringEngine::submit_step_soa(int64_t step_id,
-                                                             const py::dict& spec,
-                                                             std::optional<uint64_t> stream_handle) {
-  return impl_->submit_step_soa(step_id, spec, stream_handle);
 }
 
 int64_t NativeMonitoringEngine::add_task(int64_t step_id, const py::tuple& task_tuple) {

--- a/monitoring/csrc/native_engine.h
+++ b/monitoring/csrc/native_engine.h
@@ -19,7 +19,11 @@ class NativeMonitoringEngine : public std::enable_shared_from_this<NativeMonitor
  public:
   NativeMonitoringEngine(int64_t queue_size,
                          std::optional<at::ScalarType> cache_dtype,
-                         int64_t delay_steps);
+                         int64_t delay_steps,
+                         const std::vector<int64_t>& pinpool_bins_kb,
+                         int64_t pinpool_max_mb,
+                         int64_t host_copy_threads,
+                         int64_t host_copy_queue_size);
   ~NativeMonitoringEngine();
 
   py::dict get_stats();
@@ -44,11 +48,6 @@ class NativeMonitoringEngine : public std::enable_shared_from_this<NativeMonitor
                                bool cap_enabled,
                                double cap_ratio,
                                int64_t driver_guard_mb);
-
-  // Struct-of-arrays submit to minimize Python overhead
-  std::vector<int64_t> submit_step_soa(int64_t step_id,
-                                       const py::dict& spec,
-                                       std::optional<uint64_t> stream_handle);
 
   // Low-overhead single task append
   int64_t add_task(int64_t step_id, const py::tuple& task_tuple);
@@ -135,7 +134,11 @@ class BackendFuture {
 
 std::shared_ptr<NativeMonitoringEngine> create_engine(int64_t queue_size,
                                                       py::object cache_dtype,
-                                                      int64_t delay_steps);
+                                                      int64_t delay_steps,
+                                                      const std::vector<int64_t>& pinpool_bins_kb,
+                                                      int64_t pinpool_max_mb,
+                                                      int64_t host_copy_threads,
+                                                      int64_t host_copy_queue_size);
 
 }  // namespace monitoring
 

--- a/monitoring/csrc/native_engine_internal.h
+++ b/monitoring/csrc/native_engine_internal.h
@@ -112,7 +112,11 @@ struct NativeMonitoringEngine::Impl {
   // Lifecycle
   Impl(int64_t queue_size,
        std::optional<at::ScalarType> cache_dtype,
-       int64_t delay_steps);
+       int64_t delay_steps,
+       const std::vector<int64_t>& pinpool_bins_kb,
+       int64_t pinpool_max_mb,
+       int64_t host_copy_threads,
+       int64_t host_copy_queue_size);
   ~Impl();
 
   // Public API (mirrors NativeMonitoringEngine)
@@ -138,10 +142,6 @@ struct NativeMonitoringEngine::Impl {
                                bool cap_enabled,
                                double cap_ratio,
                                int64_t driver_guard_mb);
-
-  std::vector<int64_t> submit_step_soa(int64_t step_id,
-                                       const py::dict& spec,
-                                       std::optional<uint64_t> stream_handle);
 
   int64_t add_task(int64_t step_id, const py::tuple& task_tuple);
   void seal_step(int64_t step_id, std::optional<uint64_t> stream_handle);
@@ -215,10 +215,6 @@ struct NativeMonitoringEngine::Impl {
   void record_step_name_token(int64_t step_id, const std::string& name, int64_t token, int64_t task_size);
 
   // Data ----------------------------------------------------------------
-  // D2H offload controls
-  bool move_to_cpu_{false};
-  bool use_pinned_{true};
-
   // Pinned memory pool (for stable GPU->CPU offload throughput)
   struct PinnedBlock {
     at::Tensor buf;              // 1D pinned tensor with element dtype
@@ -229,7 +225,6 @@ struct NativeMonitoringEngine::Impl {
   };
 
   // Pool controls and state
-  bool enable_pinpool_{false};
   size_t pinpool_max_bytes_{512ull * 1024ull * 1024ull}; // total pool cap
   std::vector<size_t> pinpool_bins_bytes_; // capacity bins in bytes (ascending)
 

--- a/monitoring/engine.py
+++ b/monitoring/engine.py
@@ -8,7 +8,6 @@ arrives we retain a Python fallback that mirrors the established behaviour.
 
 from __future__ import annotations
 
-import os
 import threading
 import time
 from collections import deque
@@ -19,7 +18,7 @@ from typing import Any, Deque, Dict, Iterable, List, Optional, Sequence, Tuple, 
 import torch
 
 from .task import CacheFuture, MonitoringTask
-from .config import MonitoringConfig
+from .config import AdvanceConfig, MonitoringConfig
 
 from .utils import Slice
 
@@ -78,14 +77,16 @@ class MonitoringEngine:
         self.async_enabled = async_enabled
         self.cache_dtype = cache_dtype
         self._delay_steps = max(0, int(delay_steps))
-        self._debug = bool(int(os.environ.get("MON_ENGINE_DEBUG", "0")))
         self.config = config
+        self._debug_enabled = bool(self.config.debug) if self.config is not None else False
+        self._nvtx_enabled = self._debug_enabled
         self._request_capture_enabled = True
         self._capture_enabled = True
         self._hook_cache_config_id: Optional[int] = None
         self._hook_cache_key: Optional[int] = None
         self._hook_cache_list: Optional[List[str]] = None
         self._hook_cache_set: Optional[set[str]] = None
+        self._sync_hook_debug_flag()
 
         self._current_step_id: int = 0
         self._pending_tasks: Dict[int, List[Tuple[MonitoringTask, CacheFuture]]] = {}
@@ -110,7 +111,13 @@ class MonitoringEngine:
         self._host_engine_enabled = False
 
         if async_enabled and torch.cuda.is_available():
-            native_backend = _load_native_backend(queue_size, cache_dtype, self._delay_steps)
+            advance_cfg = self.config.advance if self.config is not None else AdvanceConfig()
+            native_backend = _load_native_backend(
+                queue_size,
+                cache_dtype,
+                self._delay_steps,
+                advance_cfg,
+            )
             if native_backend is not None:
                 self._backend = native_backend
                 self._native_backend = native_backend
@@ -127,7 +134,6 @@ class MonitoringEngine:
                     queue_size=queue_size,
                     cache_dtype=cache_dtype,
                     delay_steps=self._delay_steps,
-                    debug=self._debug,
                 )
                 self._backend = python_backend
                 self._python_backend = python_backend
@@ -166,16 +172,8 @@ class MonitoringEngine:
                     raise RuntimeError("Failed to start host_engine") from exc
                 self._host_engine_enabled = True
 
-        # Native batch (SoA) aggregation buffers (optional)
-        self._native_batch_enabled = bool(int(os.environ.get("MON_NATIVE_BATCH", "0")))
-        # Native builder (C++-side append of hooks) – strongest offload
-        self._native_builder_enabled = bool(int(os.environ.get("MON_NATIVE_BUILDER", "1")))
-        # Native callback (C++ hook) – eliminates Python hook overhead
-        self._native_callback_enabled = bool(int(os.environ.get("MON_NATIVE_CALLBACK", "1")))
-        self._native_batch: Dict[int, Dict[str, list]] = {}
-
         # Stats (optional) --------------------------------------------------
-        self._stats_enabled = bool(int(os.environ.get("MON_ENGINE_STATS", "0")))
+        self._stats_enabled = self._debug_enabled
         self._stats_hooks = 0
         self._stats_steps = 0
         self._stats_tasks = 0
@@ -216,8 +214,6 @@ class MonitoringEngine:
         bucket.append((task, future))
         if self._stats_enabled:
             self._stats_hooks += 1
-        if self._debug:
-            print(f"[MonEng] submit step={step_id} bucket_size={len(bucket)}")
 
         return future
 
@@ -233,7 +229,7 @@ class MonitoringEngine:
         except Exception:
             _nvtx = None  # type: ignore
 
-        if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+        if _nvtx is not None and self._nvtx_enabled:
             _nvtx.range_push("MonEng::PyStartStep")
 
         phase_code = 0
@@ -257,10 +253,8 @@ class MonitoringEngine:
             backend = self._native_backend
             if backend is not None:
                 backend.begin_step(int(self._current_step_id), phase_code)
-        if self._debug:
-            print(f"[MonEng] start_step -> step_id={self._current_step_id}")
 
-        if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+        if _nvtx is not None and self._nvtx_enabled:
             _nvtx.range_pop()
 
     def begin_request(self, request_id: int) -> None:
@@ -355,6 +349,18 @@ class MonitoringEngine:
             int(schedule.warmup_requests),
         )
 
+    def _sync_hook_debug_flag(self) -> None:
+        """Propagate debug mode to hook_points module without hard import coupling."""
+
+        try:
+            from . import hook_points  # local import to avoid import cycle at module load
+
+            setter = getattr(hook_points, "set_monitoring_debug", None)
+            if setter is not None:
+                setter(self._debug_enabled)
+        except Exception:
+            pass
+
     def _apply_native_runtime_config(self) -> None:
         if not self._native_backend or self.config is None:
             return
@@ -384,10 +390,6 @@ class MonitoringEngine:
         if self._model_id is None:
             return
         if not self._capture_enabled:
-            return
-
-        # Require native callback path to populate futures in cache_dict.
-        if not (self._native_builder_enabled and self._native_callback_enabled):
             return
 
         if input_ids is None or not hasattr(input_ids, "shape"):
@@ -444,11 +446,6 @@ class MonitoringEngine:
             self._active_batch_request_ids = [f"{gid}:{i}" for i in range(batch_size)]
             self._active_batch_start_idx_per_request = [0] * batch_size
             self._active_batch_finished_per_request = [False] * batch_size
-            if not is_prefill and self._debug:
-                print(
-                    "[MonEng] _register_db_step decode-path fallback init/reset "
-                    f"(batch_size={batch_size})"
-                )
 
         req_ids = self._active_batch_request_ids
         starts = self._active_batch_start_idx_per_request
@@ -459,22 +456,14 @@ class MonitoringEngine:
         token_ranges: List[Tuple[int, int]] = []
         if is_prefill:
             if attention_mask is None or not hasattr(attention_mask, "dim"):
-                if self._debug:
-                    print("[MonEng] skip db step: prefill requires attention_mask [B, L]")
                 return
             if int(attention_mask.dim()) != 2:
-                if self._debug:
-                    print("[MonEng] skip db step: prefill requires 2D attention_mask [B, L]")
                 return
             try:
                 lengths = attention_mask.sum(dim=1).tolist()
             except Exception:
-                if self._debug:
-                    print("[MonEng] skip db step: failed to compute lengths from attention_mask")
                 return
             if len(lengths) != batch_size:
-                if self._debug:
-                    print("[MonEng] skip db step: attention_mask batch mismatch")
                 return
             for i in range(batch_size):
                 start_i = int(starts[i])
@@ -546,9 +535,8 @@ class MonitoringEngine:
                 [token_ranges],  # N=1 in V1
                 [cache_dict],    # N=1 in V1
             )
-        except Exception as exc:
-            if self._debug:
-                print(f"[MonEng] host_engine.submit failed: {exc}")
+        except Exception:
+            pass
         finally:
             self._pending_db_step = None
 
@@ -563,16 +551,11 @@ class MonitoringEngine:
             from torch.cuda import nvtx as _nvtx  # type: ignore
         except Exception:
             _nvtx = None  # type: ignore
-        if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+        if _nvtx is not None and self._nvtx_enabled:
             _nvtx.range_push("MonEng::PyEndStep")
 
         step_id = self._current_step_id
         tasks = self._pending_tasks.pop(step_id, [])
-
-        if self._debug:
-            print(
-                f"[MonEng] end_step step_id={step_id} tasks={len(tasks)} delay={self._delay_steps}"
-            )
 
         try:
             producer_stream = torch.cuda.current_stream()
@@ -588,32 +571,6 @@ class MonitoringEngine:
                 import time
                 _t_end0 = time.perf_counter()
             stream_handle = _stream_to_handle(producer_stream)
-            # Prefer native batch (SoA) if enabled and we have aggregated specs
-            if self._native_batch_enabled and step_id in self._native_batch:
-                spec = self._native_batch.pop(step_id, {})
-                if spec.get("tensors"):
-                    if self._stats_enabled:
-                        import time
-                        t0 = time.perf_counter()
-                        _ = backend.submit_step_soa(step_id, spec, stream_handle)
-                        self._stats_native_submit_ms += (time.perf_counter() - t0) * 1000.0
-                        self._stats_steps += 1
-                        self._stats_tasks += len(spec.get("tensors", []))
-                    else:
-                        getattr(backend, "submit_step_soa")(step_id, spec, stream_handle)
-                else:
-                    # No tasks actually aggregated; seal to maintain ordering
-                    backend.seal_step(step_id, stream_handle)
-                self._submit_pending_db_step()
-                if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
-                    _nvtx.range_pop()
-                if _t_end0 is not None:
-                    _dt = (time.perf_counter() - _t_end0) * 1000.0
-                    self._stats_endstep_ms_total += _dt
-                    self._stats_endstep_calls += 1
-                    if _dt > self._stats_endstep_ms_max:
-                        self._stats_endstep_ms_max = _dt
-                return
 
             if tasks:
                 # Build tuple payloads (measure serialize cost) and submit.
@@ -656,7 +613,7 @@ class MonitoringEngine:
                 else:
                     backend.seal_step(step_id, stream_handle)
             self._submit_pending_db_step()
-            if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+            if _nvtx is not None and self._nvtx_enabled:
                 _nvtx.range_pop()
             if _t_end0 is not None:
                 _dt = (time.perf_counter() - _t_end0) * 1000.0
@@ -668,11 +625,11 @@ class MonitoringEngine:
 
         backend = self._python_backend
         if backend is None:
-            if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+            if _nvtx is not None and self._nvtx_enabled:
                 _nvtx.range_pop()
             return
         backend.submit_step(step_id, tasks, producer_stream)
-        if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+        if _nvtx is not None and self._nvtx_enabled:
             _nvtx.range_pop()
         if self._stats_enabled:
             import time
@@ -744,9 +701,6 @@ class MonitoringEngine:
 
     def close(self) -> None:
         """Tear down backend resources."""
-        _debug = bool(int(os.environ.get("MON_ENGINE_DEBUG", "0")))
-        if _debug:
-            print("[MonEng] close() called")
         self._pending_db_step = None
         self._active_batch_request_ids = None
         self._active_batch_start_idx_per_request = None
@@ -800,15 +754,6 @@ class MonitoringEngine:
                         pass
                 # Optional: slice mode stats
                 try:
-                    from .task import get_slice_stats  # type: ignore
-                    slice_stats = get_slice_stats()
-                    if slice_stats:
-                        print("[MonEng/SliceStats]", slice_stats)
-                except Exception:
-                    pass
-                # Hook-side stats from TL integration (optional)
-                try:
-                    # The hook module path in this repo
                     from monitoring.hook_points import get_monitoring_hook_stats
                     hook_stats = get_monitoring_hook_stats()
                     if hook_stats:
@@ -822,14 +767,8 @@ class MonitoringEngine:
                     pass
                 self._host_engine = None
                 self._host_engine_enabled = False
-            if _debug:
-                print("[MonEng] calling clear_completed_results()")
             self.clear_completed_results()
-            if _debug:
-                print("[MonEng] calling backend.close()")
             backend.close()
-            if _debug:
-                print("[MonEng] backend.close() returned")
             self._native_backend = None
             self._backend = None
             return
@@ -846,11 +785,10 @@ class MonitoringEngine:
 
         if self._using_native_backend and self._native_backend is not None:
             try:
-                import torch
                 from torch.cuda import nvtx as _nvtx  # type: ignore
             except Exception:
                 _nvtx = None  # type: ignore
-            if _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))):
+            if _nvtx is not None and self._nvtx_enabled:
                 _nvtx.range_push("MonEng::PyClearResults")
                 try:
                     self._native_backend.clear_completed_results()
@@ -882,6 +820,7 @@ def _load_native_backend(
     queue_size: int,
     cache_dtype: Optional[torch.dtype],
     delay_steps: int,
+    advance: AdvanceConfig,
 ) -> Optional[Any]:
     """Attempt to load the native backend extension.
 
@@ -899,6 +838,10 @@ def _load_native_backend(
             queue_size=queue_size,
             cache_dtype=cache_dtype,
             delay_steps=delay_steps,
+            pinpool_bins_kb=list(advance.pinpool_bins_kb),
+            pinpool_max_mb=int(advance.pinpool_max_mb),
+            host_copy_threads=int(advance.host_copy_threads),
+            host_copy_queue_size=int(advance.host_copy_queue_size),
         )
     except Exception:
         return None
@@ -1021,10 +964,8 @@ class _PythonBackend:
         queue_size: int,
         cache_dtype: Optional[torch.dtype],
         delay_steps: int,
-        debug: bool,
     ) -> None:
         self.cache_dtype = cache_dtype
-        self._debug = debug
         self._delay_steps = delay_steps
 
         if queue_size > 0:
@@ -1054,17 +995,13 @@ class _PythonBackend:
             self._step_buckets[step_id] = tasks_list
             self._sealed_steps.append(step_id)
 
-        if not tasks_list and self._debug:
-            print(f"[MonEng/Py] sealed empty step={step_id}")
-
         if tasks_list:
             self._ensure_started()
             if self._cache_stream is not None and producer_stream is not None:
                 try:
                     self._cache_stream.wait_stream(producer_stream)
                 except Exception:
-                    if self._debug:
-                        print(f"[MonEng/Py] wait_stream failed for step={step_id}")
+                    pass
 
         self._enqueue_ready_steps()
 
@@ -1110,8 +1047,6 @@ class _PythonBackend:
                 daemon=True,
             )
             self._worker.start()
-            if self._debug:
-                print("[MonEng/Py] worker started")
 
     def _enqueue_ready_steps(self) -> None:
         with self._lock:
@@ -1120,8 +1055,6 @@ class _PythonBackend:
                 tasks = self._step_buckets.pop(step_id, [])
                 if not tasks:
                     continue
-                if self._debug:
-                    print(f"[MonEng/Py] enqueue step={step_id} tasks={len(tasks)}")
                 self._queue.put(_StepWork(step_id, tasks))
 
     def _enqueue_all_steps(self) -> None:
@@ -1140,8 +1073,6 @@ class _PythonBackend:
             work = self._queue.get()
             if work is _QUEUE_SENTINEL:
                 self._queue.task_done()
-                if self._debug:
-                    print("[MonEng/Py] worker exiting")
                 break
 
             assert isinstance(work, _StepWork)

--- a/monitoring/hook_points.py
+++ b/monitoring/hook_points.py
@@ -6,7 +6,6 @@ Helpers to access activations in models.
 """
 
 import logging
-import os
 import time
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Sequence
@@ -30,10 +29,22 @@ try:
 except Exception:  # pragma: no cover - nvtx not always available
     _nvtx = None
 
-_NVTX_ENABLED = bool(int(os.environ.get("TL_ENABLE_NVTX", "0"))) and _nvtx is not None
-_HOOK_STATS_ENABLED = bool(int(os.environ.get("MON_ENGINE_STATS", "0"))) or bool(
-    int(os.environ.get("MON_HOOK_STATS", "0"))
-)
+_MONITORING_DEBUG = False
+
+
+def set_monitoring_debug(enabled: bool) -> None:
+    """Set shared debug mode for hook-side NVTX/stat paths."""
+
+    global _MONITORING_DEBUG
+    _MONITORING_DEBUG = bool(enabled)
+
+
+def _nvtx_enabled() -> bool:
+    return bool(_MONITORING_DEBUG and _nvtx is not None)
+
+
+def _hook_stats_enabled() -> bool:
+    return bool(_MONITORING_DEBUG)
 
 # Global accumulators for lightweight hook-side profiling (microseconds)
 _hook_total_calls = 0
@@ -86,7 +97,7 @@ def get_monitoring_hook_stats() -> dict:
 
 @contextmanager
 def _nvtx_range(message: str):
-    if _NVTX_ENABLED:
+    if _nvtx_enabled():
         _nvtx.range_push(message)
         try:
             yield
@@ -190,7 +201,7 @@ class HookPoint(nn.Module):
             from torch.cuda import nvtx as _nvtx  # type: ignore
         except Exception:
             _nvtx = None  # type: ignore
-        nvtx_enabled = _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0")))
+        nvtx_enabled = _nvtx_enabled()
         if nvtx_enabled:
             hk = self.name or "unnamed"
             _nvtx.range_push(f"TL::RegisterHook[{hk}:{dir}]")
@@ -348,7 +359,7 @@ class HookedRootModule(nn.Module):
             from torch.cuda import nvtx as _nvtx  # type: ignore
         except Exception:
             _nvtx = None  # type: ignore
-        nvtx_enabled = _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0")))
+        nvtx_enabled = _nvtx_enabled()
         if nvtx_enabled:
             _nvtx.range_push("TL::ResetHooks")
         if clear_contexts:
@@ -520,7 +531,7 @@ class HookedRootModule(nn.Module):
                 from torch.cuda import nvtx as _nvtx  # type: ignore
             except Exception:
                 _nvtx = None  # type: ignore
-            nvtx_enabled = _nvtx is not None and bool(int(os.environ.get("TL_ENABLE_NVTX", "0")))
+            nvtx_enabled = _nvtx_enabled()
             if nvtx_enabled:
                 _nvtx.range_push("TL::EnableHooks[fwd]")
             for name, hook in fwd_hooks:
@@ -698,9 +709,7 @@ class HookedRootModule(nn.Module):
             engine = self.monitoring_engine
             native_backend = getattr(engine, "_native_backend", None) if engine is not None else None
             native_using = bool(getattr(engine, "_using_native_backend", False) and native_backend is not None)
-            native_builder_enabled = bool(getattr(engine, "_native_builder_enabled", False))
-            native_callback_enabled = bool(getattr(engine, "_native_callback_enabled", False))
-            native_callback_active = native_using and native_builder_enabled and native_callback_enabled
+            native_callback_active = native_using
             if native_callback_active and not fwd and not bwd:
                 use_ctx = False
         except Exception:
@@ -733,10 +742,7 @@ class HookedRootModule(nn.Module):
                     return model_out, cache_dict
                 native_backend = getattr(engine, "_native_backend", None)
                 native_using = bool(getattr(engine, "_using_native_backend", False) and native_backend is not None)
-                native_builder_enabled = bool(getattr(engine, "_native_builder_enabled", False))
-                native_batch_enabled = bool(getattr(engine, "_native_batch_enabled", False))
-                native_callback_enabled = bool(getattr(engine, "_native_callback_enabled", False))
-                native_callback_active = native_using and native_builder_enabled and native_callback_enabled
+                native_callback_active = native_using
                 if native_callback_active and native_backend is not None:
                     # Bulk fill Python cache with BackendFutures for this step
                     with _nvtx_range("MonEng::CollectFutures"):
@@ -776,9 +782,7 @@ class HookedRootModule(nn.Module):
 
         native_backend = getattr(engine, "_native_backend", None)
         native_using = bool(getattr(engine, "_using_native_backend", False) and native_backend is not None)
-        native_builder_enabled = bool(getattr(engine, "_native_builder_enabled", False))
-        native_callback_enabled = bool(getattr(engine, "_native_callback_enabled", False))
-        native_callback_active = native_using and native_builder_enabled and native_callback_enabled
+        native_callback_active = native_using
         if not native_callback_active or native_backend is None:
             return
 
@@ -953,19 +957,10 @@ class HookedRootModule(nn.Module):
 
         native_backend = None
         native_using = False
-        native_builder_enabled = False
-        native_batch_enabled = False
-        native_callback_enabled = False
         if engine is not None:
             native_backend = getattr(engine, "_native_backend", None)
             native_using = bool(getattr(engine, "_using_native_backend", False) and native_backend is not None)
-            native_builder_enabled = bool(getattr(engine, "_native_builder_enabled", False))
-            native_batch_enabled = bool(getattr(engine, "_native_batch_enabled", False))
-            native_callback_enabled = bool(getattr(engine, "_native_callback_enabled", False))
-
-        native_callback_active = native_using and native_builder_enabled and native_callback_enabled
-        native_batch_active = native_using and native_batch_enabled and not native_callback_active
-        native_builder_python = native_using and native_builder_enabled and not native_callback_active
+        native_callback_active = native_using
 
         def save_hook(tensor: Tensor, hook: HookPoint, is_backward: bool = False):
             # for attention heads the pos dimension is the third from last
@@ -984,7 +979,7 @@ class HookedRootModule(nn.Module):
                 global _hook_total_calls, _hook_submit_calls
                 global _hook_build_us, _hook_submit_us, _hook_cache_set_us
                 global _sync_build_us, _sync_move_us, _sync_remove_batch_us, _sync_slice_us, _sync_cache_set_us
-                _hook_total_calls += 1 if _HOOK_STATS_ENABLED else 0
+                _hook_total_calls += 1 if _hook_stats_enabled() else 0
 
                 resid_stream = tensor.detach() if tensor.requires_grad else tensor
 
@@ -1005,125 +1000,8 @@ class HookedRootModule(nn.Module):
                     if native_callback_active:
                         cache[hook_name] = None
                         return
-                    if native_builder_python and native_backend is not None:
-                        # Fully offload: C++ computes pos_dim/can_slice/slice parse and appends
-                        if _HOOK_STATS_ENABLED:
-                            t0 = time.perf_counter()
-                        rb = bool(remove_batch_dim)
-                        native_backend.append_hook(int(engine._current_step_id), hook_name, resid_stream, rb, pos_slice, device if device is not None else None)
-                        if _HOOK_STATS_ENABLED:
-                            t1 = time.perf_counter()
-                            _hook_build_us += (t1 - t0) * 1e6
-                            _per_hook_build_us[hook_name] += (t1 - t0) * 1e6
-                            _per_hook_counts[hook_name] += 1
-                        cache[hook_name] = None
-                        return
-                    if native_batch_active and native_backend is not None:
-                        # Aggregate into engine's SoA buffers for per-step batch submit.
-                        from monitoring.task import _encode_slice_native  # type: ignore
-                        if _HOOK_STATS_ENABLED:
-                            t0 = time.perf_counter()
-                        rb = bool(remove_batch_dim)
-                        cs = bool(tensor.dim() >= -pos_dim)
-                        slice_tuple = _encode_slice_native(pos_slice)
-                        mode = int(slice_tuple[0])
-                        if not hasattr(engine, "_native_batch"):
-                            engine._native_batch = {}
-                        step_id_i = int(engine._current_step_id)
-                        agg = engine._native_batch.get(step_id_i)
-                        if agg is None:
-                            agg = {
-                                "tensors": [],
-                                "slice_dims": [],
-                                "remove_batch": [],
-                                "can_slice": [],
-                                "slice_modes": [],
-                                # Optional columns are created on demand only
-                                # to avoid per-hook overhead when always identity.
-                                "target_devices": [],
-                            }
-                            engine._native_batch[step_id_i] = agg
-                        a_t = agg["tensors"].append
-                        a_d = agg["slice_dims"].append
-                        a_rb = agg["remove_batch"].append
-                        a_cs = agg["can_slice"].append
-                        a_sm = agg["slice_modes"].append
-                        a_t(resid_stream)
-                        a_d(int(pos_dim))
-                        a_rb(rb)
-                        a_cs(cs)
-                        a_sm(mode)
-                        if mode == 1:
-                            iv = agg.get("int_values")
-                            if iv is None:
-                                iv = agg["int_values"] = []
-                            iv.append(int(slice_tuple[1]))
-                        elif mode == 2:
-                            ss = agg.get("slice_starts")
-                            sp = agg.get("slice_stops")
-                            st = agg.get("slice_steps")
-                            if ss is None:
-                                ss = agg["slice_starts"] = []
-                                sp = agg["slice_stops"] = []
-                                st = agg["slice_steps"] = []
-                            ss.append(slice_tuple[1])
-                            sp.append(slice_tuple[2])
-                            st.append(slice_tuple[3])
-                        elif mode == 3:
-                            ind = agg.get("indices")
-                            if ind is None:
-                                ind = agg["indices"] = []
-                            ind.append(slice_tuple[1])
-                        agg["target_devices"].append(device if device is not None else None)
-                        if _HOOK_STATS_ENABLED:
-                            t1 = time.perf_counter()
-                            _hook_build_us += (t1 - t0) * 1e6
-                            _per_hook_build_us[hook_name] += (t1 - t0) * 1e6
-                            _per_hook_counts[hook_name] += 1
-                        cache[hook_name] = None
-                        return
-                    if native_using and native_backend is not None and not native_batch_active and not native_builder_python:
-                        # Build compact tuple payload compatible with native backend
-                        from monitoring.task import _encode_slice_native  # type: ignore
-                        from monitoring.task import BackendFuture  # type: ignore
-                        if _HOOK_STATS_ENABLED:
-                            t0 = time.perf_counter()
-                        metadata = {
-                            "remove_batch_dim": remove_batch_dim,
-                            "can_slice": tensor.dim() >= -pos_dim,
-                        }
-                        slice_tuple = _encode_slice_native(pos_slice)
-                        target_dev = device if device is not None else None
-                        task_tuple = (
-                            resid_stream,
-                            int(pos_dim),
-                            bool(metadata["remove_batch_dim"]),
-                            bool(metadata["can_slice"]),
-                            slice_tuple,
-                            target_dev,
-                        )
-                        if _HOOK_STATS_ENABLED:
-                            t1 = time.perf_counter()
-                            _hook_build_us += (t1 - t0) * 1e6
-                            _per_hook_build_us[hook_name] += (t1 - t0) * 1e6
-                            _per_hook_counts[hook_name] += 1
-                            _hook_submit_calls += 1
-                            t2 = time.perf_counter()
-                            token = native_backend.add_task(int(engine._current_step_id), task_tuple)
-                            t3 = time.perf_counter()
-                            _hook_submit_us += (t3 - t2) * 1e6
-                            _per_hook_submit_us[hook_name] += (t3 - t2) * 1e6
-                            t4 = time.perf_counter()
-                            cache[hook_name] = BackendFuture(native_backend, token)
-                            t5 = time.perf_counter()
-                            _hook_cache_set_us += (t5 - t4) * 1e6
-                            _per_hook_cache_us[hook_name] += (t5 - t4) * 1e6
-                        else:
-                            token = native_backend.add_task(int(engine._current_step_id), task_tuple)
-                            cache[hook_name] = BackendFuture(native_backend, token)
-                        return
                     # Fallback to Python engine.submit if native backend is not available
-                    if _HOOK_STATS_ENABLED:
+                    if _hook_stats_enabled():
                         t0 = time.perf_counter()
                     metadata = {
                         "remove_batch_dim": remove_batch_dim,
@@ -1138,7 +1016,7 @@ class HookedRootModule(nn.Module):
                         metadata=metadata,
                         target_device=device if device is not None else None,
                     )
-                    if _HOOK_STATS_ENABLED:
+                    if _hook_stats_enabled():
                         t1 = time.perf_counter()
                         _hook_build_us += (t1 - t0) * 1e6
                         _per_hook_build_us[hook_name] += (t1 - t0) * 1e6
@@ -1160,10 +1038,10 @@ class HookedRootModule(nn.Module):
                     return
 
                 # sync build（进入同步分支到移动前的轻量准备）
-                t_sb0 = time.perf_counter() if _HOOK_STATS_ENABLED else None
-                t_mv0 = time.perf_counter() if _HOOK_STATS_ENABLED else None
+                t_sb0 = time.perf_counter() if _hook_stats_enabled() else None
+                t_mv0 = time.perf_counter() if _hook_stats_enabled() else None
                 resid_stream = resid_stream.to(device)
-                if _HOOK_STATS_ENABLED:
+                if _hook_stats_enabled():
                     if t_sb0 is not None:
                         sb_us = (t_mv0 - t_sb0) * 1e6 if t_mv0 is not None else 0.0
                         _sync_build_us += sb_us
@@ -1172,21 +1050,21 @@ class HookedRootModule(nn.Module):
                     _sync_move_us += mv_us
                     _per_hook_sync_move_us[hook_name] += mv_us
                 if remove_batch_dim:
-                    t_rm0 = time.perf_counter() if _HOOK_STATS_ENABLED else None
+                    t_rm0 = time.perf_counter() if _hook_stats_enabled() else None
                     resid_stream = resid_stream[0]
-                    if _HOOK_STATS_ENABLED:
+                    if _hook_stats_enabled():
                         _sync_remove_batch_us += (time.perf_counter() - t_rm0) * 1e6
 
                 if (
                     tensor.dim() >= -pos_dim
                 ):  # check if the residual stream has a pos dimension before trying to slice
-                    t_sl0 = time.perf_counter() if _HOOK_STATS_ENABLED else None
+                    t_sl0 = time.perf_counter() if _hook_stats_enabled() else None
                     resid_stream = pos_slice.apply(resid_stream, dim=pos_dim)
-                    if _HOOK_STATS_ENABLED:
+                    if _hook_stats_enabled():
                         sl_us = (time.perf_counter() - t_sl0) * 1e6
                         _sync_slice_us += sl_us
                         _per_hook_sync_slice_us[hook_name] += sl_us
-                if _HOOK_STATS_ENABLED:
+                if _hook_stats_enabled():
                     t_c0 = time.perf_counter()
                     cache[hook_name] = resid_stream
                     _sync_cache_set_us += (time.perf_counter() - t_c0) * 1e6

--- a/monitoring/task.py
+++ b/monitoring/task.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from collections import Counter
-import os
 from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
 import torch
@@ -15,13 +13,6 @@ from .utils import Slice
 # A lightweight payload that can be consumed directly by the native backend.
 SlicePayload = Tuple[Any, ...]
 NativePayload = Tuple[object, int, bool, bool, SlicePayload, Optional[torch.device]]
-
-# Optional slice mode statistics (guarded by env var)
-_SLICE_STATS_ENABLED = bool(int(os.environ.get("MON_ENGINE_SLICE_STATS", "0")))
-_slice_stats: Counter[str] = Counter()
-
-def get_slice_stats() -> Dict[str, int]:
-    return dict(_slice_stats)
 
 
 @dataclass
@@ -59,30 +50,20 @@ def _encode_slice(slice_obj: Any) -> SlicePayload:
     """Encode slice metadata into a compact tuple for native consumption."""
 
     if slice_obj is None:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["identity"] += 1
         return ("identity",)
 
     if Slice is not None and isinstance(slice_obj, Slice):  # pragma: no cover - optional path
         mode = getattr(slice_obj, "mode", "identity")
         data = getattr(slice_obj, "slice", None)
         if mode == "identity":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["identity"] += 1
             return ("identity",)
         if mode == "int":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["int"] += 1
             return ("int", int(data) if data is not None else 0)
         if mode == "slice":
             if isinstance(data, slice):
-                if _SLICE_STATS_ENABLED:
-                    _slice_stats["slice"] += 1
                 return ("slice", data.start, data.stop, data.step)
             return ("slice", None, None, None)
         if mode == "array":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["array"] += 1
             if data is None:
                 values: Tuple[int, ...] = ()
             elif hasattr(data, "tolist"):
@@ -95,22 +76,14 @@ def _encode_slice(slice_obj: Any) -> SlicePayload:
     slice_type = type(slice_obj)
 
     if slice_type is int:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["int"] += 1
         return ("int", int(slice_obj))
 
     if slice_type is slice:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["slice"] += 1
         return ("slice", slice_obj.start, slice_obj.stop, slice_obj.step)
 
     if slice_type in (list, tuple):
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["array"] += 1
         return ("array", tuple(int(v) for v in slice_obj))
 
-    if _SLICE_STATS_ENABLED:
-        _slice_stats["identity"] += 1
     return ("identity",)
 
 
@@ -120,30 +93,20 @@ def _encode_slice_native(slice_obj: Any) -> SlicePayload:
     Codes: 0=identity, 1=int, 2=slice, 3=array
     """
     if slice_obj is None:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["identity"] += 1
         return (0,)
 
     if Slice is not None and isinstance(slice_obj, Slice):  # pragma: no cover
         mode = getattr(slice_obj, "mode", "identity")
         data = getattr(slice_obj, "slice", None)
         if mode == "identity":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["identity"] += 1
             return (0,)
         if mode == "int":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["int"] += 1
             return (1, int(data) if data is not None else 0)
         if mode == "slice":
             if isinstance(data, slice):
-                if _SLICE_STATS_ENABLED:
-                    _slice_stats["slice"] += 1
                 return (2, data.start, data.stop, data.step)
             return (2, None, None, None)
         if mode == "array":
-            if _SLICE_STATS_ENABLED:
-                _slice_stats["array"] += 1
             if data is None:
                 values: Tuple[int, ...] = ()
             elif hasattr(data, "tolist"):
@@ -151,25 +114,15 @@ def _encode_slice_native(slice_obj: Any) -> SlicePayload:
             else:
                 values = tuple(int(v) for v in data)
             return (3, values)
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["identity"] += 1
         return (0,)
 
     t = type(slice_obj)
     if t is int:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["int"] += 1
         return (1, int(slice_obj))
     if t is slice:
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["slice"] += 1
         return (2, slice_obj.start, slice_obj.stop, slice_obj.step)
     if t in (list, tuple):
-        if _SLICE_STATS_ENABLED:
-            _slice_stats["array"] += 1
         return (3, tuple(int(v) for v in slice_obj))
-    if _SLICE_STATS_ENABLED:
-        _slice_stats["identity"] += 1
     return (0,)
 
 

--- a/tests/test_cpp_future_result.py
+++ b/tests/test_cpp_future_result.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import pytest
@@ -40,12 +39,7 @@ def _wait_native_drain_without_resolve(engine: MonitoringEngine, timeout_s: floa
     pytest.fail(f"native backend did not drain without resolve_all: {last_dbg}")
 
 
-def test_cpp_future_result_with_end_step_flow(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Use the default async offload path to better match real runs.
-    monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
-    monkeypatch.setenv("MON_NATIVE_PINNED", "1")
-    monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-
+def test_cpp_future_result_with_end_step_flow() -> None:
     engine = MonitoringEngine(async_enabled=True)
     device = torch.device("cuda")
 
@@ -97,13 +91,7 @@ def test_cpp_future_result_with_end_step_flow(monkeypatch: pytest.MonkeyPatch) -
         engine.close()
 
 
-def test_cpp_backendfuture_result_does_not_block_engine_close(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
-    monkeypatch.setenv("MON_NATIVE_PINNED", "1")
-    monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-
+def test_cpp_backendfuture_result_does_not_block_engine_close() -> None:
     engine = MonitoringEngine(async_enabled=True)
     device = torch.device("cuda")
 

--- a/tests/test_generate_with_monitoring.py
+++ b/tests/test_generate_with_monitoring.py
@@ -91,14 +91,7 @@ def _wait_native_drain_without_resolve(engine: MonitoringEngine, timeout_s: floa
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_generate_and_forward_collect_cpp_futures_and_consume_results(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("MON_NATIVE_TO_CPU", "1")
-    monkeypatch.setenv("MON_NATIVE_PINNED", "1")
-    monkeypatch.setenv("MON_NATIVE_PINPOOL", "1")
-    monkeypatch.setenv("MON_NATIVE_BUILDER", "1")
-    monkeypatch.setenv("MON_NATIVE_CALLBACK", "1")
-    monkeypatch.setenv("MON_NATIVE_BATCH", "0")
-
+def test_generate_and_forward_collect_cpp_futures_and_consume_results():
     model = _build_small_lm().to("cuda").eval()
     cfg = MonitoringConfig(hooks=HookSelection(mode="full"))
     engine = MonitoringEngine(async_enabled=True, config=cfg)

--- a/tests/test_monitoring_config.py
+++ b/tests/test_monitoring_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from monitoring import MonitoringConfig, MonitoringEngine, NativePartialSealConfig
+from monitoring import AdvanceConfig, MonitoringConfig, MonitoringEngine, NativePartialSealConfig
 
 
 def test_native_partial_seal_config_validation():
@@ -30,6 +30,64 @@ def test_monitoring_config_as_dict_includes_native_partial_seal():
         "cap_ratio": 0.9,
         "driver_guard_mb": 512,
     }
+
+
+def test_advance_config_defaults():
+    cfg = AdvanceConfig()
+    assert cfg.pinpool_bins_kb == (256, 512, 1024, 2048, 4096, 8192)
+    assert cfg.pinpool_max_mb == 512
+    assert cfg.host_copy_threads == 0
+    assert cfg.host_copy_queue_size == 512
+
+
+def test_advance_config_filters_invalid_bins_and_keeps_tuple():
+    cfg = AdvanceConfig(pinpool_bins_kb=(0, 512, -1, 1024))
+    assert cfg.pinpool_bins_kb == (512, 1024)
+    assert isinstance(cfg.pinpool_bins_kb, tuple)
+
+
+def test_advance_config_rejects_empty_or_invalid_bins():
+    with pytest.raises(ValueError, match="at least one positive integer"):
+        AdvanceConfig(pinpool_bins_kb=())
+    with pytest.raises(ValueError, match="at least one positive integer"):
+        AdvanceConfig(pinpool_bins_kb=(0, -1))
+
+
+def test_advance_config_rejects_invalid_numeric_fields():
+    with pytest.raises(ValueError, match="pinpool_max_mb must be > 0"):
+        AdvanceConfig(pinpool_max_mb=0)
+    with pytest.raises(ValueError, match="host_copy_threads must be >= 0"):
+        AdvanceConfig(host_copy_threads=-1)
+    with pytest.raises(ValueError, match="host_copy_queue_size must be > 0"):
+        AdvanceConfig(host_copy_queue_size=0)
+
+
+def test_monitoring_config_as_dict_includes_advance_debug_and_no_strip():
+    cfg = MonitoringConfig(
+        advance=AdvanceConfig(
+            pinpool_bins_kb=(512,),
+            pinpool_max_mb=256,
+            host_copy_threads=2,
+            host_copy_queue_size=64,
+        ),
+        debug=True,
+        no_strip=True,
+    )
+    data = cfg.as_dict()
+    assert data["advance"] == {
+        "pinpool_bins_kb": [512],
+        "pinpool_max_mb": 256,
+        "host_copy_threads": 2,
+        "host_copy_queue_size": 64,
+    }
+    assert data["debug"] is True
+    assert data["no_strip"] is True
+
+
+def test_monitoring_config_default_debug_false():
+    cfg = MonitoringConfig()
+    assert cfg.debug is False
+    assert cfg.as_dict()["debug"] is False
 
 
 def test_apply_native_runtime_config_calls_backend_setter():

--- a/tests/test_monitoring_engine_request_id.py
+++ b/tests/test_monitoring_engine_request_id.py
@@ -48,8 +48,6 @@ def _build_engine_for_db_step_unit() -> tuple[MonitoringEngine, _DummyHostEngine
     engine._host_engine_enabled = True
     engine._using_native_backend = True
     engine._capture_enabled = True
-    engine._native_builder_enabled = True
-    engine._native_callback_enabled = True
     return engine, host
 
 

--- a/tests/test_pinned_to_pageable.py
+++ b/tests/test_pinned_to_pageable.py
@@ -1,84 +1,29 @@
-"""
-Test suite for pinned→pageable memory conversion in MonitoringEngine.
+"""Tests for fixed pinned-offload behavior in MonitoringEngine."""
 
-Verifies that:
-1. When pinpool=0 (disabled), pinned tensors are converted to pageable
-2. When pinpool=1 (enabled), pinned tensors are converted to pageable
-3. Final results are always pageable (not pinned)
-4. VmPin memory doesn't leak over multiple steps
-"""
-
-import os
+from __future__ import annotations
 
 import pytest
 import torch
 
 from monitoring import MonitoringEngine
+from monitoring.config import AdvanceConfig, MonitoringConfig
 from monitoring.task import MonitoringTask
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_pinned_to_pageable_no_pool():
-    """Test that results are pageable when pinpool is disabled."""
-    # Configure environment
-    os.environ["MON_NATIVE_TO_CPU"] = "1"
-    os.environ["MON_NATIVE_PINNED"] = "1"
-    os.environ["MON_NATIVE_PINPOOL"] = "0"  # Disable pool
+def test_pinned_offload_results_are_pageable() -> None:
+    """Results should always end up as pageable CPU tensors."""
 
     engine = MonitoringEngine(async_enabled=True)
-
-    # Create CUDA tensor
     tensor = torch.randn(128, 512, device="cuda", dtype=torch.float32)
 
     engine.start_step()
     task = MonitoringTask(
         name="test.activation",
         tensor=tensor,
-        target_device=torch.device("cpu"),  # Request CPU offload
-        metadata={"remove_batch_dim": False, "can_slice": False},
-    )
-
-    future = engine.submit(task)
-    engine.end_step()
-
-    try:
-        # Wait for async processing
-        result = future.result(timeout=5.0)
-        engine.resolve_all()
-
-        # Assert: result is on CPU and pageable
-        assert result.device.type == "cpu", f"Result should be on CPU, got {result.device}"
-        assert not result.is_pinned(), f"Result should be pageable, but is_pinned={result.is_pinned()}"
-
-        # Verify data correctness
-        assert result.shape == tensor.shape, f"Shape mismatch: {result.shape} vs {tensor.shape}"
-        assert torch.allclose(result, tensor.cpu(), atol=1e-5), "Data mismatch"
-
-        print(f"✓ Pool disabled: result is pageable (is_pinned={result.is_pinned()})")
-    finally:
-        engine.close()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_pinned_to_pageable_with_pool():
-    """Test that results are pageable when pinpool is enabled."""
-    # Configure environment
-    os.environ["MON_NATIVE_TO_CPU"] = "1"
-    os.environ["MON_NATIVE_PINNED"] = "1"
-    os.environ["MON_NATIVE_PINPOOL"] = "1"  # Enable pool
-
-    engine = MonitoringEngine(async_enabled=True)
-
-    tensor = torch.randn(256, 768, device="cuda", dtype=torch.float32)
-
-    engine.start_step()
-    task = MonitoringTask(
-        name="test.pooled",
-        tensor=tensor,
         target_device=torch.device("cpu"),
         metadata={"remove_batch_dim": False, "can_slice": False},
     )
-
     future = engine.submit(task)
     engine.end_step()
 
@@ -86,204 +31,50 @@ def test_pinned_to_pageable_with_pool():
         result = future.result(timeout=5.0)
         engine.resolve_all()
 
-        # Key assertion: even with pool, final result should be pageable
-        assert result.device.type == "cpu", f"Result should be on CPU, got {result.device}"
-        assert not result.is_pinned(), f"Pool-backed results must be converted to pageable (is_pinned={result.is_pinned()})"
-        assert torch.allclose(result, tensor.cpu(), atol=1e-5), "Data mismatch"
-
-        # Check pool statistics (if available)
-        try:
-            backend = engine._native_backend
-            if backend is not None:
-                stats = backend.get_stats()
-                print(f"✓ Pool enabled: result is pageable (is_pinned={result.is_pinned()})")
-                if "pool_hits" in stats:
-                    print(f"  Pool hits: {stats.get('pool_hits', 0)}")
-                if "host_memcpy_mb" in stats:
-                    print(f"  Host memcpy: {stats.get('host_memcpy_mb', 0):.2f} MB")
-        except Exception:
-            pass
+        assert result.device.type == "cpu"
+        assert not result.is_pinned()
+        assert result.shape == tensor.shape
+        assert torch.allclose(result, tensor.cpu(), atol=1e-5)
     finally:
         engine.close()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_no_pinned_memory_leak():
-    """Test that pinned memory doesn't accumulate over multiple steps."""
-    # Configure environment
-    os.environ["MON_NATIVE_TO_CPU"] = "1"
-    os.environ["MON_NATIVE_PINNED"] = "1"
-    os.environ["MON_NATIVE_PINPOOL"] = "1"
+def test_advance_config_is_applied() -> None:
+    """Advanced runtime config should be accepted and produce valid stats."""
 
-    def get_vmpin_kb():
-        """Parse /proc/self/status for VmPin (Linux only)."""
-        try:
-            with open("/proc/self/status") as f:
-                for line in f:
-                    if line.startswith("VmPin:"):
-                        return int(line.split()[1])  # KB
-        except (FileNotFoundError, ValueError):
-            pytest.skip("VmPin monitoring requires Linux /proc filesystem")
-        return 0
-
-    engine = MonitoringEngine(async_enabled=True)
-
-    # Warmup
-    for _ in range(3):
-        tensor = torch.randn(100, 200, device="cuda")
-        engine.start_step()
-        task = MonitoringTask(
-            name="warmup",
-            tensor=tensor,
-            target_device=torch.device("cpu"),
-            metadata={"remove_batch_dim": False, "can_slice": False},
+    cfg = MonitoringConfig(
+        advance=AdvanceConfig(
+            pinpool_bins_kb=(512, 1024, 2048),
+            pinpool_max_mb=128,
+            host_copy_threads=2,
+            host_copy_queue_size=128,
         )
-        future = engine.submit(task)
-        engine.end_step()
-        result = future.result(timeout=5.0)
-        assert not result.is_pinned(), f"Warmup result should be pageable"
+    )
+    engine = MonitoringEngine(async_enabled=True, config=cfg)
 
-    engine.resolve_all()
-    torch.cuda.synchronize()
-
-    # Record baseline VmPin
-    vmpin_before = get_vmpin_kb()
-    print(f"VmPin baseline: {vmpin_before} KB ({vmpin_before / 1024:.2f} MB)")
-
-    # Run multiple steps
-    results = []
-    for i in range(20):
-        tensor = torch.randn(500, 512, device="cuda")
+    try:
+        tensor = torch.randn(64, 256, device="cuda", dtype=torch.float32)
         engine.start_step()
-        task = MonitoringTask(
-            name=f"step_{i}",
-            tensor=tensor,
-            target_device=torch.device("cpu"),
-            metadata={"remove_batch_dim": False, "can_slice": False},
-        )
-        future = engine.submit(task)
-        engine.end_step()
-        result = future.result(timeout=5.0)
-        assert not result.is_pinned(), f"Step {i}: result is pinned (should be pageable)"
-        results.append(result)
-
-    engine.resolve_all()
-    torch.cuda.synchronize()
-
-    # Check VmPin didn't grow significantly
-    vmpin_after = get_vmpin_kb()
-    vmpin_growth_mb = (vmpin_after - vmpin_before) / 1024.0
-
-    print(f"VmPin after: {vmpin_after} KB ({vmpin_after / 1024:.2f} MB)")
-    print(f"VmPin growth: {vmpin_growth_mb:.2f} MB")
-
-    # Allow small growth (pool preallocation), but not continuous growth
-    assert vmpin_growth_mb < 50.0, f"VmPin leaked {vmpin_growth_mb:.2f} MB (should be < 50 MB)"
-
-    print(f"✓ No memory leak: VmPin growth = {vmpin_growth_mb:.2f} MB (< 50 MB threshold)")
-
-    engine.close()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_pool_statistics():
-    """Compare pool hits/misses when pool is enabled vs disabled."""
-
-    def run_with_pool(enable_pool: bool):
-        os.environ["MON_NATIVE_TO_CPU"] = "1"
-        os.environ["MON_NATIVE_PINNED"] = "1"
-        os.environ["MON_NATIVE_PINPOOL"] = "1" if enable_pool else "0"
-
-        engine = MonitoringEngine(async_enabled=True)
-
-        for i in range(10):
-            tensor = torch.randn(128, 256, device="cuda")
-            engine.start_step()
-            task = MonitoringTask(
-                name=f"test_{i}",
+        future = engine.submit(
+            MonitoringTask(
+                name="test.advance",
                 tensor=tensor,
                 target_device=torch.device("cpu"),
                 metadata={"remove_batch_dim": False, "can_slice": False},
             )
-            future = engine.submit(task)
-            engine.end_step()
-            result = future.result(timeout=5.0)
-            assert not result.is_pinned(), f"Iteration {i}: result should be pageable"
-
-        engine.resolve_all()
-        stats = {}
-        try:
-            backend = engine._native_backend
-            if backend is not None:
-                stats = backend.get_stats()
-        except Exception:
-            pass
-        engine.close()
-        return stats
-
-    # Pool enabled
-    stats_pooled = run_with_pool(True)
-    print(f"With pool: {stats_pooled}")
-
-    # Pool disabled
-    stats_no_pool = run_with_pool(False)
-    print(f"No pool: {stats_no_pool}")
-
-    # Verify: pool enabled should have hits statistics
-    if "pool_hits" in stats_pooled:
-        assert stats_pooled["pool_hits"] > 0, "Pool should have hits when enabled"
-        print(f"✓ Pool hits: {stats_pooled['pool_hits']}")
-
-    # Both cases should have host memcpy (pinned→pageable conversion)
-    if "host_memcpy_mb" in stats_pooled:
-        assert stats_pooled["host_memcpy_mb"] > 0, "Should have host memcpy with pool"
-        print(f"✓ Host memcpy (pool): {stats_pooled['host_memcpy_mb']:.2f} MB")
-
-    if "host_memcpy_mb" in stats_no_pool:
-        assert stats_no_pool["host_memcpy_mb"] > 0, "Should have host memcpy without pool"
-        print(f"✓ Host memcpy (no pool): {stats_no_pool['host_memcpy_mb']:.2f} MB")
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_pinned_disabled_returns_pageable():
-    """Test that when pinned memory is disabled, results are still pageable."""
-    # Configure: no pinned memory
-    os.environ["MON_NATIVE_TO_CPU"] = "1"
-    os.environ["MON_NATIVE_PINNED"] = "0"  # Disable pinned
-
-    engine = MonitoringEngine(async_enabled=True)
-
-    tensor = torch.randn(64, 128, device="cuda", dtype=torch.float32)
-
-    engine.start_step()
-    task = MonitoringTask(
-        name="test.no_pinned",
-        tensor=tensor,
-        target_device=torch.device("cpu"),
-        metadata={"remove_batch_dim": False, "can_slice": False},
-    )
-
-    future = engine.submit(task)
-    engine.end_step()
-
-    try:
+        )
+        engine.end_step()
         result = future.result(timeout=5.0)
-        engine.resolve_all()
-
-        # Should be pageable (obviously, since we didn't use pinned)
         assert result.device.type == "cpu"
-        assert not result.is_pinned(), "Result should be pageable when pinned disabled"
-        assert torch.allclose(result, tensor.cpu(), atol=1e-5)
+        assert not result.is_pinned()
 
-        print(f"✓ Pinned disabled: result is pageable (is_pinned={result.is_pinned()})")
+        backend = engine._native_backend
+        assert backend is not None
+        stats = backend.get_stats()
+        assert "pool_hits" in stats
+        assert "pool_misses" in stats
+        assert "pool_high_watermark_bytes" in stats
+        assert "host_memcpy_mb" in stats
     finally:
         engine.close()
-
-
-if __name__ == "__main__":
-    # Allow running individual tests
-    import sys
-    if len(sys.argv) > 1:
-        pytest.main([__file__, "-v", "-s", "-k", sys.argv[1]])
-    else:
-        pytest.main([__file__, "-v", "-s"])

--- a/tests/test_pinned_to_pageable.py
+++ b/tests/test_pinned_to_pageable.py
@@ -2,12 +2,40 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import torch
 
 from monitoring import MonitoringEngine
 from monitoring.config import AdvanceConfig, MonitoringConfig
 from monitoring.task import MonitoringTask
+
+
+def _submit_offload(engine: MonitoringEngine, tensor: torch.Tensor, name: str) -> torch.Tensor:
+    engine.start_step()
+    future = engine.submit(
+        MonitoringTask(
+            name=name,
+            tensor=tensor,
+            target_device=torch.device("cpu"),
+            metadata={"remove_batch_dim": False, "can_slice": False},
+        )
+    )
+    engine.end_step()
+    result = future.result(timeout=10.0)
+    engine.resolve_all()
+    return result
+
+
+def _read_vmpin_kb() -> int:
+    status = Path("/proc/self/status")
+    if not status.exists():
+        pytest.skip("VmPin monitoring requires Linux /proc filesystem")
+    for line in status.read_text(encoding="utf-8").splitlines():
+        if line.startswith("VmPin:"):
+            return int(line.split()[1])
+    return 0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -17,19 +45,8 @@ def test_pinned_offload_results_are_pageable() -> None:
     engine = MonitoringEngine(async_enabled=True)
     tensor = torch.randn(128, 512, device="cuda", dtype=torch.float32)
 
-    engine.start_step()
-    task = MonitoringTask(
-        name="test.activation",
-        tensor=tensor,
-        target_device=torch.device("cpu"),
-        metadata={"remove_batch_dim": False, "can_slice": False},
-    )
-    future = engine.submit(task)
-    engine.end_step()
-
     try:
-        result = future.result(timeout=5.0)
-        engine.resolve_all()
+        result = _submit_offload(engine, tensor, "test.activation")
 
         assert result.device.type == "cpu"
         assert not result.is_pinned()
@@ -40,41 +57,94 @@ def test_pinned_offload_results_are_pageable() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_advance_config_is_applied() -> None:
-    """Advanced runtime config should be accepted and produce valid stats."""
+def test_pool_stats_and_host_memcpy_are_non_zero() -> None:
+    """Pinned-pool and host memcpy statistics should be active in fixed-on path."""
 
-    cfg = MonitoringConfig(
-        advance=AdvanceConfig(
-            pinpool_bins_kb=(512, 1024, 2048),
-            pinpool_max_mb=128,
-            host_copy_threads=2,
-            host_copy_queue_size=128,
-        )
-    )
+    cfg = MonitoringConfig(advance=AdvanceConfig(host_copy_threads=2, host_copy_queue_size=128))
     engine = MonitoringEngine(async_enabled=True, config=cfg)
 
     try:
-        tensor = torch.randn(64, 256, device="cuda", dtype=torch.float32)
-        engine.start_step()
-        future = engine.submit(
-            MonitoringTask(
-                name="test.advance",
-                tensor=tensor,
-                target_device=torch.device("cpu"),
-                metadata={"remove_batch_dim": False, "can_slice": False},
-            )
-        )
-        engine.end_step()
-        result = future.result(timeout=5.0)
-        assert result.device.type == "cpu"
-        assert not result.is_pinned()
+        for i in range(12):
+            tensor = torch.randn(192, 384, device="cuda", dtype=torch.float32)
+            result = _submit_offload(engine, tensor, f"test.stats.{i}")
+            assert result.device.type == "cpu"
+            assert not result.is_pinned()
+            assert torch.allclose(result, tensor.cpu(), atol=1e-5)
 
         backend = engine._native_backend
         assert backend is not None
         stats = backend.get_stats()
-        assert "pool_hits" in stats
-        assert "pool_misses" in stats
-        assert "pool_high_watermark_bytes" in stats
-        assert "host_memcpy_mb" in stats
+        pool_hits = int(stats.get("pool_hits", 0))
+        pool_misses = int(stats.get("pool_misses", 0))
+        host_memcpy_mb = float(stats.get("host_memcpy_mb", 0.0))
+
+        assert pool_hits + pool_misses > 0
+        assert host_memcpy_mb > 0.0
+    finally:
+        engine.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_host_copy_threads_zero_vs_parallel_consistent() -> None:
+    """Both host-copy paths should offload correctly and produce identical results."""
+
+    base = torch.arange(64 * 128, dtype=torch.float32, device="cuda").reshape(64, 128)
+
+    def run_once(host_copy_threads: int) -> list[torch.Tensor]:
+        cfg = MonitoringConfig(
+            advance=AdvanceConfig(
+                host_copy_threads=host_copy_threads,
+                host_copy_queue_size=128,
+            )
+        )
+        engine = MonitoringEngine(async_enabled=True, config=cfg)
+        outputs: list[torch.Tensor] = []
+        try:
+            for i in range(5):
+                tensor = (base + float(i)).clone()
+                result = _submit_offload(engine, tensor, f"test.threads.{host_copy_threads}.{i}")
+                assert result.device.type == "cpu"
+                assert not result.is_pinned()
+                outputs.append(result)
+        finally:
+            engine.close()
+        return outputs
+
+    serial_outputs = run_once(host_copy_threads=0)
+    parallel_outputs = run_once(host_copy_threads=2)
+
+    assert len(serial_outputs) == len(parallel_outputs) == 5
+    for serial, parallel in zip(serial_outputs, parallel_outputs):
+        assert torch.equal(serial, parallel)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_vmpin_growth_bounded_under_long_run() -> None:
+    """VmPin should stay bounded under long-run fixed pinned offload path."""
+
+    engine = MonitoringEngine(async_enabled=True)
+    shape = (256, 512)
+
+    try:
+        for i in range(4):
+            warm = torch.randn(*shape, device="cuda", dtype=torch.float32)
+            warm_res = _submit_offload(engine, warm, f"test.vmpin.warmup.{i}")
+            assert not warm_res.is_pinned()
+
+        torch.cuda.synchronize()
+        vmpin_before_kb = _read_vmpin_kb()
+
+        for i in range(24):
+            tensor = torch.randn(*shape, device="cuda", dtype=torch.float32)
+            result = _submit_offload(engine, tensor, f"test.vmpin.run.{i}")
+            assert result.device.type == "cpu"
+            assert not result.is_pinned()
+
+        torch.cuda.synchronize()
+        vmpin_after_kb = _read_vmpin_kb()
+        vmpin_growth_mb = (vmpin_after_kb - vmpin_before_kb) / 1024.0
+
+        # Allow moderate one-time growth, but reject unbounded increase.
+        assert vmpin_growth_mb < 64.0, f"VmPin growth too high: {vmpin_growth_mb:.2f} MB"
     finally:
         engine.close()

--- a/tests/test_pinned_to_pageable.py
+++ b/tests/test_pinned_to_pageable.py
@@ -90,7 +90,7 @@ def test_host_copy_threads_zero_vs_parallel_consistent() -> None:
 
     base = torch.arange(64 * 128, dtype=torch.float32, device="cuda").reshape(64, 128)
 
-    def run_once(host_copy_threads: int) -> list[torch.Tensor]:
+    def run_once(host_copy_threads: int) -> tuple[list[torch.Tensor], dict]:
         cfg = MonitoringConfig(
             advance=AdvanceConfig(
                 host_copy_threads=host_copy_threads,
@@ -106,12 +106,22 @@ def test_host_copy_threads_zero_vs_parallel_consistent() -> None:
                 assert result.device.type == "cpu"
                 assert not result.is_pinned()
                 outputs.append(result)
+
+            backend = engine._native_backend
+            assert backend is not None
+            stats = backend.get_stats()
+            pool_hits = int(stats.get("pool_hits", 0))
+            pool_misses = int(stats.get("pool_misses", 0))
+            host_memcpy_mb = float(stats.get("host_memcpy_mb", 0.0))
+
+            assert pool_hits + pool_misses > 0
+            assert host_memcpy_mb > 0.0
         finally:
             engine.close()
-        return outputs
+        return outputs, stats
 
-    serial_outputs = run_once(host_copy_threads=0)
-    parallel_outputs = run_once(host_copy_threads=2)
+    serial_outputs, _ = run_once(host_copy_threads=0)
+    parallel_outputs, _ = run_once(host_copy_threads=2)
 
     assert len(serial_outputs) == len(parallel_outputs) == 5
     for serial, parallel in zip(serial_outputs, parallel_outputs):
@@ -144,7 +154,7 @@ def test_vmpin_growth_bounded_under_long_run() -> None:
         vmpin_after_kb = _read_vmpin_kb()
         vmpin_growth_mb = (vmpin_after_kb - vmpin_before_kb) / 1024.0
 
-        # Allow moderate one-time growth, but reject unbounded increase.
-        assert vmpin_growth_mb < 64.0, f"VmPin growth too high: {vmpin_growth_mb:.2f} MB"
+        # Allow moderate one-time growth, but reject sustained growth.
+        assert vmpin_growth_mb < 16.0, f"VmPin growth too high: {vmpin_growth_mb:.2f} MB"
     finally:
         engine.close()

--- a/tests/validate_request_id_pipeline.py
+++ b/tests/validate_request_id_pipeline.py
@@ -10,6 +10,7 @@ from transformers import AutoTokenizer, LogitsProcessor
 from transformers.models.gpt2_p.modeling_gpt2 import HookedGPT2LMHeadModel
 
 from monitoring import (
+    AdvanceConfig,
     ClickHouseClientConfig,
     EnqueuePolicy,
     HostEngineConfig,
@@ -92,8 +93,8 @@ def _build_ingress_policy() -> EnqueuePolicy:
     return p
 
 
-def _build_host_config(db_cfg: ClickHouseClientConfig) -> HostEngineConfig:
-    stage_one = StageConfig.process_future(parallelism=1, name="process_future")
+def _build_host_config(db_cfg: ClickHouseClientConfig, *, debug: bool = False) -> HostEngineConfig:
+    stage_one = StageConfig.process_future(parallelism=1, name="process_future", debug=bool(debug))
     stage_two = StageConfig.clickhouse_insert(db_cfg, parallelism=1, name="clickhouse_insert")
     stage_one.input_queue = _build_queue_config()
     stage_two.input_queue = _build_queue_config()
@@ -269,14 +270,6 @@ def main() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required for this validation script.")
 
-    os.environ.setdefault("MON_NATIVE_TO_CPU", "1")
-    os.environ.setdefault("MON_NATIVE_CALLBACK", "1")
-    os.environ.setdefault("MON_NATIVE_BUILDER", "1")
-    os.environ.setdefault("MON_NATIVE_BATCH", "0")
-    os.environ.setdefault("MON_NATIVE_PINNED", "1")
-    os.environ.setdefault("MON_NATIVE_PINPOOL", "1")
-    os.environ.setdefault("MON_NATIVE_HOST_COPY_THREADS", "4")
-
     prompts = _load_prompts(args.prompts)
     device = torch.device(args.device)
 
@@ -307,13 +300,14 @@ def main() -> None:
             cap_ratio=0.8,
             driver_guard_mb=1024,
         ),
+        advance=AdvanceConfig(host_copy_threads=4),
     )
     # Enable decode-finished tracking in engine._register_db_step.
     cfg.eos_token_id = int(tokenizer.eos_token_id)
     cfg.pad_token_id = int(tokenizer.pad_token_id)
 
     db_cfg = _build_db_config(drop_existing=(not args.keep_existing_db))
-    host_cfg = _build_host_config(db_cfg)
+    host_cfg = _build_host_config(db_cfg, debug=bool(cfg.debug))
 
     engine = MonitoringEngine(
         async_enabled=True,


### PR DESCRIPTION
## Summary
This PR removes legacy runtime env toggles and consolidates runtime controls into `MonitoringConfig`.

## Final Design
- `MonitoringConfig.debug: bool` is the only debug switch.
  - `debug=true`: enable both engine stats and NVTX.
  - `debug=false`: disable both.
- `AdvanceConfig` is introduced under `MonitoringConfig` for runtime tuning:
  - `pinpool_bins_kb` (default: `[256, 512, 1024, 2048, 4096, 8192]`)
  - `pinpool_max_mb` (default: `512`)
  - `host_copy_threads` (default: `0`)
  - `host_copy_queue_size` (default: `512`)

## Removed Runtime Env Vars
- `MON_NATIVE_BATCH`
- `MON_NATIVE_BUILDER`
- `MON_NATIVE_CALLBACK`
- `MON_ENGINE_DEBUG`
- `MON_HOOK_STATS`
- `MON_ENGINE_SLICE_STATS`
- `MON_NATIVE_TO_CPU`
- `MON_NATIVE_PINNED`
- `MON_NATIVE_PINPOOL`
- `MON_NATIVE_PINNED_INDEX`

## Migrated from Env to Config
- `MON_ENGINE_STATS` + `TL_ENABLE_NVTX` -> `MonitoringConfig.debug`
- `MON_NATIVE_PINPOOL_BINS_KB` -> `MonitoringConfig.advance.pinpool_bins_kb`
- `MON_NATIVE_PINPOOL_MAX_MB` -> `MonitoringConfig.advance.pinpool_max_mb`
- `MON_NATIVE_HOST_COPY_THREADS` -> `MonitoringConfig.advance.host_copy_threads`
- `MON_NATIVE_HOST_COPY_QUEUE_SIZE` -> `MonitoringConfig.advance.host_copy_queue_size`

## Fixed Runtime Behavior
- Native builder path is always enabled.
- Native callback path is always enabled.
- D2H offload is always enabled.
- Pinned memory path is always enabled.
- Pin pool is always enabled.

## Cleanup Guarantees
- Remove all associated env reads and dead branches across Python/C++ paths.
- Update benchmark/example/test scripts to use config, not env.
- Verify removed env names are absent from runtime code via repository grep.

## Additional Changes (for Review)
- Host pipeline log noise is now debug-gated:
  - `worker X in future_process introduced ... tensor copies due to non-contiguous`
  - only prints when `process_future(debug=true)`.
- `StageConfig.process_future(...)` adds optional `debug: bool = false`.
  - backward compatible by default (silent unless debug is enabled).
- Host pipeline builders in benchmark/example/validation scripts now pass debug from `MonitoringConfig.debug`.
- README and Quick Start examples are updated to remove old runtime env usage and reflect config-driven runtime/debug setup.

## Issue Link
Part of #18


## Test Results
- Environment: `conda` env `proj-dmx`
- Command: `/home/nengneng/miniconda3/envs/proj-dmx/bin/python -m pytest -q tests/test_pinned_to_pageable.py -s`
- Result: `4 passed in 1.16s`

### Added Coverage in `tests/test_pinned_to_pageable.py`
- bounded VmPin growth under long-run fixed pinned-offload path
- non-zero runtime stats assertions: `pool_hits + pool_misses > 0`, `host_memcpy_mb > 0`
- consistency between `host_copy_threads=0` and `host_copy_threads>0` paths


### Additional Test Update
- tighten VmPin growth threshold to `< 16.0 MB` under long-run fixed pinned-offload path
- add stats non-zero assertions to both host-copy paths (`host_copy_threads=0` and `host_copy_threads=2`)
- add pure Python config tests for new fields/validation:
  - `AdvanceConfig` defaults, validation, bins filtering and tuple normalization
  - `MonitoringConfig.as_dict()` includes `advance`, `debug`, and `no_strip`
  - `MonitoringConfig.debug` default is `False`

### Latest Test Runs
- `/home/nengneng/miniconda3/envs/proj-dmx/bin/python -m pytest -q tests/test_monitoring_config.py -s`
  - `9 passed in 1.02s`
- `/home/nengneng/miniconda3/envs/proj-dmx/bin/python -m pytest -q tests/test_pinned_to_pageable.py -s`
  - `4 passed in 1.13s`
