### PR TITLE
[feature] DMILLM: drop-in vLLM LLM with per-request .dmi_internal

### DIFF
--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -25,9 +25,6 @@ export VLLM_DISABLE_COMPILE_CACHE=1
 ## Offline API
 
 ```python
-import os
-os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"  # required (see above)
-
 from vllm import LLM, SamplingParams
 
 llm = LLM(
@@ -60,9 +57,6 @@ the captured internals back from the store -- the same object the HuggingFace
 path's `out.dmi_internal` gives you.
 
 ```python
-import os
-os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"  # required (see above)
-
 from vllm import SamplingParams
 from integration.vllm_adapter import DMILLM
 

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -52,6 +52,45 @@ for o in llm.generate(["The answer is"], params):
 Set `"dmx_null_mode": False` and configure `dmx_db_*` fields to persist captures
 to ClickHouse.
 
+## Reading internals back: `DMILLM`
+
+`DMILLM` is a drop-in subclass of `LLM`: it injects the DMI worker for you, and
+every `RequestOutput` from `generate` carries a lazy `.dmi_internal` that reads
+the captured internals back from the store -- the same object the HuggingFace
+path's `out.dmi_internal` gives you.
+
+```python
+import os
+os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"  # required (see above)
+
+from vllm import SamplingParams
+from integration.vllm_adapter import DMILLM
+
+llm = DMILLM(
+    "Qwen/Qwen3-0.6B",
+    additional_config={
+        "dmx_model_id": "demo_vllm",
+        "dmx_hook_selection": "resid_pre",
+        "dmx_db_host": "localhost",
+        "dmx_db_port": 9000,
+    },
+    max_model_len=512, enforce_eager=True, gpu_memory_utilization=0.5,
+)
+
+out = llm.generate(["The capital of France is"], SamplingParams(max_tokens=8))
+
+out[0].outputs[0].text             # native vLLM output, unchanged
+out[0].dmi_internal.hidden_states  # tuple indexed by layer, each [1, seq, hidden]
+out[0].dmi_internal.available      # ['hidden_states']
+```
+
+`DMILLM` only injects `worker_cls`; pass DMI settings through `additional_config`
+exactly as with plain `LLM`. Persisting to ClickHouse (`dmx_db_*`, i.e. not
+`dmx_null_mode`) is required to read internals back. Each `RequestOutput` exposes
+only its own request's internals; for the whole batch as one
+`[batch, seq, hidden]` tensor use `get_internal(model_id)` from
+`monitoring.internal_mapper`.
+
 ## vLLM serve
 
 ```bash

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -35,6 +35,7 @@ from typing import Any, List, Optional, Tuple
 
 import torch
 
+from vllm import LLM
 from vllm.v1.worker.gpu_worker import Worker
 
 from monitoring import ring_transport
@@ -60,6 +61,8 @@ from monitoring.ring_transport import _ATTN_WT_TYPES
 from monitoring.step_context import StepContext
 
 from integration.model_shape import _make_model_shape_from_hf_config
+from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
+from monitoring.internal_mapper import make_lazy_internal
 
 
 # ---------------------------------------------------------------------------
@@ -696,8 +699,43 @@ class DMXGPUWorker(Worker):
         super().shutdown()
 
 
+def _attach_dmi_internal(outputs, model_id, reader=None):
+    """Tag each vLLM ``RequestOutput`` with a lazy ``.dmi_internal`` keyed by
+    its (normalized) request_id, so the captured internals read back per
+    request -- the same object HF's ``out.dmi_internal`` gives you."""
+    for r in outputs:
+        rid = normalize_vllm_request_id(r.request_id)
+        r.dmi_internal = make_lazy_internal(model_id, reader=reader, request_ids=[rid])
+    return outputs
+
+
+class DMILLM(LLM):
+    """Drop-in replacement for vLLM's ``LLM`` that captures model internals.
+
+    Injects the DMI worker (so ``worker_cls`` need not be passed) and tags every
+    ``RequestOutput`` from ``generate`` with a lazy ``.dmi_internal``. Pass DMI
+    settings through ``additional_config`` exactly as with plain ``LLM``
+    (``dmx_model_id``, ``dmx_db_host``, ``dmx_db_port``, ``dmx_hook_selection``, ...).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("worker_cls", "integration.vllm_adapter.DMXGPUWorker")
+        ac = kwargs.get("additional_config") or {}
+        self._dmx_model_id = ac.get("dmx_model_id") or str(
+            kwargs.get("model") or (args[0] if args else ""))
+        self._dmx_db_host = ac.get("dmx_db_host", "localhost")
+        self._dmx_db_port = int(ac.get("dmx_db_port", 9000))
+        super().__init__(*args, **kwargs)
+
+    def generate(self, *args: Any, **kwargs: Any):
+        outputs = super().generate(*args, **kwargs)
+        reader = CHClickhouseDriverReadOnly(host=self._dmx_db_host, port=self._dmx_db_port)
+        return _attach_dmi_internal(outputs, self._dmx_model_id, reader)
+
+
 __all__ = [
     "VLLMAdaptor",
     "DMXGPUWorker",
+    "DMILLM",
     "normalize_vllm_request_id",
 ]

--- a/tests/test_vllm_dmillm.py
+++ b/tests/test_vllm_dmillm.py
@@ -1,0 +1,38 @@
+"""Unit tests for DMILLM's per-request .dmi_internal tagging.
+
+Covers the tagging logic only -- no GPU, ClickHouse, or vLLM engine. The lazy
+proxy is constructed but never read, so nothing touches the store.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm")  # vllm_adapter imports vllm at module load
+
+from integration.vllm_adapter import _attach_dmi_internal, normalize_vllm_request_id
+
+
+def _fake_outputs(*request_ids):
+    return [SimpleNamespace(request_id=rid) for rid in request_ids]
+
+
+def test_tags_each_output_with_lazy_internal():
+    outs = _fake_outputs("req-a", "req-b")
+    _attach_dmi_internal(outs, "demo_vllm", reader=None)
+    assert all(hasattr(o, "dmi_internal") for o in outs)
+    assert outs[0].dmi_internal._model_id == "demo_vllm"
+
+
+def test_per_request_isolation():
+    outs = _fake_outputs("req-a", "req-b")
+    _attach_dmi_internal(outs, "m", reader=None)
+    # Each output's internal is keyed only by its own (normalized) request_id.
+    assert outs[0].dmi_internal._request_ids == (normalize_vllm_request_id("req-a"),)
+    assert outs[1].dmi_internal._request_ids == (normalize_vllm_request_id("req-b"),)
+
+
+def test_reader_passed_through():
+    outs = _fake_outputs("req-a")
+    sentinel = object()
+    _attach_dmi_internal(outs, "m", reader=sentinel)
+    assert outs[0].dmi_internal._reader is sentinel

--- a/tests/test_vllm_dmillm_e2e.py
+++ b/tests/test_vllm_dmillm_e2e.py
@@ -1,0 +1,53 @@
+"""End-to-end test for DMILLM (offline vLLM).
+
+The vLLM engine is launched in a subprocess (tests.vllm_dmillm_runner) so the
+pytest parent never initializes CUDA before the engine forks. The runner drives
+DMILLM, reads each RequestOutput's per-request .dmi_internal back from
+ClickHouse, and writes pass/fail to a result file we assert on here.
+
+Requires CUDA, a reachable ClickHouse, vLLM, and the model in cache.
+
+ClickHouse connection: DMX_DB_HOST / DMX_DB_PORT (default localhost:9000).
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+import torch
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.vllm,
+    pytest.mark.clickhouse,
+    pytest.mark.e2e,
+]
+
+
+@pytest.mark.skipif(not torch.backends.cuda.is_built(), reason="CUDA not built")
+def test_vllm_dmillm_e2e():
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    run_dir = tempfile.mkdtemp(prefix="vllm_dmillm_")
+    result_file = os.path.join(run_dir, "result.json")
+    env = dict(os.environ)
+    env.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    try:
+        r = subprocess.run(
+            [sys.executable, "-m", "tests.vllm_dmillm_runner", "--result-file", result_file],
+            env=env, capture_output=True, text=True, cwd=project_root,
+        )
+        if not os.path.exists(result_file):
+            pytest.skip(
+                f"DMILLM runner could not run (vLLM / ClickHouse / deps missing?):\n"
+                f"{r.stderr[-1500:]}"
+            )
+        with open(result_file) as f:
+            results = json.load(f)
+        failed = [t for t in results["tests"] if not t["passed"]]
+        assert not failed, f"failed checks: {failed}"
+    finally:
+        shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/vllm_dmillm_runner.py
+++ b/tests/vllm_dmillm_runner.py
@@ -1,0 +1,99 @@
+"""Subprocess runner: DMILLM offline -> read each RequestOutput's per-request
+.dmi_internal back from ClickHouse, write pass/fail to a result file.
+
+Run as a subprocess (the pytest parent must not touch CUDA before forking the
+vLLM engine). See tests/test_vllm_dmillm_e2e.py.
+
+Usage:
+    python -m tests.vllm_dmillm_runner --result-file /tmp/r.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+
+def _shapes(outputs):
+    return [(len(o.dmi_internal.hidden_states), o.dmi_internal.hidden_states[0].shape[1])
+            for o in outputs]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    ap.add_argument("--result-file", required=True)
+    args = ap.parse_args()
+
+    import torch
+    import clickhouse_driver
+    from vllm import SamplingParams
+    from integration.vllm_adapter import DMILLM
+
+    host = os.environ.get("DMX_DB_HOST", "localhost")
+    port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    model_id = f"test_dmillm::{os.getpid()}"
+    client = clickhouse_driver.Client(host=host, port=port)
+    client.execute("ALTER TABLE default.offload DELETE WHERE model_id=%(m)s", {"m": model_id})
+
+    llm = DMILLM(
+        args.model,
+        additional_config={
+            "dmx_model_id": model_id, "dmx_hook_selection": "resid_pre",
+            "dmx_db_host": host, "dmx_db_port": port,
+        },
+        max_model_len=512, enforce_eager=True, gpu_memory_utilization=0.5,
+    )
+    prompts = ["The capital of France is", "Hello"]
+    outputs = llm.generate(prompts, SamplingParams(temperature=0.0, max_tokens=8))
+
+    # No-flush read: rely on the 100ms drain-flush timeout (default since the
+    # drain-flush change) to land captures in ClickHouse without stop_monitoring.
+    time.sleep(2.0)
+    no_stop = _shapes(outputs)
+    for o in outputs:
+        o.dmi_internal.clear_cache()
+
+    # Explicit flush, then re-read as the authoritative baseline.
+    llm.collective_rpc("stop_monitoring")
+    time.sleep(0.5)
+    internals = [o.dmi_internal.hidden_states for o in outputs]
+    after_stop = [(len(hs), hs[0].shape[1]) for hs in internals]
+
+    tests = [
+        {"name": "outputs_are_native",
+         "passed": len(outputs) == 2 and all(o.outputs[0].text for o in outputs),
+         "detail": [o.outputs[0].text for o in outputs]},
+        # Auto-drain: internals reach ClickHouse without an explicit stop_monitoring.
+        {"name": "readable_without_stop_monitoring",
+         "passed": no_stop == after_stop and all(layers > 0 for layers, _ in no_stop),
+         "detail": {"no_stop": no_stop, "after_stop": after_stop}},
+        # Per-request: each is its own [1, seq, hidden] (batch dim 1).
+        {"name": "per_request_hidden_states",
+         "passed": all(len(hs) > 0 and hs[0].dim() == 3 and hs[0].shape[0] == 1
+                       for hs in internals),
+         "detail": after_stop},
+        # Ragged prompts -> independent seq lengths (no cross-padding).
+        {"name": "per_request_isolated_lengths",
+         "passed": len({s for _, s in after_stop}) > 1,
+         "detail": [s for _, s in after_stop]},
+        {"name": "available_lists_hidden_states",
+         "passed": "hidden_states" in outputs[0].dmi_internal.available,
+         "detail": outputs[0].dmi_internal.available},
+    ]
+
+    client.execute("ALTER TABLE default.offload DELETE WHERE model_id=%(m)s", {"m": model_id})
+    with open(args.result_file, "w") as f:
+        json.dump({"tests": tests}, f)
+
+    del llm
+    torch.cuda.empty_cache()
+    sys.exit(0 if all(t["passed"] for t in tests) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds

The vLLM counterpart to `get_internal` / `dmi_internal` (#64). Native vLLM returns text + token ids + logprobs and **no internals at all** — there is no `output_hidden_states` equivalent. `DMILLM` is a drop-in `LLM` subclass, so the call site stays native:

**Native vLLM:**
```python
from vllm import LLM, SamplingParams
llm = LLM("Qwen/Qwen3-0.6B")
out = llm.generate(["The capital of France is"], SamplingParams(max_tokens=8))
out[0].outputs[0].text   # that's all you get
```

**With DMI:**
```python
from vllm import SamplingParams
from integration.vllm_adapter import DMILLM      # ← LLM → DMILLM

llm = DMILLM("Qwen/Qwen3-0.6B",
             additional_config={"dmx_model_id": "demo_vllm",
                                "dmx_db_host": "localhost", "dmx_db_port": 9000})
out = llm.generate(["The capital of France is"], SamplingParams(max_tokens=8))
out[0].outputs[0].text             # native vLLM output, unchanged
out[0].dmi_internal.hidden_states  # per-layer tuple, each [1, seq, hidden]
```

`llm.generate` is 100% native; the only change is `LLM` → `DMILLM`. This mirrors the HF path's `out.dmi_internal`.

## Core changes

- **`integration/vllm_adapter.py`** — `DMILLM(LLM)`: `__init__` injects `worker_cls` and stores model_id / db connection; `generate` tags each `RequestOutput` with a lazy `.dmi_internal` keyed by its normalized `request_id`. Plus an `_attach_dmi_internal` helper. Reuses the existing `make_lazy_internal` and `normalize_vllm_request_id`.
- **Per-request**: each `RequestOutput` exposes only its own request's internals — `[1, seq, hidden]`, real length, no cross-padding (vLLM returns one `RequestOutput` per prompt). For the whole batch as one `[batch, seq, hidden]` tensor, `get_internal(model_id)` still works.
- DMI settings are passed through `additional_config` exactly as with plain `LLM`.

## Docs

- **`docs/vllm.md`** — new "Reading internals back: `DMILLM`" section.

## Testing

- **Unit** (`tests/test_vllm_dmillm.py`) — 3 passed: per-request tagging, isolation across prompts, reader passthrough (no GPU / ClickHouse).
- **E2E** (`tests/test_vllm_dmillm_e2e.py` + `tests/vllm_dmillm_runner.py`) — subprocess runner so the pytest parent never touches CUDA (per repo convention for vLLM tests). Starts a real vLLM engine on Qwen3-0.6B and reads each `RequestOutput`'s `.dmi_internal` back from ClickHouse. Checks:
  - native output unchanged;
  - **internals readable without an explicit `stop_monitoring`** — the drain-flush timeout lands captures in ClickHouse automatically, matching the post-`stop` baseline;
  - per-request `[1, seq, hidden]`;
  - ragged isolation (12 vs 8 tokens for `"The capital of France is"` vs `"Hello"`);
  - `available == ['hidden_states']`.
  
  **Passed.**

## Note

The e2e confirms internals are readable **without** an explicit flush (the drain-flush timeout auto-lands captures in ClickHouse). The runner still calls `stop_monitoring` once for a deterministic baseline; wiring auto-flush + lazy-retry into `DMILLM.generate` itself (so users never think about flush, even reading immediately after `generate`) is a follow-up PR.
