### PR TITLE
Log DMI ClickHouse sink failures

### DIFF
--- a/monitoring/csrc/clickhouse_client.cpp
+++ b/monitoring/csrc/clickhouse_client.cpp
@@ -80,18 +80,18 @@ std::string QualifiedTableNameQuoted(const std::string& db, const std::string& t
 std::string ClickHouseInitRemediation(const ClickHouseClientConfig& cfg,
                                       const char* error) {
   const std::string err = error ? error : "";
+  const bool database_missing =
+      err.find("Database ") != std::string::npos
+      && err.find("does not exist") != std::string::npos;
   if (err.find("Database default does not exist") != std::string::npos) {
     return "Please create the ClickHouse database 'default' before starting DMI.";
   }
-  if (!cfg.create_database_if_missing) {
+  if (database_missing && !cfg.create_database_if_missing) {
     return "Please set create_database_if_missing=true, or create the configured "
            "ClickHouse database '" + cfg.database + "' manually before "
            "starting DMI.";
   }
-  if (
-      err.find("Database ") != std::string::npos
-      && err.find("does not exist") != std::string::npos
-  ) {
+  if (database_missing) {
     return "Please create the missing ClickHouse database manually, or verify the "
            "configured database name and permissions.";
   }
@@ -423,9 +423,11 @@ void ClickHouseInsertStage::ThreadInit(int /*thread_idx*/, const ClickHouseClien
     tl_client->Execute("USE " + QuoteIdent(cfg.database));
     ApplySessionSettings(*tl_client, cfg);
   } catch (const std::exception& e) {
+    tl_client.reset();
     LogClickHouseInitFailure(cfg, e.what());
     throw;
   } catch (...) {
+    tl_client.reset();
     LogClickHouseInitFailure(cfg, "unknown non-std exception");
     throw;
   }

--- a/monitoring/csrc/clickhouse_client.cpp
+++ b/monitoring/csrc/clickhouse_client.cpp
@@ -101,22 +101,25 @@ std::string ClickHouseInitRemediation(const ClickHouseClientConfig& cfg,
 
 void LogClickHouseInitFailure(const ClickHouseClientConfig& cfg,
                               const char* error) noexcept {
-  try {
-    const std::string remediation = ClickHouseInitRemediation(cfg, error);
-    std::cerr
-        << "[DMI][ClickHouse] ERROR: failed to initialize ClickHouse insert "
-           "stage. "
-        << remediation
-        << " host=" << cfg.host
-        << " port=" << cfg.port
-        << " database=" << cfg.database
-        << " table=" << cfg.table
-        << " create_database_if_missing="
-        << (cfg.create_database_if_missing ? "true" : "false")
-        << " error=\"" << (error ? error : "unknown") << "\""
-        << std::endl;
-  } catch (...) {
-  }
+  static std::once_flag log_once;
+  std::call_once(log_once, [&] {
+    try {
+      const std::string remediation = ClickHouseInitRemediation(cfg, error);
+      std::cerr
+          << "[DMI][ClickHouse] ERROR: failed to initialize ClickHouse insert "
+             "stage. "
+          << remediation
+          << " host=" << cfg.host
+          << " port=" << cfg.port
+          << " database=" << cfg.database
+          << " table=" << cfg.table
+          << " create_database_if_missing="
+          << (cfg.create_database_if_missing ? "true" : "false")
+          << " error=\"" << (error ? error : "unknown") << "\""
+          << std::endl;
+    } catch (...) {
+    }
+  });
 }
 
 // --------------------- clickhouse-cpp compat: compression ---------------------

--- a/monitoring/csrc/clickhouse_client.cpp
+++ b/monitoring/csrc/clickhouse_client.cpp
@@ -77,6 +77,48 @@ std::string QualifiedTableNameQuoted(const std::string& db, const std::string& t
   return QuoteIdent(db) + "." + QuoteIdent(table);
 }
 
+std::string ClickHouseInitRemediation(const ClickHouseClientConfig& cfg,
+                                      const char* error) {
+  const std::string err = error ? error : "";
+  if (err.find("Database default does not exist") != std::string::npos) {
+    return "Please create the ClickHouse database 'default' before starting DMI.";
+  }
+  if (!cfg.create_database_if_missing) {
+    return "Please set create_database_if_missing=true, or create the configured "
+           "ClickHouse database '" + cfg.database + "' manually before "
+           "starting DMI.";
+  }
+  if (
+      err.find("Database ") != std::string::npos
+      && err.find("does not exist") != std::string::npos
+  ) {
+    return "Please create the missing ClickHouse database manually, or verify the "
+           "configured database name and permissions.";
+  }
+  return "Please check ClickHouse connectivity, credentials, database/table "
+         "configuration, and server logs.";
+}
+
+void LogClickHouseInitFailure(const ClickHouseClientConfig& cfg,
+                              const char* error) noexcept {
+  try {
+    const std::string remediation = ClickHouseInitRemediation(cfg, error);
+    std::cerr
+        << "[DMI][ClickHouse] ERROR: failed to initialize ClickHouse insert "
+           "stage. "
+        << remediation
+        << " host=" << cfg.host
+        << " port=" << cfg.port
+        << " database=" << cfg.database
+        << " table=" << cfg.table
+        << " create_database_if_missing="
+        << (cfg.create_database_if_missing ? "true" : "false")
+        << " error=\"" << (error ? error : "unknown") << "\""
+        << std::endl;
+  } catch (...) {
+  }
+}
+
 // --------------------- clickhouse-cpp compat: compression ---------------------
 
 template <typename OptionsT>
@@ -370,15 +412,23 @@ void ClickHouseInsertStage::ThreadInit(int /*thread_idx*/, const ClickHouseClien
     }
   }
 
-  // DDL init once globally (copy cfg/opts into the call_once closure)
-  std::call_once(g_schema_once, [cfg, opts]() { RunSchemaInitOnce(cfg, opts); });
+  try {
+    // DDL init once globally (copy cfg/opts into the call_once closure)
+    std::call_once(g_schema_once, [cfg, opts]() { RunSchemaInitOnce(cfg, opts); });
 
-  // Per-thread client
-  tl_client = std::make_unique<clickhouse::Client>(opts);
-  tl_client->Ping();
+    // Per-thread client
+    tl_client = std::make_unique<clickhouse::Client>(opts);
+    tl_client->Ping();
 
-  tl_client->Execute("USE " + QuoteIdent(cfg.database));
-  ApplySessionSettings(*tl_client, cfg);
+    tl_client->Execute("USE " + QuoteIdent(cfg.database));
+    ApplySessionSettings(*tl_client, cfg);
+  } catch (const std::exception& e) {
+    LogClickHouseInitFailure(cfg, e.what());
+    throw;
+  } catch (...) {
+    LogClickHouseInitFailure(cfg, "unknown non-std exception");
+    throw;
+  }
 
   tl_inited = true;
 }

--- a/monitoring/csrc/ring/p2p_thread.cpp
+++ b/monitoring/csrc/ring/p2p_thread.cpp
@@ -6,13 +6,46 @@
 #include "pinned_staging.h"
 
 #include <ATen/ATen.h>
+#include <cstdio>
 #include <cstring>
+#include <exception>
+#include <mutex>
 
 namespace ring {
 
 // ---------------------------------------------------------------------------
 // ATen helpers (no GIL required for CPU tensors)
 // ---------------------------------------------------------------------------
+
+static std::once_flag g_submit_failure_log_once;
+
+static void log_submit_failure_once(
+    const std::string& model_id,
+    const std::string& req_id,
+    const std::string& act_name,
+    int32_t layer_no,
+    int32_t shard_rank,
+    int32_t start_token,
+    int32_t end_token,
+    const char* error)
+{
+    std::call_once(g_submit_failure_log_once, [&] {
+        fprintf(stderr,
+                "[DMI][P2P] WARN: failed to submit tensor slice to host "
+                "engine; suppressing further submit errors. model_id=%s "
+                "request_id=%s act_name=%s layer_no=%d shard_rank=%d "
+                "token_range=[%d,%d) error=\"%s\"\n",
+                model_id.c_str(),
+                req_id.c_str(),
+                act_name.c_str(),
+                layer_no,
+                shard_rank,
+                start_token,
+                end_token,
+                error ? error : "unknown");
+        fflush(stderr);
+    });
+}
 
 // Build ClickHouse act_name from hook_type.
 // Per-layer: "blocks.<hook_type_name>"  (e.g. "blocks.attn.hook_pattern")
@@ -278,7 +311,15 @@ void P2PThread::do_post_processing(at::Tensor& tensor, const DrainTask& first_ta
                        req.req_id, act_name, meta.layer_no,
                        db_start, db_end,
                        std::move(slice));
+        } catch (const std::exception& e) {
+            log_submit_failure_once(current_ctx_->model_id, req.req_id,
+                                    act_name, meta.layer_no, shard_rank,
+                                    db_start, db_end, e.what());
         } catch (...) {
+            log_submit_failure_once(current_ctx_->model_id, req.req_id,
+                                    act_name, meta.layer_no, shard_rank,
+                                    db_start, db_end,
+                                    "unknown non-std exception");
         }
     }
 


### PR DESCRIPTION
Summary:
- Log ClickHouse insert stage initialization failures with remediation guidance and connection details.
- Log the first P2P submit failure instead of silently suppressing host-engine submit exceptions.

Validation:
- git diff --check
- conda run --no-capture-output -n agent-dmi make -C HF_Prometheus/monitoring
- Manual missing-database smoke test confirmed the new ClickHouse init error log.