### PR TITLE
[Feature] get_internal: read captured internals back as HF-style tuples

### DIFF
--- a/docs/huggingface.md
+++ b/docs/huggingface.md
@@ -44,6 +44,7 @@ requirements = InternalRequirements().require(
     count=model.config.num_hidden_layers,
     retry=True,
     timeout_s=30.0,
+    match_token_ranges=True,
 )
 
 out = generate_with_monitoring_dict(
@@ -60,7 +61,9 @@ token_mask = out.dmi_internal.token_mask
 
 For layer-tuple fields such as `hidden_states`, `count` validates the number of
 layers in the reassembled tuple. It does not validate token completeness inside
-each layer tensor.
+each layer tensor unless `match_token_ranges=True` is set. That option checks
+the captured row ranges against the token ranges recorded during this generate
+call. For per-layer fields it uses a fast representative-layer check.
 
 Supported mapped fields are:
 
@@ -119,8 +122,9 @@ norm = hidden_states[0].float().norm(dim=-1)[token_mask].mean()
 
 If a tensor field and `token_mask` have different `[batch, seq]` shapes, it
 usually means the tensor field was read before all rows for that field arrived.
-Current requirements for layer-tuple fields validate layer count, not token
-count, so clear that field's cache and read it again:
+Use `match_token_ranges=True` with `retry=True` to wait for expected token
+ranges. If you already cached a partial field, clear that field's cache and read
+it again:
 
 ```python
 out.dmi_internal.clear_cache("hidden_states")
@@ -159,6 +163,7 @@ out.dmi_internal.require(
     retry=True,
     timeout_s=30.0,
     poll_s=0.25,
+    match_token_ranges=True,
 )
 hidden_states = out.dmi_internal.hidden_states
 ```

--- a/docs/huggingface.md
+++ b/docs/huggingface.md
@@ -42,6 +42,8 @@ from monitoring.internal_mapper import InternalRequirements
 requirements = InternalRequirements().require(
     "hidden_states",
     count=model.config.num_hidden_layers,
+    retry=True,
+    timeout_s=30.0,
 )
 
 out = generate_with_monitoring_dict(
@@ -59,12 +61,42 @@ Plain field access such as `out.dmi_internal.hidden_states` is lazy and
 field-cached. It reads the backing store on first successful access and then
 reuses the cached value. If ClickHouse is still receiving rows, plain access can
 cache a partial result. Use a requirement when you know the expected number of
-entries and want incomplete reads to fail explicitly.
+entries.
+
+By default, requirements are strict one-shot checks:
+
+```python
+out.dmi_internal.require("hidden_states", count=model.config.num_hidden_layers)
+hidden_states = out.dmi_internal.hidden_states
+```
+
+If the field is missing or incomplete, access raises immediately. To wait for
+asynchronous ClickHouse writes, opt into retry explicitly:
+
+```python
+out.dmi_internal.require(
+    "hidden_states",
+    count=model.config.num_hidden_layers,
+    retry=True,
+    timeout_s=30.0,
+    poll_s=0.25,
+)
+hidden_states = out.dmi_internal.hidden_states
+```
+
+`retry=True` retries missing or incomplete fields until complete. `timeout_s`
+defaults to 30 seconds; pass `timeout_s=None` only when you intentionally want
+to wait forever. `poll_s` controls the interval between reads. Incomplete reads
+are not cached; successful complete reads are cached.
 
 Per-output requirements are also supported:
 
 ```python
-out.dmi_internal.require("hidden_states", count=model.config.num_hidden_layers)
+out.dmi_internal.require(
+    "hidden_states",
+    count=model.config.num_hidden_layers,
+    retry=True,
+)
 hidden_states = out.dmi_internal.hidden_states
 ```
 

--- a/docs/huggingface.md
+++ b/docs/huggingface.md
@@ -29,6 +29,53 @@ Inspect captured rows after a `ring_db` run:
 clickhouse-client --query "SELECT count() FROM default.offload"
 ```
 
+## Reading internals from HF generation output
+
+`generate_with_monitoring(...)` preserves Hugging Face's normal return behavior.
+Use `generate_with_monitoring_dict(...)` when you want a dict-style generation
+output with DMI internals attached:
+
+```python
+from integration.hf_adapter import generate_with_monitoring_dict
+from monitoring.internal_mapper import InternalRequirements
+
+requirements = InternalRequirements().require(
+    "hidden_states",
+    count=model.config.num_hidden_layers,
+)
+
+out = generate_with_monitoring_dict(
+    model,
+    **inputs,
+    max_new_tokens=8,
+    do_sample=False,
+    internal_requirements=requirements,
+)
+
+hidden_states = out.dmi_internal.hidden_states
+```
+
+Plain field access such as `out.dmi_internal.hidden_states` is lazy and
+field-cached. It reads the backing store on first successful access and then
+reuses the cached value. If ClickHouse is still receiving rows, plain access can
+cache a partial result. Use a requirement when you know the expected number of
+entries and want incomplete reads to fail explicitly.
+
+Per-output requirements are also supported:
+
+```python
+out.dmi_internal.require("hidden_states", count=model.config.num_hidden_layers)
+hidden_states = out.dmi_internal.hidden_states
+```
+
+If more rows arrive after a field has been cached, clear that field before
+reading again:
+
+```python
+out.dmi_internal.clear_cache("hidden_states")
+hidden_states = out.dmi_internal.hidden_states
+```
+
 ## Ring-transport benchmark
 
 The benchmark compares:

--- a/docs/huggingface.md
+++ b/docs/huggingface.md
@@ -55,7 +55,52 @@ out = generate_with_monitoring_dict(
 )
 
 hidden_states = out.dmi_internal.hidden_states
+token_mask = out.dmi_internal.token_mask
 ```
+
+Supported mapped fields are:
+
+| Field | DMI act_name |
+|---|---|
+| `hidden_states` | `blocks.hook_resid_pre` |
+| `attentions` | `blocks.attn.hook_pattern` |
+| `logits` | `final_logits` |
+| `token_mask` | Derived from this generate call's token ranges |
+
+These fields are reassembled into one value per field. For example,
+`hidden_states` is a tuple ordered by layer, with each tensor shaped
+`[batch, seq, hidden]`; `attentions` is a tuple ordered by layer, with each
+tensor shaped `[batch, heads, seq, seq]`; `logits` is shaped
+`[batch, seq, vocab]`; `token_mask` is shaped `[batch, seq]` with bool dtype.
+For `generate_with_monitoring_dict(...)`, tensor reads are scoped to the request
+IDs from that generate call rather than loading every row for the model_id.
+
+This is intentionally not the raw nested layout returned by
+`generate(..., output_hidden_states=True)`. Hugging Face returns generation
+internals in step-first form, roughly `step -> layer -> tensor`. DMI internals
+are returned in analysis-friendly layer-first form, `layer -> full-sequence
+tensor`, after prefill and decode chunks have been stitched together on CPU.
+The original Hugging Face generation output is still available directly on
+`out`, for example `out.sequences`.
+
+When DMI reassembles ragged per-request sequences into a batch, shorter
+requests are left-padded with synthetic zeros. These zeros are not Hugging Face
+pad-token activations. Use `token_mask` to ignore them:
+
+```python
+hidden_states = out.dmi_internal.hidden_states
+token_mask = out.dmi_internal.token_mask
+norm = hidden_states[0].float().norm(dim=-1)[token_mask].mean()
+```
+
+`dmi_internal` does not currently expose `scores` or `past_key_values`.
+Hugging Face `scores` are generation scores after logits processors/warpers,
+so they are not always the same as raw model logits; DMI exposes raw captured
+`final_logits` as `out.dmi_internal.logits` instead. `past_key_values` is not
+mapped because HF cache objects are cache-implementation-specific and DMI does
+not reconstruct that object today. If Hugging Face itself returned these fields,
+they remain available on the original generation output, for example
+`out.scores` or `out.past_key_values`.
 
 Plain field access such as `out.dmi_internal.hidden_states` is lazy and
 field-cached. It reads the backing store on first successful access and then

--- a/docs/huggingface.md
+++ b/docs/huggingface.md
@@ -58,14 +58,38 @@ hidden_states = out.dmi_internal.hidden_states
 token_mask = out.dmi_internal.token_mask
 ```
 
+For layer-tuple fields such as `hidden_states`, `count` validates the number of
+layers in the reassembled tuple. It does not validate token completeness inside
+each layer tensor.
+
 Supported mapped fields are:
 
 | Field | DMI act_name |
 |---|---|
-| `hidden_states` | `blocks.hook_resid_pre` |
-| `attentions` | `blocks.attn.hook_pattern` |
-| `logits` | `final_logits` |
 | `token_mask` | Derived from this generate call's token ranges |
+| `token_ids` | `token_ids` |
+| `embeddings` | `hook_embed` |
+| `position_embeddings` | `hook_pos_embed` |
+| `final_residual` | `hook_resid_final` |
+| `final_hidden` | `hook_final_ln` |
+| `hidden_states` | `blocks.hook_resid_pre` |
+| `ln1` | `blocks.hook_ln1` |
+| `attention_output` | `blocks.hook_attn_out` |
+| `middle_residual` | `blocks.hook_resid_mid` |
+| `ln2` | `blocks.hook_ln2` |
+| `mlp_input` | `blocks.hook_mlp_in` |
+| `mlp_output` | `blocks.hook_mlp_out` |
+| `mlp_activation` | `blocks.hook_mlp_post` |
+| `attention_scores` | `blocks.attn.hook_attn_scores` |
+| `attentions` | `blocks.attn.hook_pattern` |
+| `q` | `blocks.attn.hook_q` |
+| `k` | `blocks.attn.hook_k` |
+| `v` | `blocks.attn.hook_v` |
+| `attention_values` | `blocks.attn.hook_z` |
+| `router_logits` | `blocks.mlp.hook_router_logits` |
+| `expert_ids` | `blocks.mlp.hook_topk_ids` |
+| `expert_weights` | `blocks.mlp.hook_topk_weights` |
+| `logits` | `final_logits` |
 
 These fields are reassembled into one value per field. For example,
 `hidden_states` is a tuple ordered by layer, with each tensor shaped
@@ -91,6 +115,16 @@ pad-token activations. Use `token_mask` to ignore them:
 hidden_states = out.dmi_internal.hidden_states
 token_mask = out.dmi_internal.token_mask
 norm = hidden_states[0].float().norm(dim=-1)[token_mask].mean()
+```
+
+If a tensor field and `token_mask` have different `[batch, seq]` shapes, it
+usually means the tensor field was read before all rows for that field arrived.
+Current requirements for layer-tuple fields validate layer count, not token
+count, so clear that field's cache and read it again:
+
+```python
+out.dmi_internal.clear_cache("hidden_states")
+hidden_states = out.dmi_internal.hidden_states
 ```
 
 `dmi_internal` does not currently expose `scores` or `past_key_values`.

--- a/example/hf_attention_matrix/run_hf_attention_matrix.py
+++ b/example/hf_attention_matrix/run_hf_attention_matrix.py
@@ -120,6 +120,7 @@ def main() -> None:
         retry=True,
         timeout_s=30.0,
         poll_s=0.25,
+        match_token_ranges=True,
     )
     inputs = tokenizer(PROMPT, return_tensors="pt").to(device)
 

--- a/example/hf_attention_matrix/run_hf_attention_matrix.py
+++ b/example/hf_attention_matrix/run_hf_attention_matrix.py
@@ -1,12 +1,13 @@
-"""One-file HF example: generate, read DMI internals, print layer norms.
+"""One-file HF example: capture DMI attentions and save an attention matrix.
 
 Prerequisites:
   - ClickHouse is running on DMX_DB_HOST:DMX_DB_PORT, default localhost:9000.
   - The project is installed with the patched transformers/HF hooks.
   - CUDA is available.
+  - matplotlib is installed.
 
 Usage:
-    python example/hf_internal_norms/run_hf_internal_norms.py
+    python example/hf_attention_matrix/run_hf_attention_matrix.py
 """
 from __future__ import annotations
 
@@ -20,10 +21,13 @@ if str(_REPO_ROOT) not in sys.path:
 
 import torch
 
-MODEL_ID = "example_hf_internal_norms"
+MODEL_ID = "example_hf_attention_matrix"
 HF_MODEL = "Qwen/Qwen3-0.6B"
 PROMPT = "The capital of France is"
 MAX_NEW_TOKENS = 8
+LAYER = 0
+HEAD = 0
+OUTPUT_PNG = Path(__file__).resolve().parent / "attention_layer00_head00.png"
 
 
 def _build_db_config():
@@ -66,9 +70,17 @@ def _wipe_my_rows(db_cfg) -> None:
         print(f"[example] WARNING: row cleanup failed: {exc}", file=sys.stderr)
 
 
+def _token_labels(tokenizer, sequence: torch.Tensor, n_tokens: int) -> list[str]:
+    ids = sequence[:n_tokens].detach().cpu().tolist()
+    labels = tokenizer.convert_ids_to_tokens(ids)
+    return [label.replace("\u0120", " ").replace("\n", "\\n") for label in labels]
+
+
 def main() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("This example requires CUDA.")
+
+    import matplotlib.pyplot as plt
 
     from integration.hf_adapter import generate_with_monitoring_dict
     from monitoring import HostEngineConfig, MonitoringConfig, MonitoringEngine
@@ -86,6 +98,7 @@ def main() -> None:
     model = HookedQwen3ForCausalLM.from_pretrained(
         HF_MODEL,
         torch_dtype=torch.float16,
+        attn_implementation="eager",
     ).to(device).eval()
 
     tokenizer = AutoTokenizer.from_pretrained(HF_MODEL)
@@ -101,10 +114,8 @@ def main() -> None:
     model.monitoring_engine = engine
 
     expected_layers = model.config.num_hidden_layers
-    # For layer-tuple fields, count validates the number of layers. It does not
-    # validate token completeness inside each layer tensor.
     requirements = InternalRequirements().require(
-        "hidden_states",
+        "attentions",
         count=expected_layers,
         retry=True,
         timeout_s=30.0,
@@ -119,25 +130,39 @@ def main() -> None:
                 **inputs,
                 max_new_tokens=MAX_NEW_TOKENS,
                 do_sample=False,
-                hook_selection="hidden-states",
+                hook_selection="pattern",
                 internal_requirements=requirements,
             )
     finally:
         engine.close()
 
+    attentions = out.dmi_internal.attentions
+    token_mask = out.dmi_internal.token_mask
+    assert len(attentions) == expected_layers
+
+    matrix = attentions[LAYER][0, HEAD].float()
+    real_tokens = token_mask[0]
+    matrix = matrix[real_tokens][:, real_tokens]
+    labels = _token_labels(tokenizer, out.sequences[0], matrix.shape[0])
+
+    fig, ax = plt.subplots(figsize=(8, 7))
+    image = ax.imshow(matrix.numpy(), cmap="viridis", vmin=0.0)
+    ax.set_title(f"Layer {LAYER}, head {HEAD}")
+    ax.set_xlabel("Key token")
+    ax.set_ylabel("Query token")
+    if len(labels) <= 32:
+        ax.set_xticks(range(len(labels)))
+        ax.set_yticks(range(len(labels)))
+        ax.set_xticklabels(labels, rotation=90, fontsize=8)
+        ax.set_yticklabels(labels, fontsize=8)
+    fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+    fig.tight_layout()
+    fig.savefig(OUTPUT_PNG, dpi=160)
+    plt.close(fig)
+
     decoded = tokenizer.decode(out.sequences[0], skip_special_tokens=True)
     print(f"[example] Output: {decoded!r}")
-
-    hidden_states = out.dmi_internal.hidden_states
-    token_mask = out.dmi_internal.token_mask
-    assert len(hidden_states) == expected_layers
-    assert all(t.device.type == "cpu" for t in hidden_states)
-    assert token_mask.device.type == "cpu"
-
-    print("[example] Per-layer hidden-state activation norm:")
-    for layer, tensor in enumerate(hidden_states):
-        norm = tensor.float().norm(dim=-1)[token_mask].mean().item()
-        print(f"  layer {layer:02d}: {norm:.6f}")
+    print(f"[example] Saved attention matrix to {OUTPUT_PNG}")
 
 
 if __name__ == "__main__":

--- a/example/hf_internal_norms/run_hf_internal_norms.py
+++ b/example/hf_internal_norms/run_hf_internal_norms.py
@@ -1,0 +1,140 @@
+"""One-file HF example: generate, read DMI internals, print layer norms.
+
+Prerequisites:
+  - ClickHouse is running on DMX_DB_HOST:DMX_DB_PORT, default localhost:9000.
+  - The project is installed with the patched transformers/HF hooks.
+  - CUDA is available.
+
+Usage:
+    python example/hf_internal_norms/run_hf_internal_norms.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import torch
+
+MODEL_ID = "example_hf_internal_norms"
+HF_MODEL = "Qwen/Qwen3-0.6B"
+PROMPT = "The capital of France is"
+MAX_NEW_TOKENS = 8
+
+
+def _build_db_config():
+    from monitoring._native_engine import ClickHouseClientConfig
+
+    cfg = ClickHouseClientConfig()
+    cfg.host = os.environ.get("DMX_DB_HOST", "localhost")
+    cfg.port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    cfg.username = os.environ.get("DMX_DB_USER", "default")
+    cfg.password = os.environ.get("DMX_DB_PASSWORD", "")
+    cfg.database = os.environ.get("DMX_DB_DATABASE", "default")
+    cfg.table = os.environ.get("DMX_DB_TABLE", "offload")
+    cfg.secure = False
+    cfg.client_side_compress = "none"
+    cfg.create_database_if_missing = True
+    cfg.drop_existing_database = False
+    cfg.index_granularity = 8192
+    return cfg
+
+
+def _wipe_my_rows(db_cfg) -> None:
+    import clickhouse_driver
+
+    client = clickhouse_driver.Client(
+        host=db_cfg.host,
+        port=db_cfg.port,
+        user=db_cfg.username,
+        password=db_cfg.password,
+    )
+    try:
+        client.execute(
+            f"ALTER TABLE {db_cfg.database}.{db_cfg.table} "
+            f"DELETE WHERE model_id = %(model_id)s",
+            {"model_id": MODEL_ID},
+        )
+    except Exception as exc:
+        msg = str(exc).lower()
+        if any(s in msg for s in ("doesn't exist", "unknown table", "could not find table")):
+            return
+        print(f"[example] WARNING: row cleanup failed: {exc}", file=sys.stderr)
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("This example requires CUDA.")
+
+    from integration.hf_adapter import generate_with_monitoring_dict
+    from monitoring import HostEngineConfig, MonitoringConfig, MonitoringEngine
+    from monitoring._native_engine import StageConfig
+    from monitoring.config import CaptureSchedule
+    from monitoring.internal_mapper import InternalRequirements
+    from transformers import AutoTokenizer
+    from transformers.models.qwen3_p.modeling_qwen3 import HookedQwen3ForCausalLM
+
+    db_cfg = _build_db_config()
+    _wipe_my_rows(db_cfg)
+
+    device = torch.device("cuda")
+    print(f"[example] Loading {HF_MODEL} on CUDA in fp16 ...", flush=True)
+    model = HookedQwen3ForCausalLM.from_pretrained(
+        HF_MODEL,
+        torch_dtype=torch.float16,
+    ).to(device).eval()
+
+    tokenizer = AutoTokenizer.from_pretrained(HF_MODEL)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+
+    stage = StageConfig.clickhouse_insert(db_cfg, parallelism=4, name="ch_insert")
+    engine = MonitoringEngine(
+        config=MonitoringConfig(schedule=CaptureSchedule()),
+        model_id=MODEL_ID,
+        db_config=HostEngineConfig(stages=[stage]),
+    )
+    model.monitoring_engine = engine
+
+    expected_layers = model.config.num_hidden_layers
+    requirements = InternalRequirements().require(
+        "hidden_states",
+        count=expected_layers,
+        retry=True,
+        timeout_s=30.0,
+        poll_s=0.25,
+    )
+    inputs = tokenizer(PROMPT, return_tensors="pt").to(device)
+
+    try:
+        with torch.no_grad():
+            out = generate_with_monitoring_dict(
+                model,
+                **inputs,
+                max_new_tokens=MAX_NEW_TOKENS,
+                do_sample=False,
+                hook_selection="hidden-states",
+                internal_requirements=requirements,
+            )
+    finally:
+        engine.close()
+
+    decoded = tokenizer.decode(out.sequences[0], skip_special_tokens=True)
+    print(f"[example] Output: {decoded!r}")
+
+    hidden_states = out.dmi_internal.hidden_states
+    assert len(hidden_states) == expected_layers
+    assert all(t.device.type == "cpu" for t in hidden_states)
+
+    print("[example] Per-layer hidden-state activation norm:")
+    for layer, tensor in enumerate(hidden_states):
+        norm = tensor.float().norm(dim=-1).mean().item()
+        print(f"  layer {layer:02d}: {norm:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/hf_internal_norms/run_hf_internal_norms.py
+++ b/example/hf_internal_norms/run_hf_internal_norms.py
@@ -127,12 +127,14 @@ def main() -> None:
     print(f"[example] Output: {decoded!r}")
 
     hidden_states = out.dmi_internal.hidden_states
+    token_mask = out.dmi_internal.token_mask
     assert len(hidden_states) == expected_layers
     assert all(t.device.type == "cpu" for t in hidden_states)
+    assert token_mask.device.type == "cpu"
 
     print("[example] Per-layer hidden-state activation norm:")
     for layer, tensor in enumerate(hidden_states):
-        norm = tensor.float().norm(dim=-1).mean().item()
+        norm = tensor.float().norm(dim=-1)[token_mask].mean().item()
         print(f"  layer {layer:02d}: {norm:.6f}")
 
 

--- a/example/hf_internal_norms/run_hf_internal_norms.py
+++ b/example/hf_internal_norms/run_hf_internal_norms.py
@@ -109,6 +109,7 @@ def main() -> None:
         retry=True,
         timeout_s=30.0,
         poll_s=0.25,
+        match_token_ranges=True,
     )
     inputs = tokenizer(PROMPT, return_tensors="pt").to(device)
 

--- a/example/visualization/run_offload_hf.py
+++ b/example/visualization/run_offload_hf.py
@@ -152,7 +152,7 @@ def main() -> None:
     finally:
         engine.close()
 
-    decoded = tokenizer.decode(output_ids.sequences[0], skip_special_tokens=True)
+    decoded = tokenizer.decode(output_ids[0], skip_special_tokens=True)
     print(f"[demo] Output:  {decoded!r}", flush=True)
     print(f"[demo] model_id = {MODEL_ID}  (open visualize.ipynb to render)", flush=True)
 

--- a/example/visualization/run_offload_hf.py
+++ b/example/visualization/run_offload_hf.py
@@ -152,7 +152,7 @@ def main() -> None:
     finally:
         engine.close()
 
-    decoded = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    decoded = tokenizer.decode(output_ids.sequences[0], skip_special_tokens=True)
     print(f"[demo] Output:  {decoded!r}", flush=True)
     print(f"[demo] model_id = {MODEL_ID}  (open visualize.ipynb to render)", flush=True)
 

--- a/integration/hf_adapter.py
+++ b/integration/hf_adapter.py
@@ -694,6 +694,28 @@ class HFAdaptor(BackendAdaptor):
 # generate_with_monitoring (rewritten to use HFAdaptor)
 # ---------------------------------------------------------------------------
 
+class MonitoredGenerateOutput:
+    """HF ``generate()`` output plus the ``model_id`` needed to retrieve the
+    captured internals. ``sequences`` mirrors HF's generated token ids;
+    ``model_id`` is the handle ``get_internal`` uses. Any other attribute
+    (scores, logits, hidden_states, ...) falls through to the underlying HF
+    output when ``return_dict_in_generate=True`` was used."""
+
+    def __init__(self, raw: Any, model_id: str):
+        self._raw = raw
+        self.model_id = model_id
+
+    @property
+    def sequences(self) -> Any:
+        return getattr(self._raw, "sequences", self._raw)
+
+    def __getattr__(self, name: str) -> Any:
+        raw = self.__dict__.get("_raw")
+        if raw is not None and hasattr(raw, name):
+            return getattr(raw, name)
+        raise AttributeError(name)
+
+
 def generate_with_monitoring(
     model: Any, *args: Any,
     hook_selection: Optional[str] = None,
@@ -935,7 +957,8 @@ def generate_with_monitoring(
                 warnings.warn(msg, stacklevel=2)
 
     try:
-        return model.generate(*args, **kwargs)
+        gen = model.generate(*args, **kwargs)
+        return MonitoredGenerateOutput(gen, engine._model_id)
     finally:
         if adaptor is not None:
             adaptor.detach_model(target)
@@ -1208,6 +1231,7 @@ def generate_greedy_with_monitoring(
 __all__ = [
     "HFAdaptor",
     "GreedyGenerateTimings",
+    "MonitoredGenerateOutput",
     "generate_with_monitoring",
     "generate_greedy_with_monitoring",
     "_prepare_profile_times",

--- a/integration/hf_adapter.py
+++ b/integration/hf_adapter.py
@@ -173,6 +173,8 @@ class HFAdaptor(BackendAdaptor):
         self._batch_finished: Optional[List[bool]] = None
         self._prefill_kv_offsets: Optional[List[int]] = None
         self._orig_prepare: Any = None
+        self.request_ids_in_this_generate: List[str] = []
+        self.token_ranges_in_this_generate: Dict[str, List[Tuple[int, int]]] = {}
         # Per-instance defaults.  Per-call ``attach_model(...)`` overrides
         # only when the kwarg is explicitly passed (None means inherit).
         self._no_strip_left_pad: bool = bool(no_strip_left_pad)
@@ -465,6 +467,9 @@ class HFAdaptor(BackendAdaptor):
         if need_reset:
             gid = self.engine.next_auto_group_id()
             self._batch_request_ids = [f"{gid}:{i}" for i in range(batch_size)]
+            for rid in self._batch_request_ids:
+                if rid not in self.request_ids_in_this_generate:
+                    self.request_ids_in_this_generate.append(rid)
             self._batch_starts = [0] * batch_size
             self._batch_finished = [False] * batch_size
             # On (re)prefill, recompute kv_offsets from the attention mask
@@ -605,6 +610,11 @@ class HFAdaptor(BackendAdaptor):
                 f"token_ranges={token_ranges} finished={list(finished)}"
             )
 
+        for rid, token_range in zip(req_ids, token_ranges):
+            self.token_ranges_in_this_generate.setdefault(rid, []).append(
+                (int(token_range[0]), int(token_range[1]))
+            )
+
         # Derive q_len, kv_dim, dim0_offsets.
         q_len = int(input_shape[1]) if len(input_shape) >= 2 else 1
         is_static = (
@@ -701,6 +711,7 @@ def _generate_with_monitoring_impl(
     no_strip_right_pad: bool = False,
     eos_token_id: Any = None,
     _return_model_id: bool = False,
+    _return_internal_metadata: bool = False,
     **kwargs: Any,
 ):
     """Run HF ``generate()`` with ring-transport monitoring hooks active.
@@ -853,6 +864,8 @@ def _generate_with_monitoring_impl(
     # compare-runner test harness) can read per-step batch tracking
     # (_batch_request_ids, _batch_starts).
     engine._hf_adaptor = adaptor
+    adaptor.request_ids_in_this_generate = []
+    adaptor.token_ranges_in_this_generate = {}
     adaptor.attach_model(
         target,
         hook_selection=hook_selection or "full",
@@ -937,6 +950,17 @@ def _generate_with_monitoring_impl(
 
     try:
         gen = model.generate(*args, **kwargs)
+        if _return_internal_metadata:
+            token_ranges = {
+                rid: tuple(ranges)
+                for rid, ranges in adaptor.token_ranges_in_this_generate.items()
+            }
+            return (
+                gen,
+                engine._model_id,
+                tuple(adaptor.request_ids_in_this_generate),
+                token_ranges,
+            )
         if _return_model_id:
             return gen, engine._model_id
         return gen
@@ -999,19 +1023,24 @@ def generate_with_monitoring_dict(
         )
     gen_kwargs["return_dict_in_generate"] = True
 
-    output, model_id = _generate_with_monitoring_impl(
+    output, model_id, request_ids, token_ranges = _generate_with_monitoring_impl(
         model, *args,
         hook_selection=hook_selection,
         no_strip_left_pad=no_strip_left_pad,
         no_strip_right_pad=no_strip_right_pad,
         eos_token_id=eos_token_id,
-        _return_model_id=True,
+        _return_internal_metadata=True,
         **gen_kwargs,
     )
 
     from monitoring.internal_mapper import make_lazy_internal
     dmi_internal = make_lazy_internal(
-        model_id, reader=reader, requirements=internal_requirements)
+        model_id,
+        reader=reader,
+        requirements=internal_requirements,
+        request_ids=request_ids,
+        token_ranges=token_ranges,
+    )
     try:
         output.dmi_internal = dmi_internal
     except Exception:

--- a/integration/hf_adapter.py
+++ b/integration/hf_adapter.py
@@ -694,34 +694,13 @@ class HFAdaptor(BackendAdaptor):
 # generate_with_monitoring (rewritten to use HFAdaptor)
 # ---------------------------------------------------------------------------
 
-class MonitoredGenerateOutput:
-    """HF ``generate()`` output plus the ``model_id`` needed to retrieve the
-    captured internals. ``sequences`` mirrors HF's generated token ids;
-    ``model_id`` is the handle ``get_internal`` uses. Any other attribute
-    (scores, logits, hidden_states, ...) falls through to the underlying HF
-    output when ``return_dict_in_generate=True`` was used."""
-
-    def __init__(self, raw: Any, model_id: str):
-        self._raw = raw
-        self.model_id = model_id
-
-    @property
-    def sequences(self) -> Any:
-        return getattr(self._raw, "sequences", self._raw)
-
-    def __getattr__(self, name: str) -> Any:
-        raw = self.__dict__.get("_raw")
-        if raw is not None and hasattr(raw, name):
-            return getattr(raw, name)
-        raise AttributeError(name)
-
-
-def generate_with_monitoring(
+def _generate_with_monitoring_impl(
     model: Any, *args: Any,
     hook_selection: Optional[str] = None,
     no_strip_left_pad: bool = False,
     no_strip_right_pad: bool = False,
     eos_token_id: Any = None,
+    _return_model_id: bool = False,
     **kwargs: Any,
 ):
     """Run HF ``generate()`` with ring-transport monitoring hooks active.
@@ -958,7 +937,9 @@ def generate_with_monitoring(
 
     try:
         gen = model.generate(*args, **kwargs)
-        return MonitoredGenerateOutput(gen, engine._model_id)
+        if _return_model_id:
+            return gen, engine._model_id
+        return gen
     finally:
         if adaptor is not None:
             adaptor.detach_model(target)
@@ -972,6 +953,70 @@ def generate_with_monitoring(
                 gen_cfg.cache_implementation = _saved_cache_impl
         # force_eager is owned by before_forward (per-batch reassignment);
         # no cleanup needed -- the next generate()'s first batch will set it.
+
+
+def generate_with_monitoring(
+    model: Any, *args: Any,
+    hook_selection: Optional[str] = None,
+    no_strip_left_pad: bool = False,
+    no_strip_right_pad: bool = False,
+    eos_token_id: Any = None,
+    **kwargs: Any,
+):
+    """Run HF ``generate()`` with monitoring hooks and return HF output unchanged."""
+    return _generate_with_monitoring_impl(
+        model, *args,
+        hook_selection=hook_selection,
+        no_strip_left_pad=no_strip_left_pad,
+        no_strip_right_pad=no_strip_right_pad,
+        eos_token_id=eos_token_id,
+        **kwargs,
+    )
+
+
+def generate_with_monitoring_dict(
+    model: Any, *args: Any,
+    hook_selection: Optional[str] = None,
+    no_strip_left_pad: bool = False,
+    no_strip_right_pad: bool = False,
+    eos_token_id: Any = None,
+    reader: Any = None,
+    internal_requirements: Any = None,
+    **kwargs: Any,
+):
+    """Run monitored HF ``generate()`` and return dict-style output with DMI internals.
+
+    This API always forces ``return_dict_in_generate=True`` and attaches one DMI
+    extension, ``dmi_internal``, which lazily reads captured internals.
+    """
+    gen_kwargs = dict(kwargs)
+    if gen_kwargs.get("return_dict_in_generate") is False:
+        warnings.warn(
+            "generate_with_monitoring_dict() requires "
+            "return_dict_in_generate=True; overriding the supplied False value.",
+            UserWarning,
+            stacklevel=2,
+        )
+    gen_kwargs["return_dict_in_generate"] = True
+
+    output, model_id = _generate_with_monitoring_impl(
+        model, *args,
+        hook_selection=hook_selection,
+        no_strip_left_pad=no_strip_left_pad,
+        no_strip_right_pad=no_strip_right_pad,
+        eos_token_id=eos_token_id,
+        _return_model_id=True,
+        **gen_kwargs,
+    )
+
+    from monitoring.internal_mapper import make_lazy_internal
+    dmi_internal = make_lazy_internal(
+        model_id, reader=reader, requirements=internal_requirements)
+    try:
+        output.dmi_internal = dmi_internal
+    except Exception:
+        object.__setattr__(output, "dmi_internal", dmi_internal)
+    return output
 
 
 # ---------------------------------------------------------------------------
@@ -1231,8 +1276,8 @@ def generate_greedy_with_monitoring(
 __all__ = [
     "HFAdaptor",
     "GreedyGenerateTimings",
-    "MonitoredGenerateOutput",
     "generate_with_monitoring",
+    "generate_with_monitoring_dict",
     "generate_greedy_with_monitoring",
     "_prepare_profile_times",
     "print_prepare_profile",

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import torch
 
 from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
+from monitoring.segment_merger import merge_segments
 
 
 def _default_reader() -> CHClickhouseDriverReadOnly:
@@ -38,6 +39,17 @@ def _left_pad_stack(per_request: list[torch.Tensor]) -> torch.Tensor:
     return batched
 
 
+def _request_sort_key(request_id: str) -> tuple:
+    parts = request_id.split(":")
+    key = []
+    for part in parts:
+        try:
+            key.append((0, int(part)))
+        except ValueError:
+            key.append((1, part))
+    return tuple(key)
+
+
 def _reassemble_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
     """Reassemble a per-layer hook (residual stream, mlp, ...).
 
@@ -52,10 +64,63 @@ def _reassemble_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
     for layer in sorted(layers):
         per_request = [
             torch.cat([t for _, t in sorted(chunks)], dim=0)
-            for _, chunks in sorted(layers[layer].items())
+            for _, chunks in sorted(layers[layer].items(), key=lambda item: _request_sort_key(item[0]))
         ]
         out.append(_left_pad_stack(per_request))
     return tuple(out)
+
+
+def _left_pad_stack_attention(per_request: list[torch.Tensor]) -> torch.Tensor:
+    """Stack ragged per-request attention tensors into [batch, heads, seq, seq].
+
+    Each request tensor is [heads, query_tokens, key_tokens]. Shorter requests
+    are left-padded on both query and key axes.
+    """
+    heads = per_request[0].shape[0]
+    seq = max(t.shape[-1] for t in per_request)
+    batched = torch.zeros(len(per_request), heads, seq, seq,
+                          dtype=per_request[0].dtype)
+    for i, t in enumerate(per_request):
+        q_len = t.shape[-2]
+        k_len = t.shape[-1]
+        batched[i, :, seq - q_len:, seq - k_len:] = t
+    return batched
+
+
+def _reassemble_attention_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
+    """Reassemble attention-pattern rows as a tuple ordered by layer."""
+    layers: dict[int, dict[str, list]] = {}
+    for key, tensor in rows:
+        layers.setdefault(key[3], {}).setdefault(key[1], []).append((key[5], tensor))
+    out = []
+    for layer in sorted(layers):
+        per_request = [
+            merge_segments(
+                [t for _, t in sorted(chunks)],
+                "blocks.attn.hook_pattern",
+            )
+            for _, chunks in sorted(layers[layer].items(), key=lambda item: _request_sort_key(item[0]))
+        ]
+        out.append(_left_pad_stack_attention(per_request))
+    return tuple(out)
+
+
+def _reassemble_global(rows: list) -> torch.Tensor:
+    """Reassemble a non-layered field into [batch, seq, ...]."""
+    requests: dict[str, list] = {}
+    for key, tensor in rows:
+        requests.setdefault(key[1], []).append((key[5], tensor))
+    per_request = [
+        torch.cat([t for _, t in sorted(chunks)], dim=0)
+        for _, chunks in sorted(requests.items(), key=lambda item: _request_sort_key(item[0]))
+    ]
+    if per_request[0].ndim == 1:
+        seq = max(t.shape[0] for t in per_request)
+        batched = torch.zeros(len(per_request), seq, dtype=per_request[0].dtype)
+        for i, t in enumerate(per_request):
+            batched[i, seq - t.shape[0]:] = t
+        return batched
+    return _left_pad_stack(per_request)
 
 
 # Public field name -> (capture act_name, reassembler). The reassembler takes the
@@ -63,6 +128,8 @@ def _reassemble_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
 # internals (attention, logits, kv, ...) here, each with its own reassembler.
 _FIELDS = {
     "hidden_states": ("blocks.hook_resid_pre", _reassemble_per_layer),
+    "attentions": ("blocks.attn.hook_pattern", _reassemble_attention_per_layer),
+    "logits": ("final_logits", _reassemble_global),
 }
 
 
@@ -165,12 +232,19 @@ class _LazyInternal:
         model_id: str,
         reader: CHClickhouseDriverReadOnly | None = None,
         requirements: InternalRequirements | None = None,
+        request_ids: tuple[str, ...] | list[str] | None = None,
+        token_ranges: dict[str, tuple[tuple[int, int], ...] | list[tuple[int, int]]] | None = None,
     ) -> None:
         self._model_id = model_id
         self._reader = reader
         self._requirements = (
             requirements.copy() if requirements is not None else InternalRequirements()
         )
+        self._request_ids = tuple(request_ids or ())
+        self._token_ranges = {
+            rid: tuple((int(start), int(end)) for start, end in ranges)
+            for rid, ranges in dict(token_ranges or {}).items()
+        }
         self._field_cache: dict[str, object] = {}
 
     def require(
@@ -256,11 +330,73 @@ class _LazyInternal:
         field: str,
         requirement: _Requirement | None,
     ) -> object:
-        internal = get_internal(self._model_id, self._reader)
-        value = getattr(internal, field)
+        value = self._read_field(field)
         self._validate(field, value, requirement)
         self._field_cache[field] = value
         return value
+
+    def _reader_or_default(self) -> CHClickhouseDriverReadOnly:
+        return self._reader or _default_reader()
+
+    def _read_rows_for_field(self, field: str) -> list:
+        if field not in _FIELDS:
+            raise AttributeError(
+                f"{field!r} is not a supported DMI internal field. "
+                f"Available mapped fields: {sorted(_FIELDS)}."
+            )
+        act, _ = _FIELDS[field]
+        reader = self._reader_or_default()
+        if self._request_ids:
+            rows = []
+            for request_id in self._request_ids:
+                rows.extend(reader.prefix_get((self._model_id, request_id, act)))
+            return rows
+        return [
+            (key, tensor)
+            for key, tensor in reader.prefix_get((self._model_id,))
+            if key[2] == act
+        ]
+
+    def _read_field(self, field: str) -> object:
+        if field == "token_mask":
+            return self._build_token_mask()
+        if field not in _FIELDS:
+            raise AttributeError(
+                f"{field!r} was not captured because it is not a supported "
+                "DMI internal field. "
+                f"Available mapped fields: {sorted(_FIELDS) + ['token_mask']}."
+            )
+        act, reassemble = _FIELDS[field]
+        rows = self._read_rows_for_field(field)
+        if not rows:
+            raise AttributeError(
+                f"{field!r} was not captured in this run. "
+                f"Pass the corresponding hook via hook_selection= when generating."
+            )
+        return reassemble(rows)
+
+    def _build_token_mask(self) -> torch.Tensor:
+        if not self._request_ids or not self._token_ranges:
+            raise AttributeError(
+                "'token_mask' is not available because this internal handle "
+                "does not have per-generate request token ranges."
+            )
+        max_len = 0
+        for rid in self._request_ids:
+            ranges = self._token_ranges.get(rid, ())
+            for _, end in ranges:
+                max_len = max(max_len, int(end))
+        mask = torch.zeros(len(self._request_ids), max_len, dtype=torch.bool)
+        for batch_i, rid in enumerate(self._request_ids):
+            ranges = self._token_ranges.get(rid, ())
+            final_len = max((int(end) for _, end in ranges), default=0)
+            offset = max_len - final_len
+            for start, end in ranges:
+                start_i = int(start)
+                end_i = int(end)
+                if end_i > start_i:
+                    mask[batch_i, offset + start_i: offset + end_i] = True
+        return mask
 
     def _load_field_with_retry(
         self,
@@ -314,7 +450,15 @@ class _LazyInternal:
 
     @property
     def available(self) -> list[str]:
-        return get_internal(self._model_id, self._reader).available
+        if not self._request_ids:
+            return get_internal(self._model_id, self._reader).available
+        fields = []
+        for field in sorted(_FIELDS):
+            if self._read_rows_for_field(field):
+                fields.append(field)
+        if self._token_ranges:
+            fields.append("token_mask")
+        return fields
 
     def __getattr__(self, name: str):
         return self._load_field(name)
@@ -328,8 +472,16 @@ def make_lazy_internal(
     model_id: str,
     reader: CHClickhouseDriverReadOnly | None = None,
     requirements: InternalRequirements | None = None,
+    request_ids: tuple[str, ...] | list[str] | None = None,
+    token_ranges: dict[str, tuple[tuple[int, int], ...] | list[tuple[int, int]]] | None = None,
 ) -> _LazyInternal:
-    return _LazyInternal(model_id, reader, requirements=requirements)
+    return _LazyInternal(
+        model_id,
+        reader,
+        requirements=requirements,
+        request_ids=request_ids,
+        token_ranges=token_ranges,
+    )
 
 
 def get_internal(model_id: str, reader: CHClickhouseDriverReadOnly | None = None) -> Internal:

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -28,11 +28,11 @@ def _default_reader() -> CHClickhouseDriverReadOnly:
 
 
 def _left_pad_stack(per_request: list[torch.Tensor]) -> torch.Tensor:
-    """Stack ragged per-request tensors [seq_i, hidden] into [batch, seq, hidden],
+    """Stack ragged per-request tensors [seq_i, ...] into [batch, seq, ...],
     left-padding shorter requests with zeros so real tokens stay right-aligned --
     the layout HF's left-padded batch produces."""
     seq = max(t.shape[0] for t in per_request)
-    batched = torch.zeros(len(per_request), seq, per_request[0].shape[1],
+    batched = torch.zeros(len(per_request), seq, *per_request[0].shape[1:],
                           dtype=per_request[0].dtype)
     for i, t in enumerate(per_request):
         batched[i, seq - t.shape[0]:] = t
@@ -87,8 +87,8 @@ def _left_pad_stack_attention(per_request: list[torch.Tensor]) -> torch.Tensor:
     return batched
 
 
-def _reassemble_attention_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
-    """Reassemble attention-pattern rows as a tuple ordered by layer."""
+def _reassemble_attention_per_layer(rows: list, act_name: str) -> tuple[torch.Tensor, ...]:
+    """Reassemble attention-matrix rows as a tuple ordered by layer."""
     layers: dict[int, dict[str, list]] = {}
     for key, tensor in rows:
         layers.setdefault(key[3], {}).setdefault(key[1], []).append((key[5], tensor))
@@ -97,12 +97,18 @@ def _reassemble_attention_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
         per_request = [
             merge_segments(
                 [t for _, t in sorted(chunks)],
-                "blocks.attn.hook_pattern",
+                act_name,
             )
             for _, chunks in sorted(layers[layer].items(), key=lambda item: _request_sort_key(item[0]))
         ]
         out.append(_left_pad_stack_attention(per_request))
     return tuple(out)
+
+
+def _attention_reassembler(act_name: str):
+    def _reassemble(rows: list) -> tuple[torch.Tensor, ...]:
+        return _reassemble_attention_per_layer(rows, act_name)
+    return _reassemble
 
 
 def _reassemble_global(rows: list) -> torch.Tensor:
@@ -127,9 +133,35 @@ def _reassemble_global(rows: list) -> torch.Tensor:
 # (key, tensor) rows for its act_name and returns the field value. Add new
 # internals (attention, logits, kv, ...) here, each with its own reassembler.
 _FIELDS = {
+    "attention_output": ("blocks.hook_attn_out", _reassemble_per_layer),
+    "attention_scores": (
+        "blocks.attn.hook_attn_scores",
+        _attention_reassembler("blocks.attn.hook_attn_scores"),
+    ),
+    "attention_values": ("blocks.attn.hook_z", _reassemble_per_layer),
     "hidden_states": ("blocks.hook_resid_pre", _reassemble_per_layer),
-    "attentions": ("blocks.attn.hook_pattern", _reassemble_attention_per_layer),
+    "attentions": (
+        "blocks.attn.hook_pattern",
+        _attention_reassembler("blocks.attn.hook_pattern"),
+    ),
+    "embeddings": ("hook_embed", _reassemble_global),
+    "expert_ids": ("blocks.mlp.hook_topk_ids", _reassemble_per_layer),
+    "expert_weights": ("blocks.mlp.hook_topk_weights", _reassemble_per_layer),
+    "final_hidden": ("hook_final_ln", _reassemble_global),
+    "final_residual": ("hook_resid_final", _reassemble_global),
+    "k": ("blocks.attn.hook_k", _reassemble_per_layer),
+    "ln1": ("blocks.hook_ln1", _reassemble_per_layer),
+    "ln2": ("blocks.hook_ln2", _reassemble_per_layer),
     "logits": ("final_logits", _reassemble_global),
+    "middle_residual": ("blocks.hook_resid_mid", _reassemble_per_layer),
+    "mlp_activation": ("blocks.hook_mlp_post", _reassemble_per_layer),
+    "mlp_input": ("blocks.hook_mlp_in", _reassemble_per_layer),
+    "mlp_output": ("blocks.hook_mlp_out", _reassemble_per_layer),
+    "position_embeddings": ("hook_pos_embed", _reassemble_global),
+    "q": ("blocks.attn.hook_q", _reassemble_per_layer),
+    "router_logits": ("blocks.mlp.hook_router_logits", _reassemble_per_layer),
+    "token_ids": ("token_ids", _reassemble_global),
+    "v": ("blocks.attn.hook_v", _reassemble_per_layer),
 }
 
 
@@ -169,7 +201,11 @@ class _Requirement:
 
 
 class InternalRequirements:
-    """Reusable strictness policy for lazy internal fields."""
+    """Reusable strictness policy for lazy internal fields.
+
+    ``count`` validates ``len(field_value)``. For per-layer fields such as
+    ``hidden_states``, that means layer count, not token completeness.
+    """
 
     def __init__(self, counts: dict[str, int | _Requirement] | None = None) -> None:
         self._requirements = {

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -1,0 +1,107 @@
+"""Retrieve captured internals from the store and present them like HF's
+model output: one field per internal, mirroring its HF counterpart.
+
+Backend-agnostic -- it works off the ClickHouse rows DMI writes, regardless of
+whether the run came from the HF or vLLM path.
+
+Adding an internal: write a reassembler ``rows -> value`` (or reuse one) and add
+a ``field -> (act_name, reassembler)`` entry to ``_FIELDS``. ``get_internal``
+needs no change.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
+
+
+def _default_reader() -> CHClickhouseDriverReadOnly:
+    return CHClickhouseDriverReadOnly(
+        host=os.environ.get("DMX_DB_HOST", "localhost"),
+        port=int(os.environ.get("DMX_DB_PORT", "9000")),
+    )
+
+
+def _left_pad_stack(per_request: list[torch.Tensor]) -> torch.Tensor:
+    """Stack ragged per-request tensors [seq_i, hidden] into [batch, seq, hidden],
+    left-padding shorter requests with zeros so real tokens stay right-aligned --
+    the layout HF's left-padded batch produces."""
+    seq = max(t.shape[0] for t in per_request)
+    batched = torch.zeros(len(per_request), seq, per_request[0].shape[1],
+                          dtype=per_request[0].dtype)
+    for i, t in enumerate(per_request):
+        batched[i, seq - t.shape[0]:] = t
+    return batched
+
+
+def _reassemble_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
+    """Reassemble a per-layer hook (residual stream, mlp, ...).
+
+    rows: (key, tensor) pairs for one act_name, where
+    key = (model_id, request_id, act_name, layer_no, shard_rank, start, end).
+    Group by layer, concatenate each request's chunks along the token axis, then
+    left-pad-stack the requests. Returns a tuple ordered by layer."""
+    layers: dict[int, dict[str, list]] = {}
+    for key, tensor in rows:
+        layers.setdefault(key[3], {}).setdefault(key[1], []).append((key[5], tensor))
+    out = []
+    for layer in sorted(layers):
+        per_request = [
+            torch.cat([t for _, t in sorted(chunks)], dim=0)
+            for _, chunks in sorted(layers[layer].items())
+        ]
+        out.append(_left_pad_stack(per_request))
+    return tuple(out)
+
+
+# Public field name -> (capture act_name, reassembler). The reassembler takes the
+# (key, tensor) rows for its act_name and returns the field value. Add new
+# internals (attention, logits, kv, ...) here, each with its own reassembler.
+_FIELDS = {
+    "hidden_states": ("blocks.hook_resid_pre", _reassemble_per_layer),
+}
+
+
+class Internal:
+    """Captured internals for one run, presented like HF's model output: each
+    field mirrors its HF counterpart (e.g. ``hidden_states`` is a tuple indexed
+    by layer, each entry [batch, seq, hidden]). Only fields actually captured are
+    present -- see ``available``; accessing an uncaptured field raises."""
+
+    def __init__(self, fields: dict):
+        self._fields = fields
+
+    @property
+    def available(self) -> list[str]:
+        return sorted(self._fields)
+
+    def __getattr__(self, name: str):
+        fields = self.__dict__.get("_fields", {})
+        if name in fields:
+            return fields[name]
+        raise AttributeError(
+            f"{name!r} was not captured in this run. Available: {sorted(fields)}. "
+            f"Pass it via hook_selection= when generating."
+        )
+
+
+def get_internal(source, reader: CHClickhouseDriverReadOnly | None = None) -> Internal:
+    """Retrieve a run's captured internals.
+
+    ``source`` is either the ``generate_with_monitoring`` output (its
+    ``model_id`` is used) or a ``model_id`` string. ``reader`` defaults to a
+    local ClickHouse connection (``DMX_DB_HOST`` / ``DMX_DB_PORT``); pass one to
+    read a run from another process or host."""
+    model_id = getattr(source, "model_id", source)
+    reader = reader or _default_reader()
+    rows_by_act: dict[str, list] = {}
+    for key, tensor in reader.prefix_get((model_id,)):
+        rows_by_act.setdefault(key[2], []).append((key, tensor))
+    fields = {
+        field: reassemble(rows_by_act[act])
+        for field, (act, reassemble) in _FIELDS.items()
+        if act in rows_by_act
+    }
+    return Internal(fields)

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -198,6 +198,7 @@ class _Requirement:
     retry: bool = False
     timeout_s: float | None = 30.0
     poll_s: float = 0.25
+    match_token_ranges: bool = False
 
 
 class InternalRequirements:
@@ -205,6 +206,8 @@ class InternalRequirements:
 
     ``count`` validates ``len(field_value)``. For per-layer fields such as
     ``hidden_states``, that means layer count, not token completeness.
+    ``match_token_ranges=True`` additionally validates that captured row ranges
+    match this generate call's expected request token ranges.
     """
 
     def __init__(self, counts: dict[str, int | _Requirement] | None = None) -> None:
@@ -227,6 +230,7 @@ class InternalRequirements:
         retry: bool = False,
         timeout_s: float | None = 30.0,
         poll_s: float = 0.25,
+        match_token_ranges: bool = False,
     ) -> "InternalRequirements":
         if count < 0:
             raise ValueError("count must be non-negative")
@@ -239,6 +243,7 @@ class InternalRequirements:
             retry=bool(retry),
             timeout_s=timeout_s,
             poll_s=float(poll_s),
+            match_token_ranges=bool(match_token_ranges),
         )
         return self
 
@@ -291,6 +296,7 @@ class _LazyInternal:
         retry: bool = False,
         timeout_s: float | None = 30.0,
         poll_s: float = 0.25,
+        match_token_ranges: bool = False,
     ) -> "_LazyInternal":
         self._requirements.require(
             field,
@@ -298,6 +304,7 @@ class _LazyInternal:
             retry=retry,
             timeout_s=timeout_s,
             poll_s=poll_s,
+            match_token_ranges=match_token_ranges,
         )
         return self
 
@@ -366,7 +373,7 @@ class _LazyInternal:
         field: str,
         requirement: _Requirement | None,
     ) -> object:
-        value = self._read_field(field)
+        value = self._read_field(field, requirement)
         self._validate(field, value, requirement)
         self._field_cache[field] = value
         return value
@@ -393,7 +400,55 @@ class _LazyInternal:
             if key[2] == act
         ]
 
-    def _read_field(self, field: str) -> object:
+    def _expected_non_empty_ranges(self, request_id: str) -> tuple[tuple[int, int], ...]:
+        return tuple(
+            (int(start), int(end))
+            for start, end in self._token_ranges.get(request_id, ())
+            if int(end) > int(start)
+        )
+
+    def _actual_ranges_for_request(
+        self,
+        rows: list,
+        request_id: str,
+        layer: int | None,
+    ) -> tuple[tuple[int, int], ...]:
+        ranges = {
+            (int(key[5]), int(key[6]))
+            for key, _ in rows
+            if key[1] == request_id and (layer is None or int(key[3]) == layer)
+            and int(key[6]) > int(key[5])
+        }
+        return tuple(sorted(ranges))
+
+    def _validate_token_ranges(
+        self,
+        field: str,
+        rows: list,
+        requirement: _Requirement | None,
+    ) -> None:
+        if (
+            requirement is None
+            or not requirement.match_token_ranges
+            or not self._request_ids
+            or not self._token_ranges
+        ):
+            return
+        layers = sorted({int(key[3]) for key, _ in rows if int(key[3]) >= 0})
+        # Fast check for per-layer fields: validating the last layer catches the
+        # common "writer still pending" case without scanning every layer.
+        check_layer = layers[-1] if layers else None
+        for request_id in self._request_ids:
+            expected = self._expected_non_empty_ranges(request_id)
+            actual = self._actual_ranges_for_request(rows, request_id, check_layer)
+            if actual != expected:
+                raise IncompleteInternalError(
+                    f"{field} token ranges are incomplete for "
+                    f"model_id={self._model_id!r}, request_id={request_id!r}: "
+                    f"expected {list(expected)}, found {list(actual)}."
+                )
+
+    def _read_field(self, field: str, requirement: _Requirement | None = None) -> object:
         if field == "token_mask":
             return self._build_token_mask()
         if field not in _FIELDS:
@@ -409,6 +464,7 @@ class _LazyInternal:
                 f"{field!r} was not captured in this run. "
                 f"Pass the corresponding hook via hook_selection= when generating."
             )
+        self._validate_token_ranges(field, rows, requirement)
         return reassemble(rows)
 
     def _build_token_mask(self) -> torch.Tensor:

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -11,6 +11,8 @@ needs no change.
 from __future__ import annotations
 
 import os
+import time
+from dataclasses import dataclass
 
 import torch
 
@@ -91,23 +93,63 @@ class IncompleteInternalError(RuntimeError):
     """Raised when a required internal field is present but incomplete."""
 
 
+@dataclass(frozen=True)
+class _Requirement:
+    count: int
+    retry: bool = False
+    timeout_s: float | None = 30.0
+    poll_s: float = 0.25
+
+
 class InternalRequirements:
     """Reusable strictness policy for lazy internal fields."""
 
-    def __init__(self, counts: dict[str, int] | None = None) -> None:
-        self._counts = dict(counts or {})
+    def __init__(self, counts: dict[str, int | _Requirement] | None = None) -> None:
+        self._requirements = {
+            field: self._coerce_requirement(value)
+            for field, value in dict(counts or {}).items()
+        }
 
-    def require(self, field: str, *, count: int) -> "InternalRequirements":
+    @staticmethod
+    def _coerce_requirement(value: int | _Requirement) -> _Requirement:
+        if isinstance(value, _Requirement):
+            return value
+        return _Requirement(count=int(value))
+
+    def require(
+        self,
+        field: str,
+        *,
+        count: int,
+        retry: bool = False,
+        timeout_s: float | None = 30.0,
+        poll_s: float = 0.25,
+    ) -> "InternalRequirements":
         if count < 0:
             raise ValueError("count must be non-negative")
-        self._counts[field] = int(count)
+        if timeout_s is not None and timeout_s < 0:
+            raise ValueError("timeout_s must be non-negative or None")
+        if poll_s <= 0:
+            raise ValueError("poll_s must be positive")
+        self._requirements[field] = _Requirement(
+            count=int(count),
+            retry=bool(retry),
+            timeout_s=timeout_s,
+            poll_s=float(poll_s),
+        )
         return self
 
     def copy(self) -> "InternalRequirements":
-        return InternalRequirements(self._counts)
+        return InternalRequirements(self._requirements)
 
     def expected_count(self, field: str) -> int | None:
-        return self._counts.get(field)
+        requirement = self._requirements.get(field)
+        if requirement is None:
+            return None
+        return requirement.count
+
+    def requirement(self, field: str) -> _Requirement | None:
+        return self._requirements.get(field)
 
 
 class _LazyInternal:
@@ -131,8 +173,22 @@ class _LazyInternal:
         )
         self._field_cache: dict[str, object] = {}
 
-    def require(self, field: str, *, count: int) -> "_LazyInternal":
-        self._requirements.require(field, count=count)
+    def require(
+        self,
+        field: str,
+        *,
+        count: int,
+        retry: bool = False,
+        timeout_s: float | None = 30.0,
+        poll_s: float = 0.25,
+    ) -> "_LazyInternal":
+        self._requirements.require(
+            field,
+            count=count,
+            retry=retry,
+            timeout_s=timeout_s,
+            poll_s=poll_s,
+        )
         return self
 
     def clear_cache(self, field: str | None = None) -> None:
@@ -141,37 +197,120 @@ class _LazyInternal:
             return
         self._field_cache.pop(field, None)
 
-    def _validate(self, field: str, value: object) -> None:
-        expected = self._requirements.expected_count(field)
-        if expected is None:
-            return
+    def _count_value(self, field: str, value: object) -> int:
         try:
-            found = len(value)  # type: ignore[arg-type]
+            return len(value)  # type: ignore[arg-type]
         except TypeError as exc:
             raise IncompleteInternalError(
                 f"{field} cannot be validated for model_id={self._model_id!r}: "
                 "value has no length."
             ) from exc
-        if found != expected:
-            raise IncompleteInternalError(
-                f"{field} is incomplete for model_id={self._model_id!r}: "
-                f"expected {expected} entries, found {found}."
+
+    def _incomplete_error(
+        self,
+        field: str,
+        requirement: _Requirement,
+        *,
+        found: int | None = None,
+        timeout: bool = False,
+        cause: Exception | None = None,
+    ) -> IncompleteInternalError:
+        if found is None:
+            detail = f"expected {requirement.count} entries, found none"
+        else:
+            detail = f"expected {requirement.count} entries, found {found}"
+        if timeout:
+            timeout_text = (
+                "without timeout"
+                if requirement.timeout_s is None
+                else f"within {requirement.timeout_s:.3g}s"
             )
+            detail = f"{detail} {timeout_text}"
+        message = (
+            f"{field} is incomplete for model_id={self._model_id!r}: "
+            f"{detail}."
+        )
+        error = IncompleteInternalError(message)
+        error.field = field  # type: ignore[attr-defined]
+        error.expected = requirement.count  # type: ignore[attr-defined]
+        error.found = found  # type: ignore[attr-defined]
+        if cause is not None:
+            error.__cause__ = cause
+        return error
+
+    def _validate(
+        self,
+        field: str,
+        value: object,
+        requirement: _Requirement | None = None,
+    ) -> None:
+        requirement = requirement or self._requirements.requirement(field)
+        if requirement is None:
+            return
+        found = self._count_value(field, value)
+        if found != requirement.count:
+            raise self._incomplete_error(field, requirement, found=found)
+
+    def _load_field_once(
+        self,
+        field: str,
+        requirement: _Requirement | None,
+    ) -> object:
+        internal = get_internal(self._model_id, self._reader)
+        value = getattr(internal, field)
+        self._validate(field, value, requirement)
+        self._field_cache[field] = value
+        return value
+
+    def _load_field_with_retry(
+        self,
+        field: str,
+        requirement: _Requirement,
+    ) -> object:
+        deadline = (
+            None
+            if requirement.timeout_s is None
+            else time.monotonic() + requirement.timeout_s
+        )
+        last_error: Exception | None = None
+        last_found: int | None = None
+
+        while True:
+            try:
+                return self._load_field_once(field, requirement)
+            except IncompleteInternalError as exc:
+                last_error = exc
+                last_found = getattr(exc, "found", None)
+                if field in self._field_cache:
+                    self._field_cache.pop(field, None)
+            except AttributeError as exc:
+                last_error = exc
+
+            if deadline is not None and time.monotonic() >= deadline:
+                raise self._incomplete_error(
+                    field,
+                    requirement,
+                    found=last_found,
+                    timeout=True,
+                    cause=last_error,
+                )
+            time.sleep(requirement.poll_s)
 
     def _load_field(self, field: str) -> object:
+        requirement = self._requirements.requirement(field)
         if field in self._field_cache:
             value = self._field_cache[field]
             try:
-                self._validate(field, value)
+                self._validate(field, value, requirement)
             except Exception:
                 self._field_cache.pop(field, None)
-                raise
+                if requirement is None or not requirement.retry:
+                    raise
+                return self._load_field_with_retry(field, requirement)
             return value
-        internal = get_internal(self._model_id, self._reader)
-        value = getattr(internal, field)
-        self._validate(field, value)
-        self._field_cache[field] = value
-        return value
+        if requirement is not None and requirement.retry:
+            return self._load_field_with_retry(field, requirement)
+        return self._load_field_once(field, requirement)
 
     @property
     def available(self) -> list[str]:

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -87,14 +87,119 @@ class Internal:
         )
 
 
-def get_internal(source, reader: CHClickhouseDriverReadOnly | None = None) -> Internal:
+class IncompleteInternalError(RuntimeError):
+    """Raised when a required internal field is present but incomplete."""
+
+
+class InternalRequirements:
+    """Reusable strictness policy for lazy internal fields."""
+
+    def __init__(self, counts: dict[str, int] | None = None) -> None:
+        self._counts = dict(counts or {})
+
+    def require(self, field: str, *, count: int) -> "InternalRequirements":
+        if count < 0:
+            raise ValueError("count must be non-negative")
+        self._counts[field] = int(count)
+        return self
+
+    def copy(self) -> "InternalRequirements":
+        return InternalRequirements(self._counts)
+
+    def expected_count(self, field: str) -> int | None:
+        return self._counts.get(field)
+
+
+class _LazyInternal:
+    """Lazy proxy for captured internals.
+
+    Successful field access caches that field. Failed loads and incomplete
+    fields are passed through unchanged and are not cached, so later accesses
+    retry.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        reader: CHClickhouseDriverReadOnly | None = None,
+        requirements: InternalRequirements | None = None,
+    ) -> None:
+        self._model_id = model_id
+        self._reader = reader
+        self._requirements = (
+            requirements.copy() if requirements is not None else InternalRequirements()
+        )
+        self._field_cache: dict[str, object] = {}
+
+    def require(self, field: str, *, count: int) -> "_LazyInternal":
+        self._requirements.require(field, count=count)
+        return self
+
+    def clear_cache(self, field: str | None = None) -> None:
+        if field is None:
+            self._field_cache.clear()
+            return
+        self._field_cache.pop(field, None)
+
+    def _validate(self, field: str, value: object) -> None:
+        expected = self._requirements.expected_count(field)
+        if expected is None:
+            return
+        try:
+            found = len(value)  # type: ignore[arg-type]
+        except TypeError as exc:
+            raise IncompleteInternalError(
+                f"{field} cannot be validated for model_id={self._model_id!r}: "
+                "value has no length."
+            ) from exc
+        if found != expected:
+            raise IncompleteInternalError(
+                f"{field} is incomplete for model_id={self._model_id!r}: "
+                f"expected {expected} entries, found {found}."
+            )
+
+    def _load_field(self, field: str) -> object:
+        if field in self._field_cache:
+            value = self._field_cache[field]
+            try:
+                self._validate(field, value)
+            except Exception:
+                self._field_cache.pop(field, None)
+                raise
+            return value
+        internal = get_internal(self._model_id, self._reader)
+        value = getattr(internal, field)
+        self._validate(field, value)
+        self._field_cache[field] = value
+        return value
+
+    @property
+    def available(self) -> list[str]:
+        return get_internal(self._model_id, self._reader).available
+
+    def __getattr__(self, name: str):
+        return self._load_field(name)
+
+    def __repr__(self) -> str:
+        state = f"cached={sorted(self._field_cache)}" if self._field_cache else "pending"
+        return f"<DMIInternal model_id={self._model_id!r} state={state}>"
+
+
+def make_lazy_internal(
+    model_id: str,
+    reader: CHClickhouseDriverReadOnly | None = None,
+    requirements: InternalRequirements | None = None,
+) -> _LazyInternal:
+    return _LazyInternal(model_id, reader, requirements=requirements)
+
+
+def get_internal(model_id: str, reader: CHClickhouseDriverReadOnly | None = None) -> Internal:
     """Retrieve a run's captured internals.
 
-    ``source`` is either the ``generate_with_monitoring`` output (its
-    ``model_id`` is used) or a ``model_id`` string. ``reader`` defaults to a
-    local ClickHouse connection (``DMX_DB_HOST`` / ``DMX_DB_PORT``); pass one to
-    read a run from another process or host."""
-    model_id = getattr(source, "model_id", source)
+    ``model_id`` identifies the captured run. ``reader`` defaults to a local
+    ClickHouse connection (``DMX_DB_HOST`` / ``DMX_DB_PORT``); pass one to read
+    a run from another process or host.
+    """
     reader = reader or _default_reader()
     rows_by_act: dict[str, list] = {}
     for key, tensor in reader.prefix_get((model_id,)):

--- a/tests/test_hf_adapter_dict_api.py
+++ b/tests/test_hf_adapter_dict_api.py
@@ -25,7 +25,7 @@ def test_generate_with_monitoring_dict_forces_dict_and_attaches_lazy(monkeypatch
 
     def fake_impl(model, *args, **kwargs):
         captured.update(kwargs)
-        return output, "run-id"
+        return output, "run-id", ("0:0",), {"0:0": ((0, 2),)}
 
     monkeypatch.setattr(hf_adapter, "_generate_with_monitoring_impl", fake_impl)
 
@@ -38,10 +38,12 @@ def test_generate_with_monitoring_dict_forces_dict_and_attaches_lazy(monkeypatch
 
     assert result is output
     assert captured["return_dict_in_generate"] is True
-    assert captured["_return_model_id"] is True
+    assert captured["_return_internal_metadata"] is True
     assert "reader" not in captured
     assert "internal_requirements" not in captured
     assert repr(result.dmi_internal) == "<DMIInternal model_id='run-id' state=pending>"
+    assert result.dmi_internal._request_ids == ("0:0",)
+    assert result.dmi_internal._token_ranges == {"0:0": ((0, 2),)}
     result.dmi_internal.require("hidden_states", count=1)
     assert requirements.expected_count("hidden_states") == 2
 
@@ -52,7 +54,7 @@ def test_generate_with_monitoring_dict_warns_when_false_is_overridden(monkeypatc
 
     def fake_impl(model, *args, **kwargs):
         captured.update(kwargs)
-        return output, "run-id"
+        return output, "run-id", (), {}
 
     monkeypatch.setattr(hf_adapter, "_generate_with_monitoring_impl", fake_impl)
 

--- a/tests/test_hf_adapter_dict_api.py
+++ b/tests/test_hf_adapter_dict_api.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from integration import hf_adapter
+from monitoring.internal_mapper import InternalRequirements
+
+
+def test_generate_with_monitoring_returns_impl_output_unchanged(monkeypatch):
+    expected = object()
+
+    def fake_impl(model, *args, **kwargs):
+        return expected
+
+    monkeypatch.setattr(hf_adapter, "_generate_with_monitoring_impl", fake_impl)
+
+    assert hf_adapter.generate_with_monitoring(object(), max_new_tokens=1) is expected
+
+
+def test_generate_with_monitoring_dict_forces_dict_and_attaches_lazy(monkeypatch):
+    output = SimpleNamespace(sequences="tokens")
+    captured = {}
+    reader = object()
+    requirements = InternalRequirements().require("hidden_states", count=2)
+
+    def fake_impl(model, *args, **kwargs):
+        captured.update(kwargs)
+        return output, "run-id"
+
+    monkeypatch.setattr(hf_adapter, "_generate_with_monitoring_impl", fake_impl)
+
+    result = hf_adapter.generate_with_monitoring_dict(
+        object(),
+        max_new_tokens=1,
+        reader=reader,
+        internal_requirements=requirements,
+    )
+
+    assert result is output
+    assert captured["return_dict_in_generate"] is True
+    assert captured["_return_model_id"] is True
+    assert "reader" not in captured
+    assert "internal_requirements" not in captured
+    assert repr(result.dmi_internal) == "<DMIInternal model_id='run-id' state=pending>"
+    result.dmi_internal.require("hidden_states", count=1)
+    assert requirements.expected_count("hidden_states") == 2
+
+
+def test_generate_with_monitoring_dict_warns_when_false_is_overridden(monkeypatch):
+    output = SimpleNamespace(sequences="tokens")
+    captured = {}
+
+    def fake_impl(model, *args, **kwargs):
+        captured.update(kwargs)
+        return output, "run-id"
+
+    monkeypatch.setattr(hf_adapter, "_generate_with_monitoring_impl", fake_impl)
+
+    with pytest.warns(UserWarning, match="overriding the supplied False value"):
+        hf_adapter.generate_with_monitoring_dict(
+            object(),
+            return_dict_in_generate=False,
+        )
+
+    assert captured["return_dict_in_generate"] is True

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -35,6 +35,20 @@ class FailingOnceReader:
         return self._rows
 
 
+class SequenceReader:
+    def __init__(self, row_sets):
+        self._row_sets = list(row_sets)
+        self.calls = 0
+
+    def prefix_get(self, prefix):
+        self.calls += 1
+        idx = min(self.calls - 1, len(self._row_sets) - 1)
+        rows = self._row_sets[idx]
+        if isinstance(rows, Exception):
+            raise rows
+        return rows
+
+
 def _row(req, layer, start, tensor):
     # key = (model_id, request_id, act_name, layer_no, shard_rank, start, end)
     return ((("m", req, ACT, layer, 0, start, start + tensor.shape[0])), tensor)
@@ -151,6 +165,61 @@ def test_lazy_internal_requirement_blocks_incomplete_cache():
         internal.hidden_states
 
     assert reader.calls == 2
+
+
+def test_lazy_internal_requirement_retries_missing_until_success():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = SequenceReader([[], rows])
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=1, retry=True, timeout_s=1.0, poll_s=0.001)
+
+    assert len(internal.hidden_states) == 1
+    assert reader.calls == 2
+
+
+def test_lazy_internal_requirement_retries_incomplete_until_success():
+    one_layer = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    two_layers = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),
+        _row("0:0", 1, 0, torch.ones(3, 4)),
+    ]
+    reader = SequenceReader([one_layer, two_layers])
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=2, retry=True, timeout_s=1.0, poll_s=0.001)
+
+    assert len(internal.hidden_states) == 2
+    assert reader.calls == 2
+
+
+def test_lazy_internal_requirement_retry_timeout_raises_incomplete():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = SequenceReader([rows])
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=2, retry=True, timeout_s=0.0, poll_s=0.001)
+
+    with pytest.raises(IncompleteInternalError, match="expected 2 entries, found 1"):
+        internal.hidden_states
+    assert reader.calls == 1
+
+
+def test_lazy_internal_requirement_can_retry_without_timeout():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = SequenceReader([[], [], rows])
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=1, retry=True, timeout_s=None, poll_s=0.001)
+
+    assert len(internal.hidden_states) == 1
+    assert reader.calls == 3
+
+
+def test_lazy_internal_retry_does_not_swallow_unexpected_errors():
+    reader = SequenceReader([RuntimeError("boom")])
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=1, retry=True, timeout_s=1.0, poll_s=0.001)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        internal.hidden_states
+    assert reader.calls == 1
 
 
 def test_lazy_internal_requirement_revalidates_existing_cache():

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -49,9 +49,31 @@ class SequenceReader:
         return rows
 
 
+class PrefixReader:
+    def __init__(self, rows):
+        self._rows = rows
+        self.prefixes = []
+
+    @property
+    def calls(self):
+        return len(self.prefixes)
+
+    def prefix_get(self, prefix):
+        self.prefixes.append(prefix)
+        return [
+            (key, tensor)
+            for key, tensor in self._rows
+            if key[:len(prefix)] == prefix
+        ]
+
+
 def _row(req, layer, start, tensor):
     # key = (model_id, request_id, act_name, layer_no, shard_rank, start, end)
     return ((("m", req, ACT, layer, 0, start, start + tensor.shape[0])), tensor)
+
+
+def _row_act(req, act, layer, start, end, tensor):
+    return ((("m", req, act, layer, 0, start, end)), tensor)
 
 
 def test_per_layer_tuple_and_shape():
@@ -64,6 +86,44 @@ def test_per_layer_tuple_and_shape():
     hs = internal.hidden_states
     assert len(hs) == 2                       # two layers
     assert tuple(hs[0].shape) == (1, 3, 4)    # [batch, seq, hidden]
+
+
+def test_available_includes_hf_mapped_fields():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),
+        _row_act("0:0", "blocks.attn.hook_pattern", 0, 0, 3, torch.ones(2, 3, 3)),
+        _row_act("0:0", "final_logits", -1, 0, 3, torch.ones(3, 10)),
+    ]
+    internal = get_internal("m", FakeReader(rows))
+
+    assert internal.available == ["attentions", "hidden_states", "logits"]
+
+
+def test_logits_reassemble_global_batch_by_numeric_request_id():
+    rows = [
+        _row_act("0:10", "final_logits", -1, 0, 1, torch.full((1, 2), 10.0)),
+        _row_act("0:2", "final_logits", -1, 0, 1, torch.full((1, 2), 2.0)),
+    ]
+    logits = get_internal("m", FakeReader(rows)).logits
+
+    assert tuple(logits.shape) == (2, 1, 2)
+    assert torch.equal(logits[0, 0], torch.full((2,), 2.0))
+    assert torch.equal(logits[1, 0], torch.full((2,), 10.0))
+
+
+def test_attentions_reassemble_per_layer_with_decode_growth():
+    prefill = torch.ones(2, 2, 2)
+    decode = torch.ones(2, 1, 3) * 2
+    rows = [
+        _row_act("0:0", "blocks.attn.hook_pattern", 0, 0, 2, prefill),
+        _row_act("0:0", "blocks.attn.hook_pattern", 0, 2, 3, decode),
+    ]
+    attentions = get_internal("m", FakeReader(rows)).attentions
+
+    assert len(attentions) == 1
+    assert tuple(attentions[0].shape) == (1, 2, 3, 3)
+    assert torch.equal(attentions[0][0, :, :2, :2], prefill)
+    assert torch.equal(attentions[0][0, :, 2:, :], decode)
 
 
 def test_chunks_concat_by_start():
@@ -113,6 +173,51 @@ def test_lazy_internal_loads_once_after_success():
     assert internal.hidden_states[0].shape == (1, 3, 4)
     assert reader.calls == 1
     assert "cached=['hidden_states']" in repr(internal)
+
+
+def test_lazy_internal_with_request_ids_reads_only_requested_act_prefixes():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),
+        _row("0:1", 0, 0, torch.ones(2, 4) * 2),
+        _row_act("0:0", "final_logits", -1, 0, 3, torch.ones(3, 10)),
+        _row_act("other:0", ACT, 0, 0, 1, torch.ones(1, 4) * 9),
+    ]
+    reader = PrefixReader(rows)
+    internal = make_lazy_internal("m", reader, request_ids=("0:0", "0:1"))
+
+    hs = internal.hidden_states
+
+    assert tuple(hs[0].shape) == (2, 3, 4)
+    assert reader.prefixes == [
+        ("m", "0:0", ACT),
+        ("m", "0:1", ACT),
+    ]
+
+
+def test_lazy_internal_token_mask_uses_recorded_ranges_without_reader():
+    reader = PrefixReader([])
+    internal = make_lazy_internal(
+        "m",
+        reader,
+        request_ids=("0:0", "0:1"),
+        token_ranges={
+            "0:0": ((0, 3), (3, 4)),
+            "0:1": ((0, 2), (2, 2)),
+        },
+    )
+
+    mask = internal.token_mask
+
+    assert mask.dtype == torch.bool
+    assert torch.equal(
+        mask,
+        torch.tensor([
+            [True, True, True, True],
+            [False, False, True, True],
+        ]),
+    )
+    assert reader.calls == 0
+    assert internal.token_mask is mask
 
 
 def test_lazy_internal_retries_after_failed_load():

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -93,10 +93,20 @@ def test_available_includes_hf_mapped_fields():
         _row("0:0", 0, 0, torch.ones(3, 4)),
         _row_act("0:0", "blocks.attn.hook_pattern", 0, 0, 3, torch.ones(2, 3, 3)),
         _row_act("0:0", "final_logits", -1, 0, 3, torch.ones(3, 10)),
+        _row_act("0:0", "token_ids", -1, 0, 3, torch.arange(3)),
+        _row_act("0:0", "hook_embed", -1, 0, 3, torch.ones(3, 4)),
+        _row_act("0:0", "blocks.attn.hook_q", 0, 0, 3, torch.ones(3, 2, 2)),
     ]
     internal = get_internal("m", FakeReader(rows))
 
-    assert internal.available == ["attentions", "hidden_states", "logits"]
+    assert internal.available == [
+        "attentions",
+        "embeddings",
+        "hidden_states",
+        "logits",
+        "q",
+        "token_ids",
+    ]
 
 
 def test_logits_reassemble_global_batch_by_numeric_request_id():
@@ -109,6 +119,40 @@ def test_logits_reassemble_global_batch_by_numeric_request_id():
     assert tuple(logits.shape) == (2, 1, 2)
     assert torch.equal(logits[0, 0], torch.full((2,), 2.0))
     assert torch.equal(logits[1, 0], torch.full((2,), 10.0))
+
+
+def test_token_ids_reassemble_global_1d():
+    rows = [
+        _row_act("0:0", "token_ids", -1, 0, 2, torch.tensor([10, 11])),
+        _row_act("0:1", "token_ids", -1, 0, 1, torch.tensor([20])),
+    ]
+    token_ids = get_internal("m", FakeReader(rows)).token_ids
+
+    assert torch.equal(token_ids, torch.tensor([[10, 11], [0, 20]]))
+
+
+def test_embeddings_reassemble_global_hidden_field():
+    rows = [
+        _row_act("0:0", "hook_embed", -1, 0, 2, torch.ones(2, 4)),
+        _row_act("0:1", "hook_embed", -1, 0, 1, torch.ones(1, 4) * 2),
+    ]
+    embeddings = get_internal("m", FakeReader(rows)).embeddings
+
+    assert tuple(embeddings.shape) == (2, 2, 4)
+    assert torch.equal(embeddings[1, 0], torch.zeros(4))
+    assert torch.equal(embeddings[1, 1], torch.ones(4) * 2)
+
+
+def test_q_reassemble_per_layer():
+    rows = [
+        _row_act("0:0", "blocks.attn.hook_q", 0, 0, 2, torch.ones(2, 2, 3)),
+        _row_act("0:0", "blocks.attn.hook_q", 1, 0, 2, torch.ones(2, 2, 3) * 2),
+    ]
+    q = get_internal("m", FakeReader(rows)).q
+
+    assert len(q) == 2
+    assert tuple(q[0].shape) == (1, 2, 2, 3)
+    assert torch.equal(q[1], torch.ones(1, 2, 2, 3) * 2)
 
 
 def test_attentions_reassemble_per_layer_with_decode_growth():
@@ -124,6 +168,21 @@ def test_attentions_reassemble_per_layer_with_decode_growth():
     assert tuple(attentions[0].shape) == (1, 2, 3, 3)
     assert torch.equal(attentions[0][0, :, :2, :2], prefill)
     assert torch.equal(attentions[0][0, :, 2:, :], decode)
+
+
+def test_attention_scores_reassemble_with_negative_inf_padding():
+    prefill = torch.ones(1, 2, 2)
+    decode = torch.ones(1, 1, 3) * 2
+    rows = [
+        _row_act("0:0", "blocks.attn.hook_attn_scores", 0, 0, 2, prefill),
+        _row_act("0:0", "blocks.attn.hook_attn_scores", 0, 2, 3, decode),
+    ]
+    scores = get_internal("m", FakeReader(rows)).attention_scores
+
+    assert tuple(scores[0].shape) == (1, 1, 3, 3)
+    assert torch.isneginf(scores[0][0, 0, 0, 2])
+    assert torch.equal(scores[0][0, :, :2, :2], prefill)
+    assert torch.equal(scores[0][0, :, 2:, :], decode)
 
 
 def test_chunks_concat_by_start():

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -1,0 +1,73 @@
+"""Unit tests for monitoring.internal_mapper -- pure reassembly logic, no DB."""
+import pytest
+import torch
+
+from monitoring.internal_mapper import get_internal
+
+ACT = "blocks.hook_resid_pre"
+
+
+class FakeReader:
+    """Returns canned (key, tensor) rows regardless of the prefix."""
+    def __init__(self, rows):
+        self._rows = rows
+
+    def prefix_get(self, prefix):
+        return self._rows
+
+
+def _row(req, layer, start, tensor):
+    # key = (model_id, request_id, act_name, layer_no, shard_rank, start, end)
+    return ((("m", req, ACT, layer, 0, start, start + tensor.shape[0])), tensor)
+
+
+def test_per_layer_tuple_and_shape():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),
+        _row("0:0", 1, 0, torch.ones(3, 4) * 5),
+    ]
+    internal = get_internal("m", FakeReader(rows))
+    assert internal.available == ["hidden_states"]
+    hs = internal.hidden_states
+    assert len(hs) == 2                       # two layers
+    assert tuple(hs[0].shape) == (1, 3, 4)    # [batch, seq, hidden]
+
+
+def test_chunks_concat_by_start():
+    rows = [
+        _row("0:0", 0, 2, torch.full((1, 4), 9.0)),  # out-of-order on purpose
+        _row("0:0", 0, 0, torch.full((2, 4), 1.0)),
+    ]
+    hs = get_internal("m", FakeReader(rows)).hidden_states
+    assert tuple(hs[0].shape) == (1, 3, 4)
+    assert torch.equal(hs[0][0, :2], torch.full((2, 4), 1.0))
+    assert torch.equal(hs[0][0, 2], torch.full((4,), 9.0))
+
+
+def test_ragged_batch_left_pads():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),   # 3 tokens
+        _row("0:1", 0, 0, torch.ones(2, 4) * 2),  # 2 tokens -> left-pad to 3
+    ]
+    hs = get_internal("m", FakeReader(rows)).hidden_states
+    assert tuple(hs[0].shape) == (2, 3, 4)
+    assert torch.equal(hs[0][1, 0], torch.zeros(4))        # front row padded
+    assert torch.equal(hs[0][1, 1:], torch.ones(2, 4) * 2)  # real tokens right-aligned
+
+
+def test_uncaptured_field_raises():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    internal = get_internal("m", FakeReader(rows))
+    with pytest.raises(AttributeError, match="not captured"):
+        internal.attention
+
+
+def test_source_accepts_out_or_model_id():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+
+    class Out:
+        model_id = "m"
+
+    assert get_internal(Out(), reader).available == ["hidden_states"]
+    assert get_internal("m", reader).available == ["hidden_states"]

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -355,6 +355,47 @@ def test_lazy_internal_requirement_retries_incomplete_until_success():
     assert reader.calls == 2
 
 
+def test_lazy_internal_requirement_detects_missing_token_ranges():
+    rows = [_row("0:0", 0, 0, torch.ones(2, 4))]
+    reader = PrefixReader(rows)
+    internal = make_lazy_internal(
+        "m",
+        reader,
+        request_ids=("0:0",),
+        token_ranges={"0:0": ((0, 2), (2, 3))},
+    )
+    internal.require("hidden_states", count=1, match_token_ranges=True)
+
+    with pytest.raises(IncompleteInternalError, match="token ranges are incomplete"):
+        internal.hidden_states
+
+
+def test_lazy_internal_requirement_retries_missing_token_ranges_until_success():
+    partial = [_row("0:0", 0, 0, torch.ones(2, 4))]
+    complete = [
+        _row("0:0", 0, 0, torch.ones(2, 4)),
+        _row("0:0", 0, 2, torch.ones(1, 4)),
+    ]
+    reader = SequenceReader([partial, complete])
+    internal = make_lazy_internal(
+        "m",
+        reader,
+        request_ids=("0:0",),
+        token_ranges={"0:0": ((0, 2), (2, 3))},
+    )
+    internal.require(
+        "hidden_states",
+        count=1,
+        retry=True,
+        timeout_s=1.0,
+        poll_s=0.001,
+        match_token_ranges=True,
+    )
+
+    assert tuple(internal.hidden_states[0].shape) == (1, 3, 4)
+    assert reader.calls == 2
+
+
 def test_lazy_internal_requirement_retry_timeout_raises_incomplete():
     rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
     reader = SequenceReader([rows])

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -2,7 +2,12 @@
 import pytest
 import torch
 
-from monitoring.internal_mapper import get_internal
+from monitoring.internal_mapper import (
+    IncompleteInternalError,
+    InternalRequirements,
+    get_internal,
+    make_lazy_internal,
+)
 
 ACT = "blocks.hook_resid_pre"
 
@@ -11,8 +16,22 @@ class FakeReader:
     """Returns canned (key, tensor) rows regardless of the prefix."""
     def __init__(self, rows):
         self._rows = rows
+        self.calls = 0
 
     def prefix_get(self, prefix):
+        self.calls += 1
+        return self._rows
+
+
+class FailingOnceReader:
+    def __init__(self, rows):
+        self._rows = rows
+        self.calls = 0
+
+    def prefix_get(self, prefix):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("temporary failure")
         return self._rows
 
 
@@ -62,12 +81,106 @@ def test_uncaptured_field_raises():
         internal.attention
 
 
-def test_source_accepts_out_or_model_id():
+def test_get_internal_accepts_model_id():
     rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
     reader = FakeReader(rows)
 
-    class Out:
-        model_id = "m"
-
-    assert get_internal(Out(), reader).available == ["hidden_states"]
     assert get_internal("m", reader).available == ["hidden_states"]
+
+
+def test_lazy_internal_loads_once_after_success():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+    internal = make_lazy_internal("m", reader)
+
+    assert "pending" in repr(internal)
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 1
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 1
+    assert "cached=['hidden_states']" in repr(internal)
+
+
+def test_lazy_internal_retries_after_failed_load():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FailingOnceReader(rows)
+    internal = make_lazy_internal("m", reader)
+
+    with pytest.raises(RuntimeError, match="temporary failure"):
+        internal.hidden_states
+
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 2
+
+
+def test_lazy_internal_clear_cache_one_field():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+    internal = make_lazy_internal("m", reader)
+
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 1
+
+    internal.clear_cache("hidden_states")
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 2
+
+
+def test_lazy_internal_clear_cache_all_fields():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+    internal = make_lazy_internal("m", reader)
+
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    internal.clear_cache()
+    assert internal.hidden_states[0].shape == (1, 3, 4)
+    assert reader.calls == 2
+
+
+def test_lazy_internal_requirement_blocks_incomplete_cache():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+    internal = make_lazy_internal("m", reader)
+    internal.require("hidden_states", count=2)
+
+    with pytest.raises(IncompleteInternalError, match="expected 2 entries, found 1"):
+        internal.hidden_states
+
+    with pytest.raises(IncompleteInternalError, match="expected 2 entries, found 1"):
+        internal.hidden_states
+
+    assert reader.calls == 2
+
+
+def test_lazy_internal_requirement_revalidates_existing_cache():
+    rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
+    reader = FakeReader(rows)
+    internal = make_lazy_internal("m", reader)
+
+    assert len(internal.hidden_states) == 1
+    internal.require("hidden_states", count=2)
+
+    with pytest.raises(IncompleteInternalError, match="expected 2 entries, found 1"):
+        internal.hidden_states
+
+    assert reader.calls == 1
+    with pytest.raises(IncompleteInternalError, match="expected 2 entries, found 1"):
+        internal.hidden_states
+    assert reader.calls == 2
+
+
+def test_lazy_internal_copies_reusable_requirements():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(3, 4)),
+        _row("0:0", 1, 0, torch.ones(3, 4)),
+    ]
+    reqs = InternalRequirements().require("hidden_states", count=2)
+    first = make_lazy_internal("m", FakeReader(rows), requirements=reqs)
+    second = make_lazy_internal("m", FakeReader(rows), requirements=reqs)
+
+    first.require("hidden_states", count=1)
+
+    with pytest.raises(IncompleteInternalError, match="expected 1 entries, found 2"):
+        first.hidden_states
+    assert len(second.hidden_states) == 2

--- a/tests/test_internal_mapper_e2e.py
+++ b/tests/test_internal_mapper_e2e.py
@@ -143,18 +143,21 @@ def test_output_matches_plain_hf(single):
 
 def test_available_lists_captured_field(single, deps):
     internal = single.out.dmi_internal
-    assert internal.available == ["hidden_states"]
+    assert internal.available == ["hidden_states", "token_mask"]
 
 
 def test_hidden_states_tuple_shape(single, deps):
     internal = single.out.dmi_internal
     hs = internal.hidden_states
+    token_mask = internal.token_mask
     cfg = single.model.config
     assert len(hs) == cfg.num_hidden_layers          # one entry per block (resid_pre)
     assert all(t.dim() == 3 for t in hs)             # [batch, seq, hidden]
     assert hs[0].shape[0] == 1                        # batch
     assert hs[0].shape[2] == cfg.hidden_size         # hidden
     assert all(t.shape == hs[0].shape for t in hs)   # uniform across layers
+    assert token_mask.shape == hs[0].shape[:2]
+    assert token_mask.dtype == torch.bool
 
 
 def test_token_count_drops_unforwarded_last(single, deps):

--- a/tests/test_internal_mapper_e2e.py
+++ b/tests/test_internal_mapper_e2e.py
@@ -47,7 +47,7 @@ def deps():
         from monitoring._native_engine import ClickHouseClientConfig, StageConfig
         from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
         from monitoring.internal_mapper import get_internal
-        from integration.hf_adapter import generate_with_monitoring, MonitoredGenerateOutput
+        from integration.hf_adapter import generate_with_monitoring_dict
         import clickhouse_driver
     except Exception as exc:
         pytest.skip(f"DMI HF stack unavailable: {exc}")
@@ -66,7 +66,7 @@ def _wipe(deps, model_id):
 
 
 def _monitored(deps, model, inputs, model_id, hook_selection="resid_pre"):
-    """Run generate_with_monitoring into a fresh ClickHouse slot, return the output."""
+    """Run generate_with_monitoring_dict into a fresh ClickHouse slot."""
     _wipe(deps, model_id)
     host, port = _db_host_port()
     db = deps.ClickHouseClientConfig()
@@ -83,7 +83,7 @@ def _monitored(deps, model, inputs, model_id, hook_selection="resid_pre"):
     model.monitoring_engine = engine
     try:
         with torch.no_grad():
-            return deps.generate_with_monitoring(
+            return deps.generate_with_monitoring_dict(
                 model, **inputs, max_new_tokens=MAX_NEW, do_sample=False,
                 hook_selection=hook_selection,
             )
@@ -112,7 +112,7 @@ def single(deps, model_tok):
         ref = model.generate(**inputs, max_new_tokens=MAX_NEW, do_sample=False)
     model_id = f"test_internal::single::{uuid.uuid4().hex}"[:120]
     out = _monitored(deps, model, inputs, model_id)
-    yield SimpleNamespace(out=out, ref=ref, model=model)
+    yield SimpleNamespace(out=out, ref=ref, model=model, model_id=model_id)
     _wipe(deps, model_id)
 
 
@@ -123,16 +123,15 @@ def ragged(deps, model_tok):
     inputs = tok(["The capital of France is", "Hi"], return_tensors="pt", padding=True).to("cuda")
     model_id = f"test_internal::ragged::{uuid.uuid4().hex}"[:120]
     out = _monitored(deps, model, inputs, model_id)
-    yield SimpleNamespace(out=out, n_prompts=2)
+    yield SimpleNamespace(out=out, n_prompts=2, model_id=model_id)
     _wipe(deps, model_id)
 
 
-# --- wrapper return shape ---------------------------------------------------
+# --- dict return shape ------------------------------------------------------
 
-def test_returns_monitored_output(single, deps):
-    assert isinstance(single.out, deps.MonitoredGenerateOutput)
-    assert isinstance(single.out.model_id, str) and single.out.model_id
+def test_returns_dict_output_with_dmi_internal(single):
     assert single.out.sequences.dim() == 2  # [batch, total_len]
+    assert hasattr(single.out, "dmi_internal")
 
 
 def test_output_matches_plain_hf(single):
@@ -143,12 +142,12 @@ def test_output_matches_plain_hf(single):
 # --- get_internal: structure ------------------------------------------------
 
 def test_available_lists_captured_field(single, deps):
-    internal = deps.get_internal(single.out)
+    internal = single.out.dmi_internal
     assert internal.available == ["hidden_states"]
 
 
 def test_hidden_states_tuple_shape(single, deps):
-    internal = deps.get_internal(single.out)
+    internal = single.out.dmi_internal
     hs = internal.hidden_states
     cfg = single.model.config
     assert len(hs) == cfg.num_hidden_layers          # one entry per block (resid_pre)
@@ -161,23 +160,23 @@ def test_hidden_states_tuple_shape(single, deps):
 def test_token_count_drops_unforwarded_last(single, deps):
     # The final generated token is never fed through a forward, so it has no
     # captured hidden state: captured seq == sequence length - 1.
-    hs = deps.get_internal(single.out).hidden_states
+    hs = single.out.dmi_internal.hidden_states
     assert hs[0].shape[1] == single.out.sequences.shape[1] - 1
 
 
-# --- get_internal: source + reader handling --------------------------------
+# --- get_internal: model_id + reader handling ------------------------------
 
 def test_source_model_id_with_explicit_reader(single, deps):
     host, port = _db_host_port()
     reader = deps.CHClickhouseDriverReadOnly(host=host, port=port)
-    from_out = deps.get_internal(single.out).hidden_states
-    from_id = deps.get_internal(single.out.model_id, reader).hidden_states
+    from_out = single.out.dmi_internal.hidden_states
+    from_id = deps.get_internal(single.model_id, reader).hidden_states
     assert len(from_out) == len(from_id)
     assert torch.equal(from_out[0], from_id[0])
 
 
 def test_uncaptured_field_raises(single, deps):
-    internal = deps.get_internal(single.out)
+    internal = single.out.dmi_internal
     with pytest.raises(AttributeError, match="not captured"):
         internal.attention
 
@@ -185,7 +184,7 @@ def test_uncaptured_field_raises(single, deps):
 # --- get_internal: ragged batch left-pad -----------------------------------
 
 def test_ragged_batch_left_pads(ragged, deps):
-    hs = deps.get_internal(ragged.out).hidden_states
+    hs = ragged.out.dmi_internal.hidden_states
     layer0 = hs[0]
     assert layer0.shape[0] == ragged.n_prompts
 

--- a/tests/test_internal_mapper_e2e.py
+++ b/tests/test_internal_mapper_e2e.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for the get_internal read path.
+
+Runs Qwen3-0.6B through generate_with_monitoring (writing captures to
+ClickHouse via the native ring), then reads them back with
+monitoring.internal_mapper.get_internal and checks the result lines up with
+HuggingFace's native output.
+
+Requires a CUDA device, a reachable ClickHouse, the patched transformers fork,
+and the model in the local cache; skips cleanly otherwise.
+
+ClickHouse connection: DMX_DB_HOST / DMX_DB_PORT (default localhost:9000).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests._requirements import require_cuda, require_clickhouse, require_model_cache
+
+MODEL = "Qwen/Qwen3-0.6B"
+MAX_NEW = 8
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.e2e,
+    pytest.mark.clickhouse,
+    pytest.mark.hf,
+    require_cuda(),
+    require_clickhouse(),
+    require_model_cache(MODEL),
+]
+
+
+@pytest.fixture(scope="module")
+def deps():
+    """Import the DMI HF stack; skip the module if any piece is missing."""
+    try:
+        from transformers import AutoTokenizer
+        from transformers.models.qwen3_p.modeling_qwen3 import HookedQwen3ForCausalLM
+        from monitoring import (
+            CaptureSchedule, HostEngineConfig, MonitoringConfig, MonitoringEngine,
+        )
+        from monitoring._native_engine import ClickHouseClientConfig, StageConfig
+        from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
+        from monitoring.internal_mapper import get_internal
+        from integration.hf_adapter import generate_with_monitoring, MonitoredGenerateOutput
+        import clickhouse_driver
+    except Exception as exc:
+        pytest.skip(f"DMI HF stack unavailable: {exc}")
+    return SimpleNamespace(**{k: v for k, v in locals().items() if k != "exc"})
+
+
+def _db_host_port():
+    return (os.environ.get("DMX_DB_HOST", "localhost"),
+            int(os.environ.get("DMX_DB_PORT", "9000")))
+
+
+def _wipe(deps, model_id):
+    host, port = _db_host_port()
+    deps.clickhouse_driver.Client(host=host, port=port).execute(
+        "ALTER TABLE default.offload DELETE WHERE model_id = %(m)s", {"m": model_id})
+
+
+def _monitored(deps, model, inputs, model_id, hook_selection="resid_pre"):
+    """Run generate_with_monitoring into a fresh ClickHouse slot, return the output."""
+    _wipe(deps, model_id)
+    host, port = _db_host_port()
+    db = deps.ClickHouseClientConfig()
+    db.host, db.port = host, port
+    db.username, db.password = "default", ""
+    db.database, db.table = "default", "offload"
+    db.create_database_if_missing = True
+    stage = deps.StageConfig.clickhouse_insert(db, parallelism=4, name="ch_insert")
+    engine = deps.MonitoringEngine(
+        config=deps.MonitoringConfig(schedule=deps.CaptureSchedule()),
+        model_id=model_id,
+        db_config=deps.HostEngineConfig(stages=[stage]),
+    )
+    model.monitoring_engine = engine
+    try:
+        with torch.no_grad():
+            return deps.generate_with_monitoring(
+                model, **inputs, max_new_tokens=MAX_NEW, do_sample=False,
+                hook_selection=hook_selection,
+            )
+    finally:
+        engine.close()
+
+
+@pytest.fixture(scope="module")
+def model_tok(deps):
+    tok = deps.AutoTokenizer.from_pretrained(MODEL)
+    if tok.pad_token_id is None:
+        tok.pad_token_id = tok.eos_token_id
+    tok.padding_side = "left"
+    model = deps.HookedQwen3ForCausalLM.from_pretrained(
+        MODEL, dtype=torch.float16, attn_implementation="eager",
+    ).to("cuda").eval()
+    return model, tok
+
+
+@pytest.fixture(scope="module")
+def single(deps, model_tok):
+    """One prompt (batch=1): monitored output + a plain-HF reference."""
+    model, tok = model_tok
+    inputs = tok(["The capital of France is"], return_tensors="pt", padding=True).to("cuda")
+    with torch.no_grad():
+        ref = model.generate(**inputs, max_new_tokens=MAX_NEW, do_sample=False)
+    model_id = f"test_internal::single::{uuid.uuid4().hex}"[:120]
+    out = _monitored(deps, model, inputs, model_id)
+    yield SimpleNamespace(out=out, ref=ref, model=model)
+    _wipe(deps, model_id)
+
+
+@pytest.fixture(scope="module")
+def ragged(deps, model_tok):
+    """A left-padded batch of unequal-length prompts."""
+    model, tok = model_tok
+    inputs = tok(["The capital of France is", "Hi"], return_tensors="pt", padding=True).to("cuda")
+    model_id = f"test_internal::ragged::{uuid.uuid4().hex}"[:120]
+    out = _monitored(deps, model, inputs, model_id)
+    yield SimpleNamespace(out=out, n_prompts=2)
+    _wipe(deps, model_id)
+
+
+# --- wrapper return shape ---------------------------------------------------
+
+def test_returns_monitored_output(single, deps):
+    assert isinstance(single.out, deps.MonitoredGenerateOutput)
+    assert isinstance(single.out.model_id, str) and single.out.model_id
+    assert single.out.sequences.dim() == 2  # [batch, total_len]
+
+
+def test_output_matches_plain_hf(single):
+    # Monitoring must not change what the model generates.
+    assert torch.equal(single.out.sequences, single.ref)
+
+
+# --- get_internal: structure ------------------------------------------------
+
+def test_available_lists_captured_field(single, deps):
+    internal = deps.get_internal(single.out)
+    assert internal.available == ["hidden_states"]
+
+
+def test_hidden_states_tuple_shape(single, deps):
+    internal = deps.get_internal(single.out)
+    hs = internal.hidden_states
+    cfg = single.model.config
+    assert len(hs) == cfg.num_hidden_layers          # one entry per block (resid_pre)
+    assert all(t.dim() == 3 for t in hs)             # [batch, seq, hidden]
+    assert hs[0].shape[0] == 1                        # batch
+    assert hs[0].shape[2] == cfg.hidden_size         # hidden
+    assert all(t.shape == hs[0].shape for t in hs)   # uniform across layers
+
+
+def test_token_count_drops_unforwarded_last(single, deps):
+    # The final generated token is never fed through a forward, so it has no
+    # captured hidden state: captured seq == sequence length - 1.
+    hs = deps.get_internal(single.out).hidden_states
+    assert hs[0].shape[1] == single.out.sequences.shape[1] - 1
+
+
+# --- get_internal: source + reader handling --------------------------------
+
+def test_source_model_id_with_explicit_reader(single, deps):
+    host, port = _db_host_port()
+    reader = deps.CHClickhouseDriverReadOnly(host=host, port=port)
+    from_out = deps.get_internal(single.out).hidden_states
+    from_id = deps.get_internal(single.out.model_id, reader).hidden_states
+    assert len(from_out) == len(from_id)
+    assert torch.equal(from_out[0], from_id[0])
+
+
+def test_uncaptured_field_raises(single, deps):
+    internal = deps.get_internal(single.out)
+    with pytest.raises(AttributeError, match="not captured"):
+        internal.attention
+
+
+# --- get_internal: ragged batch left-pad -----------------------------------
+
+def test_ragged_batch_left_pads(ragged, deps):
+    hs = deps.get_internal(ragged.out).hidden_states
+    layer0 = hs[0]
+    assert layer0.shape[0] == ragged.n_prompts
+
+    nonzero = (layer0.abs().sum(dim=-1) > 0)          # [batch, seq] real-token mask
+    counts = nonzero.sum(dim=1)
+    assert counts.min() < counts.max()                # genuinely ragged -> padding added
+    assert bool(nonzero[:, -1].all())                 # real tokens are right-aligned
+    short = int(counts.argmin())
+    assert not bool(nonzero[short, 0])                # shorter request padded at the front


### PR DESCRIPTION
## What this adds

A read-side API that hands DMI's captured internals back in the **same shape HuggingFace gives you**, so consuming them is as familiar as `out.hidden_states`.

**Before** — off the low-level reader you reassemble everything by hand, and repeat it for every internal:

```python
rows = reader.prefix_get((model_id,))
by_layer = {}
for (mid, req, act, layer, shard, s, e), t in rows:
    if act == "blocks.hook_resid_pre":
        by_layer.setdefault(layer, []).append((s, t))
# concat each layer's chunks by token, then left-pad the ragged requests into a
# batch, then stack into [layer, batch, seq, hidden] ... and do it all again for
# attention, logits, kv, each with its own quirks
hidden = torch.stack([...])   # many lines, easy to get wrong
```

**After**:

```python
from integration.hf_adapter import generate_with_monitoring
from monitoring.internal_mapper import get_internal

out = generate_with_monitoring(model, **inputs, max_new_tokens=8,
                               hook_selection="resid_pre")

internal = get_internal(out)
internal.available        # ['hidden_states'] — what this run actually captured
internal.hidden_states    # tuple indexed by layer, each [batch, seq, hidden]
                          # exactly like HF's out.hidden_states
```

`get_internal` also takes a bare `model_id` + `reader` for cross-process / after-the-fact analysis (no model, no GPU):

```python
internal = get_internal("my_run_id", reader)
```

## Core changes — what & why

- **`monitoring/internal_mapper.py`** (new) — backend-agnostic read layer. Reads the per-`(layer, token-range)` rows DMI writes, groups by layer, concatenates along the token axis, and **left-pads ragged requests** into `[batch, seq, hidden]` (same layout as HF's left-padded batch — on CPU, after the run, no effect on generation). Returns an `Internal` whose fields mirror an HF model output; `.available` lists captured fields, and accessing an uncaptured one raises with a hint. **Extensible by design**: a `field -> (act_name, reassembler)` table (`_FIELDS`) — adding `attention` / `logits` / `kv` later is one entry + its reassembler, with no change to `get_internal`.
- **`integration/hf_adapter.py`** — `generate_with_monitoring` now returns `MonitoredGenerateOutput(.sequences, .model_id)` instead of a bare tensor. `.model_id` is the handle `get_internal` uses; any other attribute (`scores`, `logits`, tensor methods…) **falls through to the underlying HF output**, so existing call sites keep working.

## Incidental changes

- **`example/visualization/run_offload_hf.py`** — `output_ids[0]` → `output_ids.sequences[0]` for the new return type.
- Other `generate_with_monitoring` callers (`hf_compare_runner`, `test_per_hook_isolation`, `test_e2e_correctness_vs_hf`, benchmarks) unchanged — they rely on attribute fall-through.

## Testing

- **Unit** (`tests/test_internal_mapper.py`) — 5 passed: per-layer reassembly, chunk-concat order, ragged left-pad, uncaptured-field error, `source` accepts `out` or `model_id`.
- **E2E** (`tests/test_internal_mapper_e2e.py`, Qwen3-0.6B: CUDA + ClickHouse + fork) — 8 passed: return type, **output identical to native HF generate**, `.available`, tuple shape / layer count / hidden dim, token count (drops the unforwarded last token), `model_id`+`reader` path, uncaptured-field error, ragged-batch left-pad. Each run uses a uuid `model_id` with teardown cleanup — 0 leftover rows.
