### PR TITLE
chore: finalize issue #18 env cleanup audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Optional DB overrides:
 - Runtime env toggles under `MON_NATIVE_*` are removed.
 - Use `MonitoringConfig` for runtime tuning (`advance.*`) and debug behavior (`debug`).
 - For benchmark scripts that expose it, use `--nvtx` to enable debug/NVTX (`MonitoringConfig.debug=True`).
+- Policy: new runtime behavior knobs must be added via config fields, not new environment variables.
 
 ### Args
 ```bash

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -62,7 +62,7 @@ LDFLAGS := $(TORCH_LIB_FLAGS) $(CUDA_LIB_FLAGS) $(TORCH_RPATH_FLAGS) $(CUDA_RPAT
 CLICKHOUSE_INCLUDE := $(abspath $(CURDIR)/../libs/clickhouse-cpp)
 CLICKHOUSE_LIB_DIR := $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/clickhouse)
 CLICKHOUSE_LIBS    := -lclickhouse-cpp-lib
-CLICKHOUSE_CONTRIB  ?= $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/contrib)
+CLICKHOUSE_CONTRIB := $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/contrib)
 
 ifneq ($(CLICKHOUSE_INCLUDE),)
 CXXFLAGS += -I$(CLICKHOUSE_INCLUDE) -I$(CLICKHOUSE_INCLUDE)/contrib/absl

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -49,9 +49,6 @@ ABI_FLAG := $(shell $(PYTHON) -c "import torch; print(f'-D_GLIBCXX_USE_CXX11_ABI
 # Pybind11 ABI flags
 PYBIND_FLAGS := $(shell $(PYTHON) -c "import pybind11; print(' '.join([f'-DPYBIND11_COMPILER_TYPE=\\\"{pybind11.get_compiler_type()}\\\"', f'-DPYBIND11_STDLIB=\\\"{pybind11.get_stdlib()}\\\"', f'-DPYBIND11_BUILD_ABI=\\\"{pybind11.get_build_abi()}\\\"']))" 2>/dev/null || echo "")
 
-# Note: MON_DEBUG is now checked at RUNTIME via std::getenv(), not at compile time
-# No need for compile-time -DMON_DEBUG flag
-
 CXXFLAGS := -std=c++17 -O3 -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable \
             -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=$(TARGET) \
             $(ABI_FLAG) $(PYBIND_FLAGS) \
@@ -61,10 +58,10 @@ LDFLAGS := $(TORCH_LIB_FLAGS) $(CUDA_LIB_FLAGS) $(TORCH_RPATH_FLAGS) $(CUDA_RPAT
            -lc10 -lc10_cuda -ltorch_cpu -ltorch_cuda -ltorch -ltorch_python -lcudart -lpthread
 
 
-# ---- ClickHouse C++ client (override if your lib name/path differs) ----
-CLICKHOUSE_INCLUDE ?= $(abspath $(CURDIR)/../libs/clickhouse-cpp)
-CLICKHOUSE_LIB_DIR  ?= $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/clickhouse)
-CLICKHOUSE_LIBS    ?= -lclickhouse-cpp-lib
+# ---- ClickHouse C++ client (fixed in-repo paths) ----
+CLICKHOUSE_INCLUDE := $(abspath $(CURDIR)/../libs/clickhouse-cpp)
+CLICKHOUSE_LIB_DIR := $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/clickhouse)
+CLICKHOUSE_LIBS    := -lclickhouse-cpp-lib
 CLICKHOUSE_CONTRIB  ?= $(abspath $(CURDIR)/../libs/clickhouse-cpp/build/contrib)
 
 ifneq ($(CLICKHOUSE_INCLUDE),)

--- a/monitoring/_native_engine.py
+++ b/monitoring/_native_engine.py
@@ -2,28 +2,18 @@
 
 from __future__ import annotations
 
-import importlib
 from pathlib import Path
-import os
 from typing import Any, Optional
 import importlib.util
 import glob
 
 import torch
 
-try:
-    from torch.utils.cpp_extension import load as load_extension
-except ImportError:  # pragma: no cover - torch without cpp extension support
-    load_extension = None  # type: ignore[assignment]
-
 _EXTENSION_NAME = "monitoring_native_backend"
 _EXTENSION_MODULE: Optional[Any] = None
 
 
 BASE_DIR = Path(__file__).resolve().parent
-REPO_ROOT = BASE_DIR.parent
-CLICKHOUSE_ROOT = (REPO_ROOT / "libs" / "clickhouse-cpp").resolve()
-CLICKHOUSE_LIB_DIR = (CLICKHOUSE_ROOT / "build" / "clickhouse").resolve()
 
 
 _NATIVE_EXPORTS = (
@@ -44,16 +34,13 @@ def _load_extension() -> Any:
     if _EXTENSION_MODULE is not None:
         return _EXTENSION_MODULE
 
-    force_build = bool(int(os.environ.get("MON_NATIVE_FORCE_BUILD", "0")))
-
-    # 1) Prefer a locally built .so in this repo to avoid importing a stale
-    #    system-wide module with the same name.
+    # JIT build is intentionally disabled for reproducibility/stability.
+    # Only load an already-built extension from this repository tree.
     pkg_dir = Path(__file__).resolve().parent
     repo_root = pkg_dir.parent
-    candidates = [] if force_build else []
-    if not force_build:
-        candidates.extend(glob.glob(str(pkg_dir / f"{_EXTENSION_NAME}*.so")))
-        candidates.extend(glob.glob(str(repo_root / f"{_EXTENSION_NAME}*.so")))
+    candidates = []
+    candidates.extend(glob.glob(str(pkg_dir / f"{_EXTENSION_NAME}*.so")))
+    candidates.extend(glob.glob(str(repo_root / f"{_EXTENSION_NAME}*.so")))
 
     for so_path in candidates:
         try:
@@ -64,60 +51,13 @@ def _load_extension() -> Any:
                 _EXTENSION_MODULE = module
                 return _EXTENSION_MODULE
         except Exception:
-            # Fall back to next strategy
+            # Continue searching other local candidates.
             pass
 
-    # 2) Try to import an installed module by name (may be stale).
-    if not force_build:
-        try:
-            _EXTENSION_MODULE = importlib.import_module(_EXTENSION_NAME)
-            return _EXTENSION_MODULE
-        except ImportError:
-            pass
-
-    if load_extension is None:
-        raise ImportError("torch.utils.cpp_extension is not available")
-
-    source_dir = Path(__file__).resolve().parent / "csrc"
-
-    use_unified = bool(int(os.environ.get("MON_NATIVE_UNIFIED", "0")))
-    if use_unified:
-        unified = source_dir / "unified.cpp"
-        if not unified.exists():
-            raise ImportError("unified.cpp not found in csrc")
-        sources = [str(unified)]
-    else:
-        sources = sorted(str(p) for p in source_dir.glob("*.cpp") if p.name != "unified.cpp")
-        if not sources:
-            raise ImportError("native engine source files not found")
-
-    extra_cflags = ["-O3"]
-    extra_cuda_cflags = ["-O3"]
-    extra_ldflags = []
-    if bool(int(os.environ.get("MON_NATIVE_LTO", "0"))):
-        extra_cflags.append("-flto")
-        extra_ldflags.append("-flto")
-
-
-    # ---- ClickHouse C++ client (fixed in-repo paths) ----
-    extra_cflags.append(f"-I{CLICKHOUSE_ROOT}")
-    extra_cuda_cflags.append(f"-I{CLICKHOUSE_ROOT}")
-    extra_ldflags.extend([f"-L{CLICKHOUSE_LIB_DIR}", f"-Wl,-rpath,{CLICKHOUSE_LIB_DIR}"])
-    extra_ldflags.append("-lclickhouse-cpp-lib")
-
-    try:
-        _EXTENSION_MODULE = load_extension(
-            name=_EXTENSION_NAME,
-            sources=sources,
-            extra_cflags=extra_cflags,
-            extra_cuda_cflags=extra_cuda_cflags,
-            verbose=False,
-            extra_ldflags=extra_ldflags,
-        )
-    except (RuntimeError, OSError) as exc:  # pragma: no cover - compile failure path
-        raise ImportError("failed to build monitoring native backend") from exc
-
-    return _EXTENSION_MODULE
+    raise ImportError(
+        "monitoring native backend .so not found in repository. "
+        "Build it first with `make -C monitoring`."
+    )
 
 
 def create_engine(

--- a/monitoring/_native_engine.py
+++ b/monitoring/_native_engine.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 import os
-import shlex
 from typing import Any, Optional
 import importlib.util
 import glob
@@ -22,13 +21,9 @@ _EXTENSION_MODULE: Optional[Any] = None
 
 
 BASE_DIR = Path(__file__).resolve().parent
-
-def get_env_path(var_name, relative_path_str):
-    val = os.environ.get(var_name)
-    if val is None:
-        # Join the file's dir with the relative path and make it absolute
-        return str((BASE_DIR / relative_path_str).resolve())
-    return val
+REPO_ROOT = BASE_DIR.parent
+CLICKHOUSE_ROOT = (REPO_ROOT / "libs" / "clickhouse-cpp").resolve()
+CLICKHOUSE_LIB_DIR = (CLICKHOUSE_ROOT / "build" / "clickhouse").resolve()
 
 
 _NATIVE_EXPORTS = (
@@ -104,22 +99,11 @@ def _load_extension() -> Any:
         extra_ldflags.append("-flto")
 
 
-    # ---- ClickHouse C++ client (matches Makefile env knobs) ----
-    # CLICKHOUSE_INCLUDE: path to headers (e.g. /usr/local/include)
-    # CLICKHOUSE_LIB_DIR: path to libs    (e.g. /usr/local/lib)
-    # CLICKHOUSE_LIBS:    link flags      (default: -lclickhouse-cpp-lib)
-    ch_include = get_env_path("CLICKHOUSE_INCLUDE", "../libs/clickhouse-cpp")
-    if ch_include:
-        extra_cflags.append(f"-I{ch_include}")
-        extra_cuda_cflags.append(f"-I{ch_include}")
-
-    ch_lib_dir = get_env_path("CLICKHOUSE_LIB_DIR", "../libs/clickhouse-cpp/build/clickhouse")
-    if ch_lib_dir:
-        extra_ldflags.extend([f"-L{ch_lib_dir}", f"-Wl,-rpath,{ch_lib_dir}"])
-
-    ch_libs = os.environ.get("CLICKHOUSE_LIBS", "-lclickhouse-cpp-lib").strip()
-    if ch_libs:
-        extra_ldflags.extend(shlex.split(ch_libs))
+    # ---- ClickHouse C++ client (fixed in-repo paths) ----
+    extra_cflags.append(f"-I{CLICKHOUSE_ROOT}")
+    extra_cuda_cflags.append(f"-I{CLICKHOUSE_ROOT}")
+    extra_ldflags.extend([f"-L{CLICKHOUSE_LIB_DIR}", f"-Wl,-rpath,{CLICKHOUSE_LIB_DIR}"])
+    extra_ldflags.append("-lclickhouse-cpp-lib")
 
     try:
         _EXTENSION_MODULE = load_extension(


### PR DESCRIPTION
## Summary
This PR finalizes the remaining cleanup for issue #18 after #24:
- remove remaining build-time `MON_NATIVE_*` env entry points from runtime loader
- disable runtime JIT extension build path (load prebuilt `.so` only)
- fix ClickHouse build paths to stable in-repo paths
- add explicit runtime knob policy to README

## Acceptance Criteria Audit
- [x] All `MON_NATIVE_*` runtime vars removed and replaced by config fields
- [x] All debug/stats env vars removed; replaced by a single debug config flag
- [x] Zero `os.getenv("MON_NATIVE_")` / `getenv("MON_NATIVE_")` in runtime code
- [x] Dead code paths removed together with their env var reads
- [x] Policy documented: new knobs go through config, not new env vars

## Notes
- Native loader now fails fast with a clear message if `.so` is missing: build via `make -C monitoring`.

Part of #18
