### PR TITLE
Clean up repo path and user info leaks

### DIFF
--- a/Quick_Start.ipynb
+++ b/Quick_Start.ipynb
@@ -20,7 +20,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/nengneng/miniconda3/envs/proj-dmx/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "<python-site-packages>/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }

--- a/benchmark/clean_clickhouse.sh
+++ b/benchmark/clean_clickhouse.sh
@@ -9,17 +9,38 @@ if [ -z "${CLICKHOUSE_DATA_DIR}" ]; then
     exit 1
 fi
 
-if [ ! -d "${CLICKHOUSE_DATA_DIR}" ]; then
-    echo "ERROR: CLICKHOUSE_DATA_DIR does not exist or is not a directory: ${CLICKHOUSE_DATA_DIR}"
-    exit 1
-fi
-
 case "${CLICKHOUSE_DATA_DIR}" in
-    ""|"/")
+    "."|"..")
         echo "ERROR: refusing to operate on unsafe CLICKHOUSE_DATA_DIR=${CLICKHOUSE_DATA_DIR}"
         exit 1
         ;;
 esac
+
+RESOLVED_CLICKHOUSE_DATA_DIR="$(realpath "${CLICKHOUSE_DATA_DIR}" 2>/dev/null || true)"
+if [ -z "${RESOLVED_CLICKHOUSE_DATA_DIR}" ]; then
+    echo "ERROR: unable to resolve CLICKHOUSE_DATA_DIR to an absolute path: ${CLICKHOUSE_DATA_DIR}"
+    exit 1
+fi
+
+case "${RESOLVED_CLICKHOUSE_DATA_DIR}" in
+    ""|"/"|"."|"..")
+        echo "ERROR: refusing to operate on unsafe CLICKHOUSE_DATA_DIR=${RESOLVED_CLICKHOUSE_DATA_DIR}"
+        exit 1
+        ;;
+    /*)
+        ;;
+    *)
+        echo "ERROR: CLICKHOUSE_DATA_DIR must resolve to an absolute path: ${RESOLVED_CLICKHOUSE_DATA_DIR}"
+        exit 1
+        ;;
+esac
+
+CLICKHOUSE_DATA_DIR="${RESOLVED_CLICKHOUSE_DATA_DIR}"
+
+if [ ! -d "${CLICKHOUSE_DATA_DIR}" ]; then
+    echo "ERROR: CLICKHOUSE_DATA_DIR does not exist or is not a directory: ${CLICKHOUSE_DATA_DIR}"
+    exit 1
+fi
 
 echo "=== Stopping ClickHouse ==="
 sudo systemctl stop clickhouse-server

--- a/benchmark/clean_clickhouse.sh
+++ b/benchmark/clean_clickhouse.sh
@@ -9,6 +9,18 @@ if [ -z "${CLICKHOUSE_DATA_DIR}" ]; then
     exit 1
 fi
 
+if [ ! -d "${CLICKHOUSE_DATA_DIR}" ]; then
+    echo "ERROR: CLICKHOUSE_DATA_DIR does not exist or is not a directory: ${CLICKHOUSE_DATA_DIR}"
+    exit 1
+fi
+
+case "${CLICKHOUSE_DATA_DIR}" in
+    ""|"/")
+        echo "ERROR: refusing to operate on unsafe CLICKHOUSE_DATA_DIR=${CLICKHOUSE_DATA_DIR}"
+        exit 1
+        ;;
+esac
+
 echo "=== Stopping ClickHouse ==="
 sudo systemctl stop clickhouse-server
 sleep 2

--- a/benchmark/clean_clickhouse.sh
+++ b/benchmark/clean_clickhouse.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 set -e
 
+CLICKHOUSE_DATA_DIR="${CLICKHOUSE_DATA_DIR:-$(clickhouse extract-from-config --key=path 2>/dev/null || true)}"
+
+if [ -z "${CLICKHOUSE_DATA_DIR}" ]; then
+    echo "ERROR: unable to detect ClickHouse data dir automatically."
+    echo "Set CLICKHOUSE_DATA_DIR to your ClickHouse data directory and retry."
+    exit 1
+fi
+
 echo "=== Stopping ClickHouse ==="
 sudo systemctl stop clickhouse-server
 sleep 2
 
-echo "=== Clearing /var/lib/clickhouse/ ==="
-sudo rm -rf /var/lib/clickhouse/*
+echo "=== Clearing ${CLICKHOUSE_DATA_DIR}/ ==="
+sudo rm -rf "${CLICKHOUSE_DATA_DIR}"/*
 
 echo "=== Verifying ==="
-if [ -z "$(ls -A /var/lib/clickhouse/)" ]; then
+if [ -z "$(ls -A "${CLICKHOUSE_DATA_DIR}/")" ]; then
     echo "Data directory is clean."
 else
     echo "WARNING: directory not empty!"
-    ls -la /var/lib/clickhouse/
+    ls -la "${CLICKHOUSE_DATA_DIR}/"
 fi
 
 echo "=== Restarting ClickHouse ==="

--- a/benchmark/plot_memory_trends.ipynb
+++ b/benchmark/plot_memory_trends.ipynb
@@ -37,7 +37,7 @@
         {
           "data": {
             "text/plain": [
-              "PosixPath('/home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results')"
+              "PosixPath('benchmark/results')"
             ]
           },
           "execution_count": 139,
@@ -76,11 +76,11 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "HF GPU CSV: /home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results/gpu_mem_hf_20260128_191929.csv\n",
-            "HF CPU CSV: /home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results/cpu_mem_hf_20260128_191929.csv\n",
-            "Monitoring GPU CSV: /home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results/gpu_mem_monitoring_20260128_191929.csv\n",
-            "Monitoring CPU CSV: /home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results/cpu_mem_monitoring_20260128_191929.csv\n",
-            "Summary: /home/nengneng/AIPrometheus/HF_Prometheus/benchmark/results/summary_20260128_191929.json\n"
+            "HF GPU CSV: benchmark/results/gpu_mem_hf_20260128_191929.csv\n",
+            "HF CPU CSV: benchmark/results/cpu_mem_hf_20260128_191929.csv\n",
+            "Monitoring GPU CSV: benchmark/results/gpu_mem_monitoring_20260128_191929.csv\n",
+            "Monitoring CPU CSV: benchmark/results/cpu_mem_monitoring_20260128_191929.csv\n",
+            "Summary: benchmark/results/summary_20260128_191929.json\n"
           ]
         }
       ],

--- a/benchmark/tests/analyze_overhead_scaling.py
+++ b/benchmark/tests/analyze_overhead_scaling.py
@@ -1,5 +1,6 @@
 """Analyze how overhead scales with tensor size for precision reduction vs quantization."""
 
+from pathlib import Path
 import torch
 import time
 import matplotlib
@@ -350,7 +351,9 @@ def benchmark_scaling():
     ax.grid(True, alpha=0.3)
 
     plt.tight_layout()
-    plot_path = '/home/nengneng/AIPrometheus/HF_Prometheus/results/overhead_scaling_analysis.png'
+    results_dir = Path(__file__).resolve().parents[2] / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    plot_path = results_dir / "overhead_scaling_analysis.png"
     plt.savefig(plot_path, dpi=150, bbox_inches='tight')
     print(f"\n✅ Plots saved to: {plot_path}")
 

--- a/docs/backup/benchmark/tests/PROFILE_USAGE.md
+++ b/docs/backup/benchmark/tests/PROFILE_USAGE.md
@@ -73,7 +73,7 @@ Timing results (decode duration per run):
 ...
 
 Profiler traces written under:
-  /home/user/HF_Prometheus/results/my_profile_run
+  results/my_profile_run
 ```
 
 ⚠️ Note: The wallclock times include profiler overhead and are **NOT** comparable to `--no-profile` runs.

--- a/docs/dev_log/12_30_2025review.md
+++ b/docs/dev_log/12_30_2025review.md
@@ -1,7 +1,7 @@
 # proj-dmx 12-30-2025 restart review
 
 **日期**: 2025-12-30
-**评估人**: NengnengYu
+**评估人**: 项目维护者
 **评估范围**: 当前进度
 
 ---
@@ -738,5 +738,4 @@ sampling:
 验证：当前performance
 
 - 调研STRAPLLM,运行benchmark,对比性能,对比实现
-
 

--- a/experiments/offline_inference/archived/retry_nnsight_llama.sbatch
+++ b/experiments/offline_inference/archived/retry_nnsight_llama.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -44,7 +49,7 @@ SAMPLE_FILE_SHAREGPT="../../benchmark/data/offline_e2e/sharegpt_500_sample1.json
 RING_STEP_MB=5120
 RING_MIN_MB=5120
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/retry_nnsight_llama.sbatch
+++ b/experiments/offline_inference/archived/retry_nnsight_llama.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -44,7 +44,9 @@ SAMPLE_FILE_SHAREGPT="../../benchmark/data/offline_e2e/sharegpt_500_sample1.json
 RING_STEP_MB=5120
 RING_MIN_MB=5120
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -55,7 +57,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/retry_nnsight_qwen14b.sbatch
+++ b/experiments/offline_inference/archived/retry_nnsight_qwen14b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -52,7 +52,9 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -63,7 +65,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/retry_nnsight_qwen14b.sbatch
+++ b/experiments/offline_inference/archived/retry_nnsight_qwen14b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -52,7 +57,7 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/retry_proj_dmi_hs_logits.sbatch
+++ b/experiments/offline_inference/archived/retry_proj_dmi_hs_logits.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -56,7 +56,9 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -67,7 +69,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/retry_proj_dmi_hs_logits.sbatch
+++ b/experiments/offline_inference/archived/retry_proj_dmi_hs_logits.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -56,7 +61,7 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/retry_proj_dmi_internal_hooks.sbatch
+++ b/experiments/offline_inference/archived/retry_proj_dmi_internal_hooks.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -58,7 +58,9 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -69,7 +71,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/retry_proj_dmi_internal_hooks.sbatch
+++ b/experiments/offline_inference/archived/retry_proj_dmi_internal_hooks.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -58,7 +63,7 @@ LOG_DIR="${RESULTS_DIR}/logs"
 SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${LOG_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_baselines.sbatch
+++ b/experiments/offline_inference/archived/run_baselines.sbatch
@@ -9,7 +9,7 @@
 
 set -eo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -53,7 +53,9 @@ CAPTURE_MODE="hs"
 HOOK_LABEL="capture_${CAPTURE_MODE}"
 
 # ---- 拷贝模型到本地 NVMe /tmp 加速加载 ----
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -62,7 +64,7 @@ SRC_HUB="${SCRATCH}/hf_cache/hub"
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
 
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"

--- a/experiments/offline_inference/archived/run_baselines.sbatch
+++ b/experiments/offline_inference/archived/run_baselines.sbatch
@@ -9,7 +9,12 @@
 
 set -eo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -53,7 +58,7 @@ CAPTURE_MODE="hs"
 HOOK_LABEL="capture_${CAPTURE_MODE}"
 
 # ---- 拷贝模型到本地 NVMe /tmp 加速加载 ----
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +66,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +61,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -72,7 +74,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_full_sweep_hs_logits.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_hs_logits.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +66,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep_hs_logits.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_hs_logits.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +61,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -72,7 +74,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_full_sweep_hs_logits_llama31_8b.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_hs_logits_llama31_8b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +66,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep_hs_logits_llama31_8b.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_hs_logits_llama31_8b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -61,7 +61,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -72,7 +74,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_full_sweep_internal_hooks.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_internal_hooks.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -63,7 +68,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep_internal_hooks.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_internal_hooks.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -63,7 +63,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -74,7 +76,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_full_sweep_internal_hooks_llama31_8b.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_internal_hooks_llama31_8b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -63,7 +68,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_full_sweep_internal_hooks_llama31_8b.sbatch
+++ b/experiments/offline_inference/archived/run_full_sweep_internal_hooks_llama31_8b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -63,7 +63,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,capture_mode,hook_label,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -74,7 +76,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_hook_count_dmi_20g_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_hook_count_dmi_20g_qwen3_4b.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -83,7 +88,7 @@ HOOK_COUNTS=(1 73 145 253 325)
 
 echo "dataset,model,batch_size,hook_count,hook_selection,baseline,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_hook_count_dmi_20g_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_hook_count_dmi_20g_qwen3_4b.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -83,7 +83,9 @@ HOOK_COUNTS=(1 73 145 253 325)
 
 echo "dataset,model,batch_size,hook_count,hook_selection,baseline,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -94,7 +96,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_hook_count_sweep_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_hook_count_sweep_qwen3_4b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -84,7 +84,9 @@ BASELINES=("hf_native_compile" "torch_hooks_eager" "proj_dmi_compile")
 
 echo "dataset,model,batch_size,hook_count,hook_selection,baseline,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -95,7 +97,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_hook_count_sweep_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_hook_count_sweep_qwen3_4b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -84,7 +89,7 @@ BASELINES=("hf_native_compile" "torch_hooks_eager" "proj_dmi_compile")
 
 echo "dataset,model,batch_size,hook_count,hook_selection,baseline,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
@@ -83,7 +83,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-set -uo pipefail
+set -euo pipefail
 
-SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-SCRATCH=${SCRATCH:-/scratch/zt1/project/zaoxing-prj/user/ynn1999}
+SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 
@@ -83,7 +83,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
@@ -83,7 +83,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-set -uo pipefail
+set -euo pipefail
 
-SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-SCRATCH=${SCRATCH:-/scratch/zt1/project/zaoxing-prj/user/ynn1999}
+SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 
@@ -83,7 +83,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sbatch
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
@@ -77,7 +77,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-set -uo pipefail
+set -euo pipefail
 
-SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 

--- a/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
+++ b/experiments/offline_inference/archived/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-SCRATCH=${SCRATCH:-/scratch/zt1/project/zaoxing-prj/user/ynn1999}
+SCRATCH=${SCRATCH:-YOUR_SCRATCH_PATH}
 ENV_DIR=${ENV_DIR:-${SCRATCH}/proj-dmx}
 PROJECT=${PROJECT:-${SCRATCH}/DMI/DMI}
 
@@ -77,7 +77,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}" "${ATTEMPT_DIR}"
 echo "baseline,ring_mb,max_batch_size,last_ok_bs,first_fail_bs,target_tok_s,compute_tok_s,prompts_s,total_seconds,search_total_seconds,search_log_file,search_json" > "${SUMMARY_CSV}"
 echo "baseline,ring_mb,batch_size,status,target_tok_s,compute_tok_s,prompts_s,total_seconds,log_file,json_file" > "${ATTEMPTS_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID:-manual}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/archived/run_prefill_backpressure_dmi_ring_sweep_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_prefill_backpressure_dmi_ring_sweep_qwen3_4b.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -59,7 +64,7 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,status,hook_label,ring_mb,results_json,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_prefill_backpressure_dmi_ring_sweep_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_prefill_backpressure_dmi_ring_sweep_qwen3_4b.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -59,7 +59,9 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,status,hook_label,ring_mb,results_json,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -70,7 +72,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_prefill_backpressure_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_prefill_backpressure_qwen3_4b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -59,7 +64,7 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,status,hook_label,results_json,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_prefill_backpressure_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_prefill_backpressure_qwen3_4b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -59,7 +59,9 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,status,hook_label,results_json,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -70,7 +72,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_step_breakdown_microbench_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_step_breakdown_microbench_qwen3_4b.sbatch
@@ -9,7 +9,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI
 
@@ -66,7 +66,9 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,batch_size,status,prefill_compute_ms,prefill_total_ms,decode_compute_ms,decode_total_ms,results_json,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/archived/run_step_breakdown_microbench_qwen3_4b.sbatch
+++ b/experiments/offline_inference/archived/run_step_breakdown_microbench_qwen3_4b.sbatch
@@ -9,7 +9,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI
 
@@ -66,7 +71,7 @@ SUMMARY_CSV="${RESULTS_DIR}/summary.csv"
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 echo "baseline,batch_size,status,prefill_compute_ms,prefill_total_ms,decode_compute_ms,decode_total_ms,results_json,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/run_tp_compile_sharegpt_qwen3_14b.sbatch
+++ b/experiments/offline_inference/archived/run_tp_compile_sharegpt_qwen3_14b.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -65,7 +65,9 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,tp_size,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -76,7 +78,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/archived/run_tp_compile_sharegpt_qwen3_14b.sbatch
+++ b/experiments/offline_inference/archived/run_tp_compile_sharegpt_qwen3_14b.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -65,7 +70,7 @@ mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
 echo "model,dataset,batch_size,baseline,tp_size,status,ring_mb,target_tok_s,compute_tok_s,log_file" > "${SUMMARY_CSV}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/archived/test_internal_hooks_smoke.sh
+++ b/experiments/offline_inference/archived/test_internal_hooks_smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 

--- a/experiments/offline_inference/archived/test_internal_hooks_smoke.sh
+++ b/experiments/offline_inference/archived/test_internal_hooks_smoke.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 

--- a/experiments/offline_inference/archived/test_llama31_8b_smoke.sh
+++ b/experiments/offline_inference/archived/test_llama31_8b_smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 

--- a/experiments/offline_inference/archived/test_llama31_8b_smoke.sh
+++ b/experiments/offline_inference/archived/test_llama31_8b_smoke.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 

--- a/experiments/offline_inference/microbenchmark_step_breakdown_qwen3_4b.sh
+++ b/experiments/offline_inference/microbenchmark_step_breakdown_qwen3_4b.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
 cd "${PROJECT_ROOT}"
 
-PYTHON_BIN="${PYTHON_BIN:-/home/nengneng/miniconda3/envs/proj-dmx/bin/python}"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || command -v python)}"
 GPU="${GPU:-1}"
 MODEL="${MODEL:-qwen3-4b}"
 RESULTS_ROOT="${RESULTS_ROOT:-experiments/offline_inference/results/step_breakdown_qwen3_4b_local}"

--- a/experiments/offline_inference/microbenchmark_storage_ablation_qwen3_4b.sh
+++ b/experiments/offline_inference/microbenchmark_storage_ablation_qwen3_4b.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
 cd "${PROJECT_ROOT}"
 
-PYTHON_BIN="${PYTHON_BIN:-/home/nengneng/miniconda3/envs/proj-dmx/bin/python}"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || command -v python)}"
 GPU="${GPU:-1}"
 MODEL="${MODEL:-qwen3-4b}"
 BATCH_SIZE="${BATCH_SIZE:-64}"

--- a/experiments/offline_inference/scripts/sample_chat_datasets.py
+++ b/experiments/offline_inference/scripts/sample_chat_datasets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import bisect
 import json
+import os
 import random
 from collections import defaultdict
 from pathlib import Path
@@ -15,17 +16,34 @@ from datasets import Dataset
 
 
 DEFAULT_OUT_DIR = Path("benchmark/data/offline_e2e")
-SHAREGPT_PATH = Path(
-    "/home/nengneng/.cache/huggingface/hub/"
-    "datasets--anon8231489123--ShareGPT_Vicuna_unfiltered/"
-    "snapshots/192ab2185289094fc556ec8ce5ce1e8e587154ca/"
-    "ShareGPT_V3_unfiltered_cleaned_split.json"
-)
-WILDCHAT_DIR = Path(
-    "/home/nengneng/.cache/huggingface/datasets/"
-    "allenai___wild_chat-1_m/default/0.0.0/7d6490e462285cf85d91eabea0f9a954fbddcd1f"
-)
 DEFAULT_SEEDS = [3407, 3408, 3409]
+
+
+def _default_hf_home() -> Path:
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home).expanduser()
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home).expanduser() / "huggingface"
+    return Path.home() / ".cache" / "huggingface"
+
+
+DEFAULT_HF_HOME = _default_hf_home()
+DEFAULT_SHAREGPT_PATH = (
+    DEFAULT_HF_HOME
+    / "hub"
+    / "datasets--anon8231489123--ShareGPT_Vicuna_unfiltered"
+    / "snapshots"
+    / "192ab2185289094fc556ec8ce5ce1e8e587154ca"
+    / "ShareGPT_V3_unfiltered_cleaned_split.json"
+)
+DEFAULT_WILDCHAT_DIR = Path(
+    os.environ.get(
+        "HF_DATASETS_CACHE",
+        str(DEFAULT_HF_HOME / "datasets"),
+    )
+).expanduser() / "allenai___wild_chat-1_m" / "default" / "0.0.0" / "7d6490e462285cf85d91eabea0f9a954fbddcd1f"
 
 
 def _canonical_text(messages: Iterable[Dict[str, str]]) -> str:
@@ -178,10 +196,10 @@ def _sample_sharegpt(raw_rows: List[Dict[str, object]], seeds: List[int], sample
     return out, total
 
 
-def _load_wildchat_shards():
-    shard_paths = sorted(WILDCHAT_DIR.glob("wild_chat-1_m-train-*.arrow"))
+def _load_wildchat_shards(wildchat_dir: Path):
+    shard_paths = sorted(wildchat_dir.glob("wild_chat-1_m-train-*.arrow"))
     if not shard_paths:
-        raise FileNotFoundError(f"no WildChat shards found under {WILDCHAT_DIR}")
+        raise FileNotFoundError(f"no WildChat shards found under {wildchat_dir}")
     shards = []
     prefix = [0]
     for path in shard_paths:
@@ -246,6 +264,16 @@ def _write_jsonl(path: Path, rows: List[Dict[str, object]]) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sample fixed chat benchmark datasets locally.")
     parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument(
+        "--sharegpt-path",
+        default=os.environ.get("SHAREGPT_PATH", str(DEFAULT_SHAREGPT_PATH)),
+        help="Path to ShareGPT_V3_unfiltered_cleaned_split.json.",
+    )
+    parser.add_argument(
+        "--wildchat-dir",
+        default=os.environ.get("WILDCHAT_DIR", str(DEFAULT_WILDCHAT_DIR)),
+        help="Directory containing wild_chat-1_m-train-*.arrow shards.",
+    )
     parser.add_argument("--sample-size", type=int, default=1000)
     parser.add_argument(
         "--seeds",
@@ -261,8 +289,10 @@ def main() -> None:
     enc = tiktoken.get_encoding("cl100k_base")
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    sharegpt_path = Path(args.sharegpt_path).expanduser()
+    wildchat_dir = Path(args.wildchat_dir).expanduser()
 
-    with open(SHAREGPT_PATH, "r", encoding="utf-8") as handle:
+    with open(sharegpt_path, "r", encoding="utf-8") as handle:
         sharegpt_raw = json.load(handle)
     sharegpt_samples, sharegpt_total = _sample_sharegpt(
         sharegpt_raw,
@@ -271,7 +301,7 @@ def main() -> None:
         enc=enc,
     )
 
-    wildchat_shards, wildchat_prefix = _load_wildchat_shards()
+    wildchat_shards, wildchat_prefix = _load_wildchat_shards(wildchat_dir)
     wildchat_samples, wildchat_total = _sample_wildchat(
         wildchat_shards,
         wildchat_prefix,

--- a/experiments/offline_inference/testing/test_hook_count_sweep_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_hook_count_sweep_qwen3_4b_smoke.sbatch
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -49,7 +54,7 @@ CAPTURE_MODE="hs_logits"
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/hook_count_smoke_qwen3_4b_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/testing/test_hook_count_sweep_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_hook_count_sweep_qwen3_4b_smoke.sbatch
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -49,7 +49,9 @@ CAPTURE_MODE="hs_logits"
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/hook_count_smoke_qwen3_4b_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"
@@ -60,7 +62,7 @@ trap 'if [ -n "${CLEANUP_DIR}" ] && [ -d "${CLEANUP_DIR}" ]; then echo "Cleaning
 verify_copy() {
     local src="$1"
     local dst="$2"
-    local log="/tmp/verify_${SLURM_JOB_ID}.log"
+    local log="${TMP_ROOT}/verify_${SLURM_JOB_ID}.log"
     if ! diff -qr --no-dereference "$src" "$dst" >"$log" 2>&1; then
         echo "ERROR: copy verification failed!"
         head -100 "$log" || true

--- a/experiments/offline_inference/testing/test_internal_hooks_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_internal_hooks_smoke.sbatch
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/test_internal_hooks_smoke.sh"

--- a/experiments/offline_inference/testing/test_internal_hooks_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_internal_hooks_smoke.sbatch
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/test_internal_hooks_smoke.sh"

--- a/experiments/offline_inference/testing/test_llama31_8b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_llama31_8b_smoke.sbatch
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/test_llama31_8b_smoke.sh"

--- a/experiments/offline_inference/testing/test_llama31_8b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_llama31_8b_smoke.sbatch
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 bash "${PROJECT}/experiments/offline_inference/test_llama31_8b_smoke.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_compile_dmi_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_compile_dmi_smoke.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_compile_dmi_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_compile_dmi_smoke.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_compile_dmi.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_dmi_eager_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_dmi_eager_smoke.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_dmi_eager_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_dmi_eager_smoke.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b_dmi_eager.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_smoke.sbatch
@@ -10,7 +10,12 @@
 
 set -uo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b.sh"

--- a/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_max_batch_hs_logits_qwen3_14b_smoke.sbatch
@@ -10,7 +10,7 @@
 
 set -uo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 PROJECT=${SCRATCH}/DMI/DMI
 
 SMOKE=1 bash "${PROJECT}/experiments/offline_inference/run_max_batch_hs_logits_qwen3_14b.sh"

--- a/experiments/offline_inference/testing/test_prefill_backpressure_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_prefill_backpressure_qwen3_4b_smoke.sbatch
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -48,7 +53,7 @@ RING_FLUSH=0.15
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/prefill_backpressure_smoke_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/offline_inference/testing/test_prefill_backpressure_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_prefill_backpressure_qwen3_4b_smoke.sbatch
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI/DMI
 
@@ -48,7 +48,9 @@ RING_FLUSH=0.15
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/prefill_backpressure_smoke_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_local.sh
+++ b/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_local.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
 cd "${PROJECT_ROOT}"
 
-PYTHON_BIN="${PYTHON_BIN:-/home/nengneng/miniconda3/envs/proj-dmx/bin/python}"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || command -v python)}"
 GPU="${GPU:-1}"
 MODEL="${MODEL:-qwen3-4b}"
 RESULTS_DIR="${RESULTS_DIR:-experiments/offline_inference/results/step_breakdown_qwen3_4b_local_smoke}"

--- a/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_smoke.sbatch
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRATCH=/scratch/zt1/project/zaoxing-prj/user/ynn1999
+SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI
 
@@ -57,7 +57,9 @@ HOOK_SELECTION="hidden-states,final_ln,logits"
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/step_breakdown_smoke_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-LOCAL_NVME_HF="/tmp/${USER}_hf_cache_${SLURM_JOB_ID}"
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+mkdir -p "${TMP_ROOT}"
+LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"
 CLEANUP_DIR="${LOCAL_NVME_HF}"
 mkdir -p "${LOCAL_NVME_HF}/hub"

--- a/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_smoke.sbatch
+++ b/experiments/offline_inference/testing/test_step_breakdown_microbench_qwen3_4b_smoke.sbatch
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-SCRATCH="${SCRATCH:-YOUR_SCRATCH_PATH}"
+SCRATCH="${SCRATCH:-}"
+if [ -z "${SCRATCH}" ] || [ "${SCRATCH}" = "YOUR_SCRATCH_PATH" ]; then
+    echo "ERROR: SCRATCH is not set to a valid scratch directory." >&2
+    echo "Please export SCRATCH=/path/to/your/scratch before running this script." >&2
+    exit 1
+fi
 ENV_DIR=${SCRATCH}/proj-dmx
 PROJECT=${SCRATCH}/DMI
 
@@ -57,7 +62,7 @@ HOOK_SELECTION="hidden-states,final_ln,logits"
 RESULTS_DIR="${PROJECT}/experiments/offline_inference/results/step_breakdown_smoke_$(date '+%Y%m%d_%H%M%S')_${SLURM_JOB_ID}"
 mkdir -p "${RESULTS_DIR}"
 
-TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+TMP_ROOT="${TMP_ROOT:-${TMPDIR:-/tmp}}"
 mkdir -p "${TMP_ROOT}"
 LOCAL_NVME_HF="${TMP_ROOT}/${USER}_hf_cache_${SLURM_JOB_ID}"
 LOCAL_HF="${LOCAL_NVME_HF}"

--- a/experiments/online_serving/envs/vllm_hook.requirements.txt
+++ b/experiments/online_serving/envs/vllm_hook.requirements.txt
@@ -128,7 +128,7 @@ opentelemetry-sdk==1.40.0
 opentelemetry-semantic-conventions==0.61b0
 opentelemetry-semantic-conventions-ai==0.4.15
 outlines_core==0.2.11
-packaging @ file:///home/task_176104874243446/conda-bld/packaging_1761049080023/work
+packaging==26.0
 pandas==3.0.1
 partial-json-parser==0.2.1.1.post7
 pillow==12.1.1

--- a/experiments/online_serving/script/sbatch/adapt_bl_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_llama8b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-llama8b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_bl_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_llama8b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-llama8b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_bl_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_qwen14b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-qwen14b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_bl_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_qwen14b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-qwen14b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_bl_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_qwen4b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-qwen4b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_bl_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_bl_qwen4b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/abl-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/abl-qwen4b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_llama8b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-llama8b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_llama8b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-llama8b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_qwen14b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-qwen14b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_qwen14b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-qwen14b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_qwen4b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-qwen4b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_dmi_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_dmi_qwen4b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/admi-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/admi-qwen4b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 ENV_PYTHON=$(pwd)/envs/vllm-h100/bin/python3.10
 SITE=$(pwd)/dmi-env/lib/python3.10/site-packages

--- a/experiments/online_serving/script/sbatch/adapt_hook_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_llama8b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-llama8b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/adapt_hook_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_llama8b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-llama8b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-llama8b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/adapt_hook_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_qwen14b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-qwen14b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/adapt_hook_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_qwen14b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-qwen14b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-qwen14b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/adapt_hook_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_qwen4b.sbatch
@@ -8,7 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-qwen4b-%j.err
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/adapt_hook_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/adapt_hook_qwen4b.sbatch
@@ -8,8 +8,8 @@
 #SBATCH --output=cur_sbatch_log/ahk-qwen4b-%j.out
 #SBATCH --error=cur_sbatch_log/ahk-qwen4b-%j.err
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 source vllm-hook-env/bin/activate
 export PYTHONPATH=$(pwd)/vllm-0.17.0:$PYTHONPATH

--- a/experiments/online_serving/script/sbatch/build_trtllm_engines.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_engines.sbatch
@@ -10,8 +10,8 @@
 
 set -eo pipefail
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 # LD_LIBRARY_PATH: MPI + nvidia libs, but use cublas13_only (no libcudart.so.13)
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia

--- a/experiments/online_serving/script/sbatch/build_trtllm_engines.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_engines.sbatch
@@ -10,7 +10,8 @@
 
 set -eo pipefail
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 # LD_LIBRARY_PATH: MPI + nvidia libs, but use cublas13_only (no libcudart.so.13)
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia

--- a/experiments/online_serving/script/sbatch/build_trtllm_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_llama8b.sbatch
@@ -10,7 +10,8 @@
 
 set -eo pipefail
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia
 NVIDIA_LIBS=$(find $NVIDIA_BASE -maxdepth 2 -name lib -type d ! -path "*/cu13/*" 2>/dev/null | paste -sd:)

--- a/experiments/online_serving/script/sbatch/build_trtllm_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_llama8b.sbatch
@@ -10,8 +10,8 @@
 
 set -eo pipefail
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia
 NVIDIA_LIBS=$(find $NVIDIA_BASE -maxdepth 2 -name lib -type d ! -path "*/cu13/*" 2>/dev/null | paste -sd:)

--- a/experiments/online_serving/script/sbatch/build_trtllm_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_qwen14b.sbatch
@@ -10,7 +10,8 @@
 
 set -eo pipefail
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia
 NVIDIA_LIBS=$(find $NVIDIA_BASE -maxdepth 2 -name lib -type d ! -path "*/cu13/*" 2>/dev/null | paste -sd:)

--- a/experiments/online_serving/script/sbatch/build_trtllm_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/build_trtllm_qwen14b.sbatch
@@ -10,8 +10,8 @@
 
 set -eo pipefail
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 
 NVIDIA_BASE=envs/trtllm/lib/python3.10/site-packages/nvidia
 NVIDIA_LIBS=$(find $NVIDIA_BASE -maxdepth 2 -name lib -type d ! -path "*/cu13/*" 2>/dev/null | paste -sd:)

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_llama8b.sbatch
@@ -9,8 +9,8 @@
 #SBATCH --error=d2h-serve-llama8b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_llama8b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_llama8b.sbatch
@@ -9,7 +9,8 @@
 #SBATCH --error=d2h-serve-llama8b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen14b.sbatch
@@ -9,7 +9,8 @@
 #SBATCH --error=d2h-serve-qwen14b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen14b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen14b.sbatch
@@ -9,8 +9,8 @@
 #SBATCH --error=d2h-serve-qwen14b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen4b.sbatch
@@ -9,8 +9,8 @@
 #SBATCH --error=d2h-serve-qwen4b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-WORK_ROOT=""
-cd ""
+WORK_ROOT="${WORK_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${WORK_ROOT}"
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen4b.sbatch
+++ b/experiments/online_serving/script/sbatch/run_trtllm_d2h_serve_qwen4b.sbatch
@@ -9,7 +9,8 @@
 #SBATCH --error=d2h-serve-qwen4b-%j.err
 #SBATCH --exclude=gpu-a6-2
 
-cd ~/scratch.zaoxing-prj
+WORK_ROOT=""
+cd ""
 MPIRUN=/cvmfs/hpcsw.umd.edu/spack-software/2023.11.20/linux-rhel8-x86_64/gcc-11.3.0/openmpi-4.1.5-h3d4fsbq2zpfqyhmle4c44k35mvpw2bp/bin/mpirun
 
 # ---------- Environment ----------

--- a/logs/test.out
+++ b/logs/test.out
@@ -1,6 +1,6 @@
 ============================= test session starts ==============================
 platform linux -- Python 3.10.18, pytest-8.4.2, pluggy-1.5.0
-rootdir: /home/nengneng/AIPrometheus/HF_Prometheus
+rootdir: <repo-root>
 plugins: typeguard-4.4.4, jaxtyping-0.3.3, anyio-4.11.0
 collected 2 items
 

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -106,7 +106,7 @@ endif
 endif
 
 # ---- CUDA kernel compilation (nvcc) ----------------------------------------
-NVCC    ?= /usr/local/cuda/bin/nvcc
+NVCC    ?= $(shell command -v nvcc 2>/dev/null || printf '%s' nvcc)
 SM_ARCH ?= native
 
 NVCCFLAGS := \

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -106,7 +106,7 @@ endif
 endif
 
 # ---- CUDA kernel compilation (nvcc) ----------------------------------------
-NVCC    ?= $(shell command -v nvcc 2>/dev/null || printf '%s' nvcc)
+NVCC    ?= /usr/local/cuda/bin/nvcc
 SM_ARCH ?= native
 
 NVCCFLAGS := \

--- a/monitoring/csrc/ring/drain_thread.cpp
+++ b/monitoring/csrc/ring/drain_thread.cpp
@@ -71,6 +71,19 @@ void DrainThread::force_flush_and_wait() {
     flush_done_cv_.wait(lk, [this] { return flush_done_; });
 }
 
+uint64_t DrainThread::force_flush_and_wait_timed() {
+    const auto start = std::chrono::steady_clock::now();
+    force_flush_and_wait();
+    const uint64_t wait_us = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - start).count());
+    {
+        std::lock_guard<std::mutex> lk(mgmt_mu_);
+        last_force_flush_wait_us_ = wait_us;
+    }
+    return wait_us;
+}
+
 // ---------------------------------------------------------------------------
 // Task queue interface for p2p thread
 // ---------------------------------------------------------------------------
@@ -127,6 +140,21 @@ uint64_t DrainThread::cpu_task_head() const {
 
 uint64_t DrainThread::cpu_task_tail_committed() const {
     return cpu_task_tail_;
+}
+
+FlushStats DrainThread::get_stats() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
+    FlushStats stats{};
+    stats.pending_entries = pending_entries_;
+    stats.pending_bytes = pending_bytes_;
+    stats.cpu_payload_head = cpu_payload_head_;
+    stats.cpu_payload_tail_committed = cpu_payload_tail_committed_;
+    stats.total_flushes = total_flushes_;
+    stats.last_flush_entries = last_flush_entries_;
+    stats.last_flush_bytes = last_flush_bytes_;
+    stats.last_flush_complete_monotonic_us = last_flush_complete_monotonic_us_;
+    stats.last_force_flush_wait_us = last_force_flush_wait_us_;
+    return stats;
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +214,12 @@ void DrainThread::do_full_flush() {
         {
             std::lock_guard<std::mutex> lk(mgmt_mu_);
             cpu_payload_tail_committed_ = cpu_payload_tail_;
+            total_flushes_ += 1;
+            last_flush_entries_ = flush_count;
+            last_flush_bytes_ = flush_bytes;
+            last_flush_complete_monotonic_us_ = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now().time_since_epoch()).count());
         }
         submit_to_p2p(flush_count, flush_bytes);
         {
@@ -268,6 +302,12 @@ void DrainThread::loop() {
             {
                 std::lock_guard<std::mutex> lk(mgmt_mu_);
                 cpu_payload_tail_committed_ = cpu_payload_tail_;
+                total_flushes_ += 1;
+                last_flush_entries_ = flush_count;
+                last_flush_bytes_ = flush_bytes;
+                last_flush_complete_monotonic_us_ = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::steady_clock::now().time_since_epoch()).count());
             }
 
             submit_to_p2p(flush_count, flush_bytes);

--- a/monitoring/csrc/ring/drain_thread.h
+++ b/monitoring/csrc/ring/drain_thread.h
@@ -28,6 +28,18 @@
 
 namespace ring {
 
+struct FlushStats {
+    uint64_t pending_entries{0};
+    uint64_t pending_bytes{0};
+    uint64_t cpu_payload_head{0};
+    uint64_t cpu_payload_tail_committed{0};
+    uint64_t total_flushes{0};
+    uint64_t last_flush_entries{0};
+    uint64_t last_flush_bytes{0};
+    uint64_t last_flush_complete_monotonic_us{0};
+    uint64_t last_force_flush_wait_us{0};
+};
+
 class DrainThread {
 public:
     DrainThread(RingState& rs, PinnedStaging& staging, const RingConfig& cfg);
@@ -45,6 +57,7 @@ public:
     // until it finishes.  Caller must have done cudaStreamSynchronize on
     // the main stream first so all GPU writes are visible.
     void force_flush_and_wait();
+    uint64_t force_flush_and_wait_timed();
 
     // Submit a CPU-direct tensor to drain -> p2p pipeline.
     // The tensor is already in pageable CPU memory; skips D2H and staging.
@@ -64,6 +77,7 @@ public:
     uint64_t cpu_payload_tail_committed() const;
     uint64_t cpu_task_head() const;
     uint64_t cpu_task_tail_committed() const;
+    FlushStats get_stats() const;
 
     // Pre-allocate ring space for the next step's producer kernels.
     // Advances cpu_payload_head_ and cpu_task_head_ under mgmt_mu_.
@@ -83,7 +97,7 @@ private:
     bool                    notified_{false};
 
     // ---- mgmt_mu_ protects all state below this line ----
-    std::mutex              mgmt_mu_;
+    mutable std::mutex      mgmt_mu_;
 
     uint64_t                visible_head_{0};
     uint64_t                pending_entries_{0};
@@ -98,6 +112,11 @@ private:
 
     std::chrono::steady_clock::time_point first_complete_time_{};
     bool                    has_complete_time_{false};
+    uint64_t                total_flushes_{0};
+    uint64_t                last_flush_entries_{0};
+    uint64_t                last_flush_bytes_{0};
+    uint64_t                last_flush_complete_monotonic_us_{0};
+    uint64_t                last_force_flush_wait_us_{0};
     // ---- end mgmt_mu_ protected state ----
 
     // Force-flush signalling (Python thread -> drain thread)

--- a/tests/hf_comparator.py
+++ b/tests/hf_comparator.py
@@ -5,9 +5,9 @@ No CUDA needed — runs entirely on CPU.
 
 Usage:
     python -m tests.hf_comparator \
-        --ref-dir /tmp/hf_ref \
-        --mon-dir /tmp/hf_mon \
-        --result-file /tmp/hf_result.json
+        --ref-dir ./tmp/hf_ref \
+        --mon-dir ./tmp/hf_mon \
+        --result-file ./tmp/hf_result.json
 """
 import argparse
 import json

--- a/tests/hf_monitored_runner.py
+++ b/tests/hf_monitored_runner.py
@@ -3,7 +3,7 @@
 Activations go to ClickHouse. Saves model_id to disk for the comparator.
 
 Usage:
-    python -m tests.hf_monitored_runner --output-dir /tmp/hf_mon
+    python -m tests.hf_monitored_runner --output-dir ./tmp/hf_mon
 """
 import argparse
 import json

--- a/tests/hf_reference_runner.py
+++ b/tests/hf_reference_runner.py
@@ -6,7 +6,7 @@ _HFRef objects without loading a model.
 Accepts the same env vars as test_e2e_correctness_vs_hf.py for parity.
 
 Usage:
-    python tests/hf_reference_runner.py --output-dir /tmp/hf_ref
+    python tests/hf_reference_runner.py --output-dir ./tmp/hf_ref
 """
 import argparse
 import os

--- a/tests/identical_vllm.sh
+++ b/tests/identical_vllm.sh
@@ -22,6 +22,8 @@ export TORCHINDUCTOR_CACHE_ROOT
 
 safe_clear_dir() {
     local dir_path=$1
+    local resolved_tmp_root
+    local resolved_dir_path
 
     case "${dir_path}" in
         ""|"/")
@@ -30,12 +32,26 @@ safe_clear_dir() {
             ;;
     esac
 
-    case "${dir_path}" in
-        "${TMP_ROOT}"|"${TMP_ROOT}"/*)
-            rm -rf "${dir_path}" 2>/dev/null
+    resolved_tmp_root="$(realpath "${TMP_ROOT}" 2>/dev/null || true)"
+    resolved_dir_path="$(realpath -m "${dir_path}" 2>/dev/null || true)"
+    if [ -z "${resolved_tmp_root}" ] || [ -z "${resolved_dir_path}" ]; then
+        echo "ERROR: unable to resolve safe delete paths under TMP_ROOT." >&2
+        exit 1
+    fi
+
+    case "${resolved_tmp_root}" in
+        ""|"/"|"."|"..")
+            echo "ERROR: refusing to use unsafe TMP_ROOT=${resolved_tmp_root}" >&2
+            exit 1
+            ;;
+    esac
+
+    case "${resolved_dir_path}" in
+        "${resolved_tmp_root}"|"${resolved_tmp_root}"/*)
+            rm -rf "${resolved_dir_path}" 2>/dev/null
             ;;
         *)
-            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${dir_path}" >&2
+            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${resolved_dir_path}" >&2
             exit 1
             ;;
     esac

--- a/tests/identical_vllm.sh
+++ b/tests/identical_vllm.sh
@@ -15,6 +15,9 @@
 set -e
 
 export VLLM_DISABLE_COMPILE_CACHE=1
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+RUN_USER="${USER:-$(id -un 2>/dev/null || printf '%s' user)}"
+TORCHINDUCTOR_CACHE_ROOT="${TORCHINDUCTOR_CACHE_ROOT:-${TMP_ROOT}/torchinductor_${RUN_USER}}"
 
 run_identical_test() {
     local model_name=$1
@@ -28,7 +31,8 @@ run_identical_test() {
     fi
 
     echo "=== $model_name identical check ($mode_name) ring=${ring_mb}MB ==="
-    rm -rf /tmp/torchinductor_$(whoami)/ 2>/dev/null
+    mkdir -p "${TMP_ROOT}"
+    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \

--- a/tests/identical_vllm.sh
+++ b/tests/identical_vllm.sh
@@ -18,6 +18,28 @@ export VLLM_DISABLE_COMPILE_CACHE=1
 TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
 RUN_USER="${USER:-$(id -un 2>/dev/null || printf '%s' user)}"
 TORCHINDUCTOR_CACHE_ROOT="${TORCHINDUCTOR_CACHE_ROOT:-${TMP_ROOT}/torchinductor_${RUN_USER}}"
+export TORCHINDUCTOR_CACHE_ROOT
+
+safe_clear_dir() {
+    local dir_path=$1
+
+    case "${dir_path}" in
+        ""|"/")
+            echo "ERROR: refusing to delete unsafe directory: ${dir_path:-<empty>}" >&2
+            exit 1
+            ;;
+    esac
+
+    case "${dir_path}" in
+        "${TMP_ROOT}"|"${TMP_ROOT}"/*)
+            rm -rf "${dir_path}" 2>/dev/null
+            ;;
+        *)
+            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${dir_path}" >&2
+            exit 1
+            ;;
+    esac
+}
 
 run_identical_test() {
     local model_name=$1
@@ -32,7 +54,7 @@ run_identical_test() {
 
     echo "=== $model_name identical check ($mode_name) ring=${ring_mb}MB ==="
     mkdir -p "${TMP_ROOT}"
-    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
+    safe_clear_dir "${TORCHINDUCTOR_CACHE_ROOT}"
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \

--- a/tests/ring/Makefile
+++ b/tests/ring/Makefile
@@ -1,4 +1,4 @@
-NVCC     ?= /usr/local/cuda/bin/nvcc
+NVCC     ?= $(shell command -v nvcc 2>/dev/null || printf '%s' nvcc)
 SM_ARCH  ?= native
 CXX_STD  ?= c++17
 BUILD    := build

--- a/tests/ring/Makefile
+++ b/tests/ring/Makefile
@@ -1,4 +1,4 @@
-NVCC     ?= $(shell command -v nvcc 2>/dev/null || { [ -x /usr/local/cuda/bin/nvcc ] && printf '%s' /usr/local/cuda/bin/nvcc; } || printf '%s' nvcc)
+NVCC     ?= $(shell command -v nvcc 2>/dev/null || printf '%s' nvcc)
 SM_ARCH  ?= native
 CXX_STD  ?= c++17
 BUILD    := build

--- a/tests/ring/Makefile
+++ b/tests/ring/Makefile
@@ -1,4 +1,4 @@
-NVCC     ?= $(shell command -v nvcc 2>/dev/null || printf '%s' nvcc)
+NVCC     ?= $(shell command -v nvcc 2>/dev/null || { [ -x /usr/local/cuda/bin/nvcc ] && printf '%s' /usr/local/cuda/bin/nvcc; } || printf '%s' nvcc)
 SM_ARCH  ?= native
 CXX_STD  ?= c++17
 BUILD    := build

--- a/tests/verify_vllm.sh
+++ b/tests/verify_vllm.sh
@@ -24,6 +24,28 @@ export VLLM_DISABLE_COMPILE_CACHE=1
 TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
 RUN_USER="${USER:-$(id -un 2>/dev/null || printf '%s' user)}"
 TORCHINDUCTOR_CACHE_ROOT="${TORCHINDUCTOR_CACHE_ROOT:-${TMP_ROOT}/torchinductor_${RUN_USER}}"
+export TORCHINDUCTOR_CACHE_ROOT
+
+safe_clear_dir() {
+    local dir_path=$1
+
+    case "${dir_path}" in
+        ""|"/")
+            echo "ERROR: refusing to delete unsafe directory: ${dir_path:-<empty>}" >&2
+            exit 1
+            ;;
+    esac
+
+    case "${dir_path}" in
+        "${TMP_ROOT}"|"${TMP_ROOT}"/*)
+            rm -rf "${dir_path}" 2>/dev/null
+            ;;
+        *)
+            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${dir_path}" >&2
+            exit 1
+            ;;
+    esac
+}
 
 run_test() {
     local model_name=$1
@@ -35,7 +57,7 @@ run_test() {
 
     echo "=== $model_name $mode_name ring=${size_name} ==="
     mkdir -p "${TMP_ROOT}"
-    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
+    safe_clear_dir "${TORCHINDUCTOR_CACHE_ROOT}"
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \
@@ -82,7 +104,7 @@ run_identical_test() {
 
     echo "=== $model_name identical check ($mode_name) ring=${ring_mb}MB ==="
     mkdir -p "${TMP_ROOT}"
-    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
+    safe_clear_dir "${TORCHINDUCTOR_CACHE_ROOT}"
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \

--- a/tests/verify_vllm.sh
+++ b/tests/verify_vllm.sh
@@ -21,6 +21,9 @@
 set -e
 
 export VLLM_DISABLE_COMPILE_CACHE=1
+TMP_ROOT="${TMP_ROOT:-${PWD}/.tmp}"
+RUN_USER="${USER:-$(id -un 2>/dev/null || printf '%s' user)}"
+TORCHINDUCTOR_CACHE_ROOT="${TORCHINDUCTOR_CACHE_ROOT:-${TMP_ROOT}/torchinductor_${RUN_USER}}"
 
 run_test() {
     local model_name=$1
@@ -31,7 +34,8 @@ run_test() {
     local ring_mb=$6
 
     echo "=== $model_name $mode_name ring=${size_name} ==="
-    rm -rf /tmp/torchinductor_$(whoami)/ 2>/dev/null
+    mkdir -p "${TMP_ROOT}"
+    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \
@@ -77,7 +81,8 @@ run_identical_test() {
     fi
 
     echo "=== $model_name identical check ($mode_name) ring=${ring_mb}MB ==="
-    rm -rf /tmp/torchinductor_$(whoami)/ 2>/dev/null
+    mkdir -p "${TMP_ROOT}"
+    rm -rf "${TORCHINDUCTOR_CACHE_ROOT}" 2>/dev/null
     rm -rf ~/.cache/vllm/ 2>/dev/null
 
     E2E_MODEL=$model_key \

--- a/tests/verify_vllm.sh
+++ b/tests/verify_vllm.sh
@@ -28,6 +28,8 @@ export TORCHINDUCTOR_CACHE_ROOT
 
 safe_clear_dir() {
     local dir_path=$1
+    local resolved_tmp_root
+    local resolved_dir_path
 
     case "${dir_path}" in
         ""|"/")
@@ -36,12 +38,26 @@ safe_clear_dir() {
             ;;
     esac
 
-    case "${dir_path}" in
-        "${TMP_ROOT}"|"${TMP_ROOT}"/*)
-            rm -rf "${dir_path}" 2>/dev/null
+    resolved_tmp_root="$(realpath "${TMP_ROOT}" 2>/dev/null || true)"
+    resolved_dir_path="$(realpath -m "${dir_path}" 2>/dev/null || true)"
+    if [ -z "${resolved_tmp_root}" ] || [ -z "${resolved_dir_path}" ]; then
+        echo "ERROR: unable to resolve safe delete paths under TMP_ROOT." >&2
+        exit 1
+    fi
+
+    case "${resolved_tmp_root}" in
+        ""|"/"|"."|"..")
+            echo "ERROR: refusing to use unsafe TMP_ROOT=${resolved_tmp_root}" >&2
+            exit 1
+            ;;
+    esac
+
+    case "${resolved_dir_path}" in
+        "${resolved_tmp_root}"|"${resolved_tmp_root}"/*)
+            rm -rf "${resolved_dir_path}" 2>/dev/null
             ;;
         *)
-            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${dir_path}" >&2
+            echo "ERROR: refusing to delete directory outside TMP_ROOT: ${resolved_dir_path}" >&2
             exit 1
             ;;
     esac

--- a/tests/vllm_identical_comparator.py
+++ b/tests/vllm_identical_comparator.py
@@ -5,9 +5,9 @@ No CUDA needed — runs entirely on CPU.
 
 Usage:
     python -m tests.vllm_identical_comparator \
-        --ref-config /tmp/ref/ref_config.json \
-        --mon-dir /tmp/vllm_mon \
-        --result-file /tmp/result.json
+        --ref-config ./tmp/ref/ref_config.json \
+        --mon-dir ./tmp/vllm_mon \
+        --result-file ./tmp/result.json
 """
 import argparse
 import json

--- a/tests/vllm_logprob_runner.py
+++ b/tests/vllm_logprob_runner.py
@@ -5,8 +5,8 @@ Two modes:
   default: load original model (stock vLLM)
 
 Usage:
-    python -m tests.vllm_logprob_runner --output /tmp/logprobs_orig.pt
-    REF_CONFIG=/tmp/ref_config.json python -m tests.vllm_logprob_runner --output /tmp/logprobs_ref.pt --ref
+    python -m tests.vllm_logprob_runner --output ./tmp/logprobs_orig.pt
+    REF_CONFIG=./tmp/ref_config.json python -m tests.vllm_logprob_runner --output ./tmp/logprobs_ref.pt --ref
 """
 import argparse
 import os

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -3,7 +3,7 @@
 Activations go to ClickHouse. Saves metadata to disk for the comparator.
 
 Usage:
-    python -m tests.vllm_monitored_runner --output-dir /tmp/vllm_mon
+    python -m tests.vllm_monitored_runner --output-dir ./tmp/vllm_mon
 """
 import argparse
 import json

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -3,8 +3,8 @@
 Tensors saved to disk.  Exits cleanly so GPU is released.
 
 Usage:
-    REF_CONFIG=/tmp/ref/ref_config.json \
-    python -m tests.vllm_ref_runner --output-dir /tmp/ref
+    REF_CONFIG=./tmp/ref/ref_config.json \
+    python -m tests.vllm_ref_runner --output-dir ./tmp/ref
 """
 import argparse
 import json

--- a/tests/vllm_rowcnt_comparator.py
+++ b/tests/vllm_rowcnt_comparator.py
@@ -5,9 +5,9 @@ No CUDA needed — runs entirely on CPU.
 
 Usage:
     python -m tests.vllm_rowcnt_comparator \
-        --ref-dir /tmp/vllm_ref \
-        --mon-dir /tmp/vllm_mon \
-        --result-file /tmp/vllm_result.json
+        --ref-dir ./tmp/vllm_ref \
+        --mon-dir ./tmp/vllm_mon \
+        --result-file ./tmp/vllm_result.json
 """
 import argparse
 import json


### PR DESCRIPTION
## Summary
- remove hardcoded personal and machine-specific paths from tracked scripts and notebooks
- replace fixed environment and scratch paths with auto-detection, env vars, or portable placeholders
- clean up test and benchmark helpers to avoid user-specific local paths while keeping them usable

## Validation
- python -m py_compile benchmark/tests/analyze_overhead_scaling.py experiments/offline_inference/scripts/sample_chat_datasets.py tests/hf_comparator.py tests/hf_monitored_runner.py tests/hf_reference_runner.py tests/vllm_identical_comparator.py tests/vllm_logprob_runner.py tests/vllm_monitored_runner.py tests/vllm_ref_runner.py tests/vllm_rowcnt_comparator.py
- bash -n benchmark/clean_clickhouse.sh tests/identical_vllm.sh tests/verify_vllm.sh and the updated offline_inference archived/testing scripts
- git grep confirmed no remaining personal username or /home path leaks outside sample datasets and vendored integration content