### PR TITLE
vllm: fix continuous-batch capture mis-associating activations with requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,16 @@ llm = LLM(
     worker_cls="integration.vllm_adapter.DMXGPUWorker",
     additional_config={
         "dmx_hook_selection": "vllm-full",
-        "dmx_null_mode": True,   # capture + transport, drop on host (no DB needed)
+        "dmx_null_mode": False,
+        "dmx_db_host": "",       # active capture + transport; no persistence
     },
 )
 
 for o in llm.generate(["The answer is"], SamplingParams(max_tokens=16)):
     print(o.outputs[0].text)
-# Internal states for every layer have been captured into Ring²
-# during the run. Set "dmx_null_mode": False and configure a sink
-# to persist them.
+# Internal states for every layer have traversed Ring² during the run.
+# Configure a sink to persist them. Setting "dmx_null_mode": True
+# disables DMI planning, metadata, and payload copying.
 ```
 
 | | |

--- a/benchmark/bench_vllm_transport.py
+++ b/benchmark/bench_vllm_transport.py
@@ -2,7 +2,8 @@
 
 Compares modes:
   baseline         -- plain vLLM generate, no monitoring
-  ring_null        -- ring transport active (GPU->ring->CPU), null sink (no DB write)
+  ring_null        -- public DMI no-op/null mode (no planning or payload copy)
+  ring_active      -- ring transport active, no persistence sink
   ring_db          -- ring transport + ClickHouse ingestion
 
 Reports total wall time (ms) and throughput (tok/s) for the generate call.
@@ -10,7 +11,7 @@ TTFT (time to first token) is not measured — vLLM's offline LLM API
 does not expose per-token timing.
 
 Usage:
-  python -m benchmark.bench_vllm_transport --model gpt2 --modes baseline,ring_null
+  python -m benchmark.bench_vllm_transport --model gpt2 --modes baseline,ring_active
   python -m benchmark.bench_vllm_transport --model qwen3 --num-prompts 8 --max-tokens 64
   python -m benchmark.bench_vllm_transport --model gpt2 --modes baseline,ring_null,ring_db
 
@@ -62,6 +63,8 @@ class BenchConfig:
     # vLLM
     max_model_len: int = 512
     gpu_memory_utilization: float = 0.5
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
 
 
 @dataclass
@@ -94,7 +97,7 @@ def _run_mode(mode: str, cfg: BenchConfig) -> None:
 
     if mode == "baseline":
         pass  # no monitoring
-    elif mode in ("ring_null", "ring_db"):
+    elif mode in ("ring_null", "ring_active", "ring_db"):
         worker_cls = "integration.vllm_adapter.DMXGPUWorker"
         additional_config = {
             "dmx_hook_selection": cfg.hook_selection,
@@ -103,6 +106,9 @@ def _run_mode(mode: str, cfg: BenchConfig) -> None:
         }
         if mode == "ring_null":
             additional_config["dmx_null_mode"] = True
+        elif mode == "ring_active":
+            additional_config["dmx_null_mode"] = False
+            additional_config["dmx_db_host"] = ""
         elif mode == "ring_db":
             additional_config["dmx_db_host"] = cfg.db_host
             additional_config["dmx_db_port"] = cfg.db_port
@@ -115,6 +121,8 @@ def _run_mode(mode: str, cfg: BenchConfig) -> None:
         max_model_len=cfg.max_model_len,
         enforce_eager=cfg.enforce_eager,
         gpu_memory_utilization=cfg.gpu_memory_utilization,
+        tensor_parallel_size=cfg.tensor_parallel_size,
+        pipeline_parallel_size=cfg.pipeline_parallel_size,
     )
     if worker_cls:
         kwargs["worker_cls"] = worker_cls
@@ -154,14 +162,10 @@ def _run_mode(mode: str, cfg: BenchConfig) -> None:
     print(f"\n  Summary:  total={mean_t:.1f} ms  std={std_t:.1f} ms  "
           f"throughput={mean_tps:.1f} tok/s")
 
-    # Explicit per-worker flush+stop before LLM teardown. Avoids the
-    # implicit DMXGPUWorker.shutdown() race against vLLM's 8s deadline
-    # (see vllm_adapter.py:587 warning). No-op for baseline mode where
-    # the worker isn't a DMXGPUWorker.
-    try:
+    # Explicit per-worker flush+stop before LLM teardown. Keep shutdown
+    # failures visible for modes that actually start monitoring.
+    if mode in ("ring_active", "ring_db"):
         llm.collective_rpc("stop_monitoring")
-    except Exception:
-        pass
     del llm
     torch.cuda.empty_cache()
 
@@ -177,6 +181,7 @@ def main():
     print(f"  vLLM Ring Transport Benchmark")
     print(f"  model={model_id}  prompts={cfg.num_prompts}  max_tokens={cfg.max_tokens}")
     print(f"  enforce_eager={cfg.enforce_eager}  ring={cfg.ring_payload_mb}MB")
+    print(f"  tp={cfg.tensor_parallel_size}  pp={cfg.pipeline_parallel_size}")
     print(f"  hooks={cfg.hook_selection}")
     print(f"  warmup={cfg.warmup}  iters={cfg.iters}")
     print(f"  modes={cfg.modes}")
@@ -223,7 +228,7 @@ def _parse_args() -> BenchConfig:
     g.add_argument("--warmup", type=int, default=2)
     g.add_argument("--iters", type=int, default=5)
     g.add_argument("--modes", default="baseline,ring_null",
-                   help="comma-separated: baseline,ring_null,ring_db")
+                   help="comma-separated: baseline,ring_null,ring_active,ring_db")
     g.add_argument("--enforce-eager", action="store_true")
     g.add_argument("--hook-selection", default="vllm-full")
 
@@ -238,6 +243,8 @@ def _parse_args() -> BenchConfig:
     g = p.add_argument_group("vLLM")
     g.add_argument("--max-model-len", type=int, default=512)
     g.add_argument("--gpu-memory-utilization", type=float, default=0.5)
+    g.add_argument("--tensor-parallel-size", type=int, default=1)
+    g.add_argument("--pipeline-parallel-size", type=int, default=1)
 
     ns = p.parse_args()
     return BenchConfig(
@@ -256,6 +263,8 @@ def _parse_args() -> BenchConfig:
         db_port=ns.db_port,
         max_model_len=ns.max_model_len,
         gpu_memory_utilization=ns.gpu_memory_utilization,
+        tensor_parallel_size=ns.tensor_parallel_size,
+        pipeline_parallel_size=ns.pipeline_parallel_size,
     )
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,9 +73,10 @@ poll timeout), copies ready payloads out of the GPU payload ring into a
 pinned host staging buffer, and hands them to a p2p thread that submits to
 the host engine — a single-stage ClickHouse insert pipeline (`DMXHostEngine`).
 
-A runtime `dmx_null_mode=True` switch short-circuits the p2p submit step:
-payloads still flow GPU → ring → drain → staging, but nothing is inserted.
-This is useful for isolating transport overhead independently of ClickHouse.
+A runtime `dmx_null_mode=True` switch disables DMI step planning, metadata,
+and payload copying; the native producer path remains in no-op/null mode.
+For active transport without persistence, use `dmx_null_mode=False` and leave
+the database host empty.
 
 The drain pipeline is independent of the inference loop: backpressure on the
 sink does not block the GPU producer as long as the rings are sized for the

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,15 +35,15 @@ ring. Force flush at 100% capacity is always active (prevents deadlock).
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `drain_flush_task_ratio` | `float` | 0.0 | Flush when scanned entries >= this fraction of `task_ring_entries`. 0 = disabled. |
-| `drain_flush_payload_ratio` | `float` | 0.0 | Flush when scanned payload bytes >= this fraction of `payload_ring_bytes`. 0 = disabled. |
+| `drain_flush_payload_ratio` | `float` | 0.5 | Flush when scanned payload bytes >= this fraction of `payload_ring_bytes`. 0 = disabled. |
 | `drain_flush_entry_threshold` | `uint64_t` | 0 | Flush after N entries ready. 0 = disabled. |
 | `drain_flush_byte_threshold` | `uint64_t` | 0 | Flush after N payload bytes ready. 0 = disabled. |
-| `drain_flush_timeout_us` | `uint64_t` | 100000 | If a complete tensor has been pending for longer than this many microseconds, flush unconditionally. 0 = disabled. |
+| `drain_flush_timeout_us` | `uint64_t` | 0 | If a complete tensor has been pending for longer than this many microseconds, flush unconditionally. 0 = disabled. |
 
-With timeout-based flushing disabled explicitly (`drain_flush_timeout_us = 0`)
-and all other flush thresholds at 0, the drain thread only flushes when the ring
-is 100% full or at `stop()` time. This minimizes CUDA API calls but increases
-latency.
+By default, timeout-based flushing is disabled and the drain thread flushes at
+50% payload-ring usage. If `drain_flush_payload_ratio` and all other thresholds
+are explicitly set to 0, the drain thread only flushes when the ring is 100%
+full or at `stop()` time.
 
 ## P2P Thread / Output
 
@@ -97,10 +97,10 @@ All E2E ring parameters are set via `E2E_*` environment variables
 | `E2E_RING_PINNED_BYTES` | 4 GiB | `pinned_staging_bytes` |
 | `E2E_DRAIN_POLL_TIMEOUT_US` | 100 | `drain_poll_timeout_us` |
 | `E2E_DRAIN_FLUSH_TASK_RATIO` | 0.0 | `drain_flush_task_ratio` |
-| `E2E_DRAIN_FLUSH_PAYLOAD_RATIO` | 0.0 | `drain_flush_payload_ratio` |
+| `E2E_DRAIN_FLUSH_PAYLOAD_RATIO` | 0.5 | `drain_flush_payload_ratio` |
 | `E2E_DRAIN_FLUSH_ENTRY_THRESHOLD` | 0 | `drain_flush_entry_threshold` |
 | `E2E_DRAIN_FLUSH_BYTE_THRESHOLD` | 0 | `drain_flush_byte_threshold` |
-| `E2E_DRAIN_FLUSH_TIMEOUT_US` | 100000 | `drain_flush_timeout_us` |
+| `E2E_DRAIN_FLUSH_TIMEOUT_US` | 0 | `drain_flush_timeout_us` |
 | `E2E_CLONE_SLICES` | 0 | `clone_slices` |
 | `E2E_INSERT_QUEUE_MAX_BYTES` | 512 MiB | `insert_queue_max_bytes` |
 | `E2E_INSERT_QUEUE_MAX_ITEMS` | 4096 | `insert_queue_max_items` |

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -37,7 +37,8 @@ llm = LLM(
         "dmx_hook_selection": "vllm-full",
         "dmx_ring_payload_mb": 4096,
         "dmx_ring_pinned_mb": 4096,
-        "dmx_null_mode": True,
+        "dmx_null_mode": False,
+        "dmx_db_host": "",
     },
 )
 
@@ -46,8 +47,10 @@ for o in llm.generate(["The answer is"], params):
     print(o.outputs[0].text)
 ```
 
-Set `"dmx_null_mode": False` and configure `dmx_db_*` fields to persist captures
-to ClickHouse.
+With `"dmx_null_mode": False` and no database host, capture and transport remain
+active without persistence. Configure `dmx_db_*` fields to persist captures to
+ClickHouse. Setting `"dmx_null_mode": True` disables DMI planning, metadata,
+and payload copying.
 
 ## Reading internals back: `DMILLM`
 
@@ -79,9 +82,9 @@ out[0].dmi_internal.available      # ['hidden_states']
 ```
 
 `DMILLM` only injects `worker_cls`; pass DMI settings through `additional_config`
-exactly as with plain `LLM`. Persisting to ClickHouse (`dmx_db_*`, i.e. not
-`dmx_null_mode`) is required to read internals back. Each `RequestOutput` exposes
-only its own request's internals; for the whole batch as one
+exactly as with plain `LLM`. A nonempty `dmx_db_host` and
+`dmx_null_mode=False` are required to read internals back. Each `RequestOutput`
+exposes only its own request's internals; for the whole batch as one
 `[batch, seq, hidden]` tensor use `get_internal(model_id)` from
 `monitoring.internal_mapper`.
 
@@ -104,15 +107,15 @@ vllm serve Qwen/Qwen3-8B \
 | Field | Meaning |
 |---|---|
 | `dmx_hook_selection` | Hook preset, usually `vllm-full` |
-| `dmx_null_mode` | `True` drops captures after transport; `False` persists |
+| `dmx_null_mode` | `True` disables DMI planning, metadata, and payload copying; `False` enables capture/transport |
 | `dmx_ring_payload_mb` | GPU payload ring size |
 | `dmx_ring_pinned_mb` | Host-side pinned payload staging buffer (D2H copy target). `0` = match `dmx_ring_payload_mb`. |
-| `dmx_drain_flush_timeout_us` | Max time a completed tensor waits before GPU-to-CPU drain flush. Default `100000` (100 ms). `0` disables timeout-based flushing. |
+| `dmx_drain_flush_timeout_us` | Max time a completed tensor waits before GPU-to-CPU drain flush. Default `0` (disabled). |
 | `dmx_db_host`, `dmx_db_port` | ClickHouse connection |
 
 ## Troubleshooting
 
 - **Baseline vLLM** — remove `worker_cls` and `additional_config`.
-- **Transport-only run** — set `"dmx_null_mode": True`.
+- **Transport-only run** — set `"dmx_null_mode": False` and leave `dmx_db_host` empty.
 - **`libstdc++` mismatch** — preload the conda libstdc++:
   `LD_PRELOAD=$CONDA_PREFIX/lib/libstdc++.so.6 python your_script.py`.

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -317,9 +317,26 @@ class VLLMAdaptor(BackendAdaptor):
         _step = self._step_counter
 
         num_scheduled = scheduler_output.num_scheduled_tokens  # dict[req_id, int]
-        req_ids = list(num_scheduled.keys())
+        # ROW ORDER IS LOAD-BEARING. vLLM V1's model_runner lays out the flattened
+        # hidden-tensor rows in INPUT_BATCH order (input_batch.req_ids), NOT in
+        # num_scheduled_tokens dict order: _prepare_inputs builds
+        #   num_scheduled_np = [num_scheduled[i] for i in input_batch.req_ids]
+        #   req_indices = np.repeat(arange[:num_reqs], num_scheduled_np)
+        # so rows are concatenated per request in input_batch order. Under
+        # continuous batching the dict order diverges from the slot order
+        # (freed-slot reuse / condense), so iterating the dict attaches each
+        # request's metadata to ANOTHER request's rows -> right metadata, WRONG
+        # activation. Order by input_batch; fall back to dict order when there is
+        # no input_batch (single-request / unexpected shape).
+        input_batch = getattr(model_runner, "input_batch", None)
+        ib_req_ids = getattr(input_batch, "req_ids", None) if input_batch is not None else None
+        if (ib_req_ids is not None and len(ib_req_ids) == len(num_scheduled)
+                and all(r in num_scheduled for r in ib_req_ids)):
+            req_ids = list(ib_req_ids)
+        else:
+            req_ids = list(num_scheduled.keys())
         num_reqs = len(req_ids)
-        num_scheduled_per_req = list(num_scheduled.values())
+        num_scheduled_per_req = [num_scheduled[rid] for rid in req_ids]
         total_q = total_tokens
 
         padded_q = self.predict_padded_q_len(model_runner, total_q)
@@ -631,6 +648,26 @@ class DMXGPUWorker(Worker):
             self.model_runner.model, hook_selection=self._dmx_hook_selection
         )
 
+        # The per-step capture context (which flattened row belongs to which
+        # request) MUST be built from the POST-_update_states input_batch order.
+        # before_forward used to run in execute_model BEFORE super().execute_model
+        # -> before the model_runner's _update_states (remove_request /
+        # add_request / condense), so it saw the PREVIOUS step's input_batch order
+        # while the forward lays rows out in THIS step's order -> per-request
+        # metadata attached to the wrong row under continuous batching. Wrap
+        # _update_states so the context is built right after it (input_batch now
+        # reflects this step) and before the forward.
+        mr = self.model_runner
+        adaptor = self.adaptor
+        _orig_update_states = mr._update_states
+
+        def _dmx_update_states(scheduler_output):
+            _orig_update_states(scheduler_output)
+            if scheduler_output.total_num_scheduled_tokens > 0:
+                adaptor.before_forward(scheduler_output, mr)
+
+        mr._update_states = _dmx_update_states
+
     def compile_or_warm_up_model(self) -> float:
         # Warmup runs with null_mode=True (set in init_device).
         # Producer kernels fire but are no-ops -- ring stays clean.
@@ -650,11 +687,9 @@ class DMXGPUWorker(Worker):
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:
-        if (
-            self.adaptor is not None
-            and scheduler_output.total_num_scheduled_tokens > 0
-        ):
-            self.adaptor.before_forward(scheduler_output, self.model_runner)
+        # NOTE: before_forward is now driven from a _update_states wrapper
+        # installed in load_model (so the step context is built from the
+        # POST-update input_batch row order), NOT here. See load_model.
         return super().execute_model(scheduler_output)
 
     def stop_monitoring(self) -> None:

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -317,26 +317,9 @@ class VLLMAdaptor(BackendAdaptor):
         _step = self._step_counter
 
         num_scheduled = scheduler_output.num_scheduled_tokens  # dict[req_id, int]
-        # ROW ORDER IS LOAD-BEARING. vLLM V1's model_runner lays out the flattened
-        # hidden-tensor rows in INPUT_BATCH order (input_batch.req_ids), NOT in
-        # num_scheduled_tokens dict order: _prepare_inputs builds
-        #   num_scheduled_np = [num_scheduled[i] for i in input_batch.req_ids]
-        #   req_indices = np.repeat(arange[:num_reqs], num_scheduled_np)
-        # so rows are concatenated per request in input_batch order. Under
-        # continuous batching the dict order diverges from the slot order
-        # (freed-slot reuse / condense), so iterating the dict attaches each
-        # request's metadata to ANOTHER request's rows -> right metadata, WRONG
-        # activation. Order by input_batch; fall back to dict order when there is
-        # no input_batch (single-request / unexpected shape).
-        input_batch = getattr(model_runner, "input_batch", None)
-        ib_req_ids = getattr(input_batch, "req_ids", None) if input_batch is not None else None
-        if (ib_req_ids is not None and len(ib_req_ids) == len(num_scheduled)
-                and all(r in num_scheduled for r in ib_req_ids)):
-            req_ids = list(ib_req_ids)
-        else:
-            req_ids = list(num_scheduled.keys())
+        req_ids = list(num_scheduled.keys())
         num_reqs = len(req_ids)
-        num_scheduled_per_req = [num_scheduled[rid] for rid in req_ids]
+        num_scheduled_per_req = list(num_scheduled.values())
         total_q = total_tokens
 
         padded_q = self.predict_padded_q_len(model_runner, total_q)
@@ -648,26 +631,6 @@ class DMXGPUWorker(Worker):
             self.model_runner.model, hook_selection=self._dmx_hook_selection
         )
 
-        # The per-step capture context (which flattened row belongs to which
-        # request) MUST be built from the POST-_update_states input_batch order.
-        # before_forward used to run in execute_model BEFORE super().execute_model
-        # -> before the model_runner's _update_states (remove_request /
-        # add_request / condense), so it saw the PREVIOUS step's input_batch order
-        # while the forward lays rows out in THIS step's order -> per-request
-        # metadata attached to the wrong row under continuous batching. Wrap
-        # _update_states so the context is built right after it (input_batch now
-        # reflects this step) and before the forward.
-        mr = self.model_runner
-        adaptor = self.adaptor
-        _orig_update_states = mr._update_states
-
-        def _dmx_update_states(scheduler_output):
-            _orig_update_states(scheduler_output)
-            if scheduler_output.total_num_scheduled_tokens > 0:
-                adaptor.before_forward(scheduler_output, mr)
-
-        mr._update_states = _dmx_update_states
-
     def compile_or_warm_up_model(self) -> float:
         # Warmup runs with null_mode=True (set in init_device).
         # Producer kernels fire but are no-ops -- ring stays clean.
@@ -687,9 +650,11 @@ class DMXGPUWorker(Worker):
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:
-        # NOTE: before_forward is now driven from a _update_states wrapper
-        # installed in load_model (so the step context is built from the
-        # POST-update input_batch row order), NOT here. See load_model.
+        if (
+            self.adaptor is not None
+            and scheduler_output.total_num_scheduled_tokens > 0
+        ):
+            self.adaptor.before_forward(scheduler_output, self.model_runner)
         return super().execute_model(scheduler_output)
 
     def stop_monitoring(self) -> None:

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -8,18 +8,16 @@ Key pieces:
 
   * ``VLLMAdaptor`` -- concrete ``BackendAdaptor`` for vLLM models.
     Owns the framework-fragile pieces in localized methods:
-      ``predict_padded_q_len`` (reads ``cudagraph_dispatcher._bs_to_padded_graph_size``);
-      ``build_step_context`` (constructs the packed/flattened
-      StepContext from a ``scheduler_output`` + ``model_runner`` pair);
+      ``_record_real_layout`` (copies post-prepare packed request order);
+      ``_preflight_force_eager`` (evaluates cached worst-role formulas);
+      ``build_step_context`` (uses the real layout and batch descriptor);
       ``adapt_for_cpu_direct`` (swaps padded -> unpadded q_len when an
       oversize step forces eager dispatch + safety net for this batch);
-      ``on_capacity_exceeded`` (no-op stub; transport.force_eager is
-      owned by adaptor_base.before_forward and read by the
-      ``_determine_batch_execution_and_padding`` wrapper);
+      ``before_forward`` (commits one already-computed actual plan);
       ``_warn_once_capacity`` (per-(total_q, num_reqs) shape warn).
-  * ``DMXGPUWorker`` -- ~60-line vLLM ``Worker`` subclass that owns a
-    ``VLLMAdaptor`` and delegates per-step work to it.  Architecture
-    remap (GPT2LMHeadModel -> GPT2PLMHeadModel etc.) stays here.
+  * ``DMXGPUWorker`` -- vLLM ``Worker`` subclass that owns a
+    ``VLLMAdaptor``, records the real input layout, and commits at real
+    dispatch. Architecture remap stays here.
   * Module-level ``register_preset("vllm-full", ...)`` -- relocated
     from ``monitoring/selection.py``'s default ``_HOOK_SELECTIONS``
     (deferred from Phase 1.5 per the unified-adaptor plan).  Lands as
@@ -28,30 +26,36 @@ Key pieces:
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from enum import Enum, auto
 import os
 import re
 import warnings
 from typing import Any, List, Optional, Tuple
 
+import numpy as np
 import torch
 
 from vllm import LLM
+from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
 from vllm.v1.worker.gpu_worker import Worker
 
 from monitoring import ring_transport
 from monitoring.adaptor_base import BackendAdaptor
 from monitoring.ring_transport import (
+    HookRowBasis,
     HookSpec,
     ModelShapeConfig,
     _compute_hook_shape,
     align_up_py,
+    hook_row_basis,
     install_ring_hooks,
 )
 from monitoring.selection import (
-    apply_hook_selection,
-    filter_by_pp_rank,
-    filter_by_tp_rank,
+    hook_belongs_to_pp_rank,
+    hook_belongs_to_tp_rank,
     register_preset,
+    select_hook_specs,
     _HOOK_SELECTIONS,
     _ALL_HOOK_TYPES,
 )
@@ -121,6 +125,185 @@ _ARCH_REMAP = {
 
 
 # ---------------------------------------------------------------------------
+# Per-call request-layout / dispatch state
+# ---------------------------------------------------------------------------
+
+
+class VLLMStepPhase(Enum):
+    IDLE = auto()
+    ARMED = auto()
+    LAYOUT_READY = auto()
+    COMMITTED = auto()
+
+
+class VLLMValidationMode(Enum):
+    OFF = auto()
+    VERIFY = auto()
+
+
+@dataclass(frozen=True)
+class _VLLMRealLayout:
+    raw_req_ids: Tuple[str, ...]
+    req_ids: Tuple[str, ...]
+    scheduled_counts: Tuple[int, ...]
+    computed_counts: Tuple[int, ...]
+    token_ranges: Tuple[Tuple[int, int], ...]
+    dim0_offsets: Tuple[int, ...]
+    total_rows: int
+
+
+@dataclass
+class _VLLMStepState:
+    phase: VLLMStepPhase = VLLMStepPhase.IDLE
+    scheduler_output: Any = None
+    layout: Optional[_VLLMRealLayout] = None
+    force_eager_latch: bool = False
+    prelayout_dispatch_seen: bool = False
+    capacity_candidate: Optional[Tuple[Any, Any]] = None
+    expected_dispatch: Optional[Tuple[Any, Any]] = None
+    execution_bound: Optional[int] = None
+    real_rows_bound: Optional[int] = None
+    request_rows_bound: Optional[int] = None
+    real_cudagraph_mode: Any = None
+    real_batch_descriptor: Any = None
+
+
+@dataclass(frozen=True)
+class _VLLMHookSelection:
+    local_hooks: Tuple[HookSpec, ...]
+    candidate_rank_hook_sets: Tuple[Tuple[HookSpec, ...], ...]
+
+    @classmethod
+    def from_model(
+        cls,
+        *,
+        model: Any,
+        local_hooks: Tuple[HookSpec, ...],
+        hook_selection: str,
+        cfg: ModelShapeConfig,
+        parallel_config: Any,
+        hf_config: Any,
+    ) -> "_VLLMHookSelection":
+        """Select local and model-wide rank-type hooks once at attachment."""
+        tp_size = int(parallel_config.tensor_parallel_size)
+        pp_size = int(parallel_config.pipeline_parallel_size)
+        if tp_size < 1 or pp_size < 1:
+            raise RuntimeError(
+                f"Invalid vLLM parallel sizes: TP={tp_size}, PP={pp_size}"
+            )
+
+        num_layers = getattr(
+            hf_config,
+            "num_hidden_layers",
+            getattr(hf_config, "n_layer", None),
+        )
+        if num_layers is None:
+            raise RuntimeError("DMI vLLM model has no hidden-layer count")
+        num_layers = int(num_layers)
+
+        from vllm.compilation.cuda_graph import CUDAGraphWrapper
+
+        selection_model = (
+            model.unwrap()
+            if isinstance(model, CUDAGraphWrapper)
+            else model
+        )
+        get_hook_specs = getattr(selection_model, "get_hook_specs", None)
+        if get_hook_specs is None:
+            raise RuntimeError(
+                "DMI vLLM model does not provide get_hook_specs"
+            )
+        try:
+            model_wide_specs = get_hook_specs(model_wide=True)
+        except TypeError as exc:
+            raise RuntimeError(
+                "DMI vLLM model does not support "
+                "get_hook_specs(model_wide=True)"
+            ) from exc
+        if any(spec.module is not None for spec in model_wide_specs):
+            raise RuntimeError(
+                "DMI vLLM model-wide HookSpecs must not bind live modules"
+            )
+        inventory_layers = {
+            spec.layer_no for spec in model_wide_specs if spec.layer_no >= 0
+        }
+        if inventory_layers != set(range(num_layers)):
+            raise RuntimeError(
+                "DMI vLLM model-wide hook inventory does not cover every layer"
+            )
+
+        selected_model_wide = select_hook_specs(
+            model_wide_specs, hook_selection, cfg
+        )
+
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_intervals = tuple(
+            get_pp_indices(num_layers, pp_rank, pp_size)
+            for pp_rank in range(pp_size)
+        )
+        covered_layers = [
+            layer
+            for start, end in pp_intervals
+            for layer in range(start, end)
+        ]
+        if covered_layers != list(range(num_layers)):
+            raise RuntimeError("vLLM PP layer partition is not an exact cover")
+
+        tp_role_count = min(tp_size, 2)
+        candidate_rank_hook_sets: List[Tuple[HookSpec, ...]] = []
+        for pp_rank, (start_layer, end_layer) in enumerate(pp_intervals):
+            pp_specs = tuple(
+                spec
+                for spec in selected_model_wide
+                if (
+                    (
+                        spec.layer_no < 0
+                        or start_layer <= spec.layer_no < end_layer
+                    )
+                    and hook_belongs_to_pp_rank(
+                        spec,
+                        is_first_rank=(pp_rank == 0),
+                        is_last_rank=(pp_rank == pp_size - 1),
+                    )
+                )
+            )
+            for tp_role in range(tp_role_count):
+                candidate_rank_hook_sets.append(
+                    tuple(
+                        spec
+                        for spec in pp_specs
+                        if hook_belongs_to_tp_rank(spec, tp_role)
+                    )
+                )
+
+        return cls(
+            local_hooks=local_hooks,
+            candidate_rank_hook_sets=tuple(candidate_rank_hook_sets),
+        )
+
+
+@dataclass(frozen=True)
+class _VLLMRoleFormula:
+    real_terms: Tuple[Tuple[int, int], ...] = field(default_factory=tuple)
+    execution_terms: Tuple[Tuple[int, int], ...] = field(default_factory=tuple)
+    request_terms: Tuple[Tuple[int, int], ...] = field(default_factory=tuple)
+    hook_count: int = 0
+
+    def bytes_for(
+        self, execution_rows: int, real_rows: int, request_rows: int
+    ) -> int:
+        total = 0
+        for row_bytes, multiplicity in self.real_terms:
+            total += multiplicity * align_up_py(real_rows * row_bytes, 16)
+        for row_bytes, multiplicity in self.execution_terms:
+            total += multiplicity * align_up_py(execution_rows * row_bytes, 16)
+        for row_bytes, multiplicity in self.request_terms:
+            total += multiplicity * align_up_py(request_rows * row_bytes, 16)
+        return total
+
+
+# ---------------------------------------------------------------------------
 # VLLMAdaptor
 # ---------------------------------------------------------------------------
 
@@ -134,11 +317,10 @@ class VLLMAdaptor(BackendAdaptor):
       * Request IDs come from ``scheduler_output``, not auto-minted.
       * CUDA-graph dispatch may pad ``total_q`` up to the nearest
         capture size; meta shape must match the padded tensor.
-      * When the ring is full, the worker falls back to eager for the
-        next-determined batch (we set ``force_eager_next_batch``); the
-        wrapped ``_determine_batch_execution_and_padding`` reads + clears
-        the flag so the current batch runs unpadded, and the meta is
-        rewritten via ``adapt_for_cpu_direct``.
+      * Cached role formulas decide whether the current dispatch must be
+        eager before vLLM selects its real batch descriptor.
+      * Reservation and metadata use that real descriptor plus the packed
+        request order recorded after vLLM prepares its inputs.
     """
 
     def __init__(
@@ -148,10 +330,9 @@ class VLLMAdaptor(BackendAdaptor):
         super().__init__(engine, model_id)
         self.vllm_config = vllm_config
         self._debug_step: bool = bool(os.environ.get("RING_DEBUG_STEP"))
-        # Force-eager state lives on the active transport
-        # (self.transport.force_eager).  Set by on_capacity_exceeded;
-        # read + cleared by the _determine_batch_execution_and_padding
-        # wrapper installed in DMXGPUWorker.init_device.
+        # The per-call state carries a monotonic pre-dispatch eager latch.
+        # transport.force_eager is assigned during the actual-layout commit
+        # for the producer path of that same model step.
         # User opt-in; when True, ring transport stays in null mode after
         # warmup (kernels fire as no-ops, FIFO stays empty).
         self.user_wants_null_mode: bool = False
@@ -172,6 +353,21 @@ class VLLMAdaptor(BackendAdaptor):
         self._row_count_dev: Optional[torch.Tensor] = None      # 1 int64 on GPU
         self._pinned_row_count: Optional[torch.Tensor] = None   # 1 int64 pinned host
         self._strip_eligible_hps: List[Any] = []                # for inspection
+        self._step_state = _VLLMStepState()
+        self._validation_mode = (
+            VLLMValidationMode.VERIFY
+            if self._debug_step
+            else VLLMValidationMode.OFF
+        )
+        self._role_formulas: Tuple[_VLLMRoleFormula, ...] = ()
+        self._local_role_formula: Optional[_VLLMRoleFormula] = None
+        self._has_global_hooks = False
+        self._byte_capacity = 0
+        self._task_capacity = 0
+        self._max_num_batched_tokens = 0
+        self._max_num_seqs = 0
+        self._capture_sizes: Tuple[int, ...] = ()
+        self._max_capture_size = 0
 
     # ------- abstract overrides ---------------------------------------
 
@@ -287,73 +483,35 @@ class VLLMAdaptor(BackendAdaptor):
     def build_step_context(
         self, scheduler_output: Any, model_runner: Any
     ) -> Optional[StepContext]:
-        """Construct the per-step ``StepContext`` from vLLM's
-        scheduler_output + model_runner.
-
-        The returned ``q_len`` is the CUDA-graph-padded total token
-        count; ``adapt_for_cpu_direct`` swaps it back to ``total_q`` if
-        the driver's prepare_step returns code 2 (oversize step).
-        """
-        total_tokens = scheduler_output.total_num_scheduled_tokens
-        if total_tokens == 0:
+        """Build metadata from the real packed layout and real dispatch."""
+        state = self._step_state
+        layout = state.layout
+        batch_descriptor = state.real_batch_descriptor
+        if layout is None or batch_descriptor is None:
+            raise RuntimeError(
+                "DMI vLLM step context requested before real layout/dispatch"
+            )
+        if state.scheduler_output is not scheduler_output:
+            raise RuntimeError("DMI vLLM scheduler output changed within one step")
+        if layout.total_rows == 0:
             return None
-
-        # Why vLLM has no post-EOS strip (unlike HFAdaptor):
-        #   vLLM v1's scheduler removes finished requests from
-        #   ``scheduler_output.num_scheduled_tokens`` before the next
-        #   step.  The EOS-producing step's activation is real data
-        #   (and is captured); subsequent steps for that request never
-        #   appear in ``req_ids`` because the scheduler reassigned the
-        #   slot.  No lockstep, no post-EOS noise to filter.
-        #
-        #   HF's batched ``generate()`` is lockstep: finished requests
-        #   keep producing forward activations until the whole batch
-        #   finishes or ``max_new_tokens`` hits, so HFAdaptor needs the
-        #   per-request finished latch + zero-length token_range strip.
-        #   Do NOT propagate that pattern here -- the scheduler is
-        #   already filtering for us.
 
         self._step_counter += 1
         _step = self._step_counter
+        self._last_total_q = layout.total_rows
 
-        num_scheduled = scheduler_output.num_scheduled_tokens  # dict[req_id, int]
-        req_ids = list(num_scheduled.keys())
-        num_reqs = len(req_ids)
-        num_scheduled_per_req = list(num_scheduled.values())
-        total_q = total_tokens
-
-        padded_q = self.predict_padded_q_len(model_runner, total_q)
-        self._last_total_q = total_q
-
-        # Per-request offsets and token ranges.
-        computed_map: dict = {}
-        for new_req in scheduler_output.scheduled_new_reqs:
-            computed_map[new_req.req_id] = new_req.num_computed_tokens
-        cached = scheduler_output.scheduled_cached_reqs
-        for i, rid in enumerate(cached.req_ids):
-            computed_map[rid] = cached.num_computed_tokens[i]
-
-        offset = 0
-        req_id_list: List[str] = []
-        token_ranges: List[Tuple[int, int]] = []
-        dim0_offsets: List[int] = []
-        for i in range(num_reqs):
-            rid = req_ids[i]
-            n = num_scheduled_per_req[i]
-            pre_computed = computed_map.get(rid, 0)
-            norm_id = normalize_vllm_request_id(rid)
-            req_id_list.append(norm_id)
-            token_ranges.append((pre_computed, pre_computed + n))
-            dim0_offsets.append(offset)
-            if self._debug_step:
+        if self._debug_step:
+            for i, req_id in enumerate(layout.req_ids):
+                start, end = layout.token_ranges[i]
                 print(
-                    f"[dmx_worker] step={_step} req[{i}] rid={norm_id} "
-                    f"offset={offset} n={n} "
-                    f"t_start={pre_computed} t_end={pre_computed + n} "
-                    f"pre_computed={pre_computed} padded_q={padded_q}",
+                    f"[dmx_worker] step={_step} req[{i}] rid={req_id} "
+                    f"offset={layout.dim0_offsets[i]} "
+                    f"n={layout.scheduled_counts[i]} "
+                    f"t_start={start} t_end={end} "
+                    f"pre_computed={layout.computed_counts[i]} "
+                    f"q_len={batch_descriptor.num_tokens}",
                     flush=True,
                 )
-            offset += n
 
         # Read input_ids dtype from model_runner buffer.  On non-first
         # PP ranks the buffer may not exist; pass None (the token_ids
@@ -373,23 +531,22 @@ class VLLMAdaptor(BackendAdaptor):
         return StepContext(
             model_id=str(self.model_id),
             flattened=True,
-            req_ids=req_id_list,
-            token_ranges=token_ranges,
-            dim0_offsets=dim0_offsets,
-            kv_offsets=[0] * num_reqs,
+            req_ids=list(layout.req_ids),
+            token_ranges=list(layout.token_ranges),
+            dim0_offsets=list(layout.dim0_offsets),
+            kv_offsets=[0] * len(layout.req_ids),
             tp_rank=tp_rank,
             dp_rank=dp_rank,
             ep_rank=ep_rank,
             pp_rank=pp_rank,
             batch=0,
-            q_len=padded_q,
+            q_len=int(batch_descriptor.num_tokens),
             kv_dim=0,
-            logits_to_keep=num_reqs,
+            logits_to_keep=len(layout.req_ids),
             token_ids_dtype=ids_dtype,
-            # In gpu_padding_strip mode, eligible specs use this for shape
-            # + reservation; non-eligible specs and gpu_padding_strip=False
-            # ignore (None).
-            actual_q_len=(total_q if self.gpu_padding_strip else None),
+            actual_q_len=(
+                layout.total_rows if self.gpu_padding_strip else None
+            ),
         )
 
     # ----- gpu_padding_strip integration -----
@@ -408,25 +565,570 @@ class VLLMAdaptor(BackendAdaptor):
         baked row_bytes.
         """
         super().attach_model(model, hook_selection)
-        if not self.gpu_padding_strip:
-            return
-        device = next(model.parameters()).device if hasattr(model, "parameters") else "cuda"
-        self._row_count_dev    = torch.empty(1, dtype=torch.int64, device=device)
-        self._pinned_row_count = torch.empty(1, dtype=torch.int64, pin_memory=True)
-        for spec in self.active_specs:
-            if not spec.dim0_is_actual_tokens:
-                continue
-            hp = spec.module
-            rb = _row_bytes_for_spec(spec, self.model_cfg)
-            if rb <= 0:
-                continue
-            hp._strip_tensor    = self._row_count_dev
-            hp._strip_row_bytes = rb
-            self._strip_eligible_hps.append(hp)
+        if self.gpu_padding_strip:
+            device = (
+                next(model.parameters()).device
+                if hasattr(model, "parameters")
+                else "cuda"
+            )
+            self._row_count_dev = torch.empty(
+                1, dtype=torch.int64, device=device
+            )
+            self._pinned_row_count = torch.empty(
+                1, dtype=torch.int64, pin_memory=True
+            )
+            for spec in self.active_specs:
+                if not spec.dim0_is_actual_tokens:
+                    continue
+                hp = spec.module
+                rb = _row_bytes_for_spec(spec, self.model_cfg)
+                if rb <= 0:
+                    continue
+                hp._strip_tensor = self._row_count_dev
+                hp._strip_row_bytes = rb
+                self._strip_eligible_hps.append(hp)
 
-    def before_forward(self, *raw) -> None:
-        """Standard driver, plus per-step memcpy when gpu_padding_strip=True."""
-        super().before_forward(*raw)
+        if self.transport is not None and self.transport.null_offload:
+            return
+        cfg = self.model_cfg
+        if cfg is None or self.ring_engine is None:
+            raise RuntimeError("DMI vLLM role formulas require an attached ring")
+        selection = _VLLMHookSelection.from_model(
+            model=model,
+            local_hooks=tuple(self.active_specs),
+            hook_selection=hook_selection,
+            cfg=cfg,
+            parallel_config=self.vllm_config.parallel_config,
+            hf_config=self.vllm_config.model_config.hf_config,
+        )
+        self._compile_role_formulas(selection)
+
+    def _compile_role_formulas(
+        self, selection: _VLLMHookSelection
+    ) -> None:
+        """Compile exact byte/hook formulas for distinct TP/PP rank types."""
+        cfg = self.model_cfg
+        if cfg is None or self.ring_engine is None:
+            raise RuntimeError("DMI vLLM role formulas require an attached ring")
+
+        parallel = self.vllm_config.parallel_config
+        scheduler = self.vllm_config.scheduler_config
+        tp_size = int(parallel.tensor_parallel_size)
+        if parallel.data_parallel_size > 1 and parallel.use_ubatching:
+            raise RuntimeError(
+                "DMI vLLM does not support DP with DBO/ubatching"
+            )
+
+        try:
+            self._byte_capacity = min(
+                int(self.ring_engine.payload_cap()),
+                int(self.ring_engine.staging_cap()),
+            )
+            self._task_capacity = int(self.ring_engine.task_cap())
+            self._max_num_batched_tokens = int(
+                scheduler.max_num_batched_tokens
+            )
+            self._max_num_seqs = int(scheduler.max_num_seqs)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "DMI vLLM could not cache finite scheduler/ring bounds"
+            ) from exc
+        if (
+            self._byte_capacity <= 0
+            or self._task_capacity <= 0
+            or self._max_num_batched_tokens <= 0
+            or self._max_num_seqs <= 0
+        ):
+            raise RuntimeError("DMI vLLM scheduler/ring bounds must be positive")
+
+        compilation = self.vllm_config.compilation_config
+        capture_sizes = compilation.cudagraph_capture_sizes or ()
+        try:
+            self._capture_sizes = tuple(
+                sorted({int(size) for size in capture_sizes if int(size) > 0})
+            )
+            self._max_capture_size = int(
+                compilation.max_cudagraph_capture_size
+            )
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "DMI vLLM could not cache CUDA-graph capture bounds"
+            ) from exc
+        if self._capture_sizes and (
+            self._max_capture_size <= 0
+            or self._capture_sizes[-1] > self._max_capture_size
+        ):
+            raise RuntimeError("Invalid vLLM CUDA-graph capture sizes")
+
+        if (
+            self.vllm_config.speculative_config is not None
+            and any(
+                hook_row_basis(spec.hook_type)
+                is HookRowBasis.REQUEST_ROWS
+                for specs in selection.candidate_rank_hook_sets
+                for spec in specs
+            )
+        ):
+            raise RuntimeError(
+                "DMI vLLM request-row metadata does not support "
+                "speculative decoding"
+            )
+
+        tp_role_count = min(tp_size, 2)
+
+        def add_term(
+            terms: dict[int, int], row_bytes: int, multiplicity: int
+        ) -> None:
+            terms[row_bytes] = terms.get(row_bytes, 0) + multiplicity
+
+        def compile_formula(
+            specs: Tuple[HookSpec, ...]
+        ) -> _VLLMRoleFormula:
+            real_terms: dict[int, int] = {}
+            execution_terms: dict[int, int] = {}
+            request_terms: dict[int, int] = {}
+            hook_count = 0
+            for spec in specs:
+                row_bytes = _row_bytes_for_spec(spec, cfg)
+                if row_bytes <= 0:
+                    continue
+                row_basis = hook_row_basis(spec.hook_type)
+                if row_basis is HookRowBasis.REQUEST_ROWS:
+                    add_term(request_terms, row_bytes, 1)
+                elif self.gpu_padding_strip and spec.dim0_is_actual_tokens:
+                    add_term(real_terms, row_bytes, 1)
+                else:
+                    add_term(execution_terms, row_bytes, 1)
+                hook_count += 1
+            return _VLLMRoleFormula(
+                real_terms=tuple(sorted(real_terms.items())),
+                execution_terms=tuple(sorted(execution_terms.items())),
+                request_terms=tuple(sorted(request_terms.items())),
+                hook_count=hook_count,
+            )
+
+        candidate_formulas = tuple(
+            compile_formula(specs)
+            for specs in selection.candidate_rank_hook_sets
+        )
+
+        tp_rank, _dp_rank, _ep_rank, pp_rank = self.detect_parallel_ranks()
+        local_tp_role = 0 if tp_rank == 0 else 1
+        local_candidate_index = pp_rank * tp_role_count + local_tp_role
+        if not 0 <= local_candidate_index < len(candidate_formulas):
+            raise RuntimeError("DMI vLLM could not identify its local role")
+        local_formula = candidate_formulas[local_candidate_index]
+        concrete_formula = compile_formula(selection.local_hooks)
+        if local_formula != concrete_formula:
+            raise RuntimeError(
+                "DMI vLLM cached role formula does not match local hook layout: "
+                f"cached={local_formula}, concrete={concrete_formula}"
+            )
+
+        self._role_formulas = tuple(dict.fromkeys(candidate_formulas))
+        self._local_role_formula = local_formula
+        self._has_global_hooks = any(
+            formula.hook_count > 0 for formula in self._role_formulas
+        )
+        max_hooks = max(
+            (formula.hook_count for formula in self._role_formulas),
+            default=0,
+        )
+        if max_hooks > self._task_capacity:
+            raise RuntimeError(
+                "DMI vLLM selected hooks exceed task-ring capacity: "
+                f"hooks={max_hooks}, capacity={self._task_capacity}"
+            )
+
+    def _record_real_layout(
+        self,
+        scheduler_output: Any,
+        model_runner: Any,
+        num_scheduled_tokens: Any,
+    ) -> None:
+        """Copy and validate the packed order produced by real vLLM prep."""
+        state = self._step_state
+        if state.phase is not VLLMStepPhase.ARMED:
+            raise RuntimeError(
+                "DMI vLLM observed duplicate or unarmed _prepare_inputs"
+            )
+        if state.scheduler_output is not scheduler_output:
+            raise RuntimeError("DMI vLLM scheduler output changed during prep")
+
+        num_reqs = int(model_runner.input_batch.num_reqs)
+        raw_req_ids = tuple(model_runner.input_batch.req_ids[:num_reqs])
+        scheduled_counts = tuple(
+            int(value) for value in num_scheduled_tokens
+        )
+        computed_counts = tuple(
+            int(value)
+            for value in model_runner.input_batch.num_computed_tokens_cpu[
+                :num_reqs
+            ]
+        )
+        if (
+            len(raw_req_ids) != num_reqs
+            or len(scheduled_counts) != num_reqs
+            or len(computed_counts) != num_reqs
+        ):
+            raise RuntimeError("DMI vLLM packed layout lengths disagree")
+        if any(not isinstance(req_id, str) for req_id in raw_req_ids):
+            raise RuntimeError("DMI vLLM request IDs must be strings")
+        if len(set(raw_req_ids)) != num_reqs:
+            raise RuntimeError("DMI vLLM packed request IDs are not unique")
+
+        req_ids = tuple(
+            normalize_vllm_request_id(req_id) for req_id in raw_req_ids
+        )
+        if len(set(req_ids)) != num_reqs:
+            raise RuntimeError(
+                "DMI vLLM normalized request IDs are not unique"
+            )
+        if any(value < 0 for value in scheduled_counts):
+            raise RuntimeError("DMI vLLM scheduled token count is negative")
+        if any(value < 0 for value in computed_counts):
+            raise RuntimeError("DMI vLLM computed token count is negative")
+
+        scheduler_counts = scheduler_output.num_scheduled_tokens
+        if (
+            len(scheduler_counts) != num_reqs
+            or set(scheduler_counts) != set(raw_req_ids)
+        ):
+            raise RuntimeError(
+                "DMI vLLM packed IDs do not match scheduler membership"
+            )
+        for req_id, count in zip(raw_req_ids, scheduled_counts):
+            if int(scheduler_counts[req_id]) != count:
+                raise RuntimeError(
+                    f"DMI vLLM scheduled count mismatch for {req_id!r}"
+                )
+
+        total_rows = sum(scheduled_counts)
+        if total_rows != int(scheduler_output.total_num_scheduled_tokens):
+            raise RuntimeError(
+                "DMI vLLM packed rows do not match scheduler total"
+            )
+
+        offsets: List[int] = []
+        token_ranges: List[Tuple[int, int]] = []
+        offset = 0
+        for scheduled, computed in zip(
+            scheduled_counts, computed_counts
+        ):
+            offsets.append(offset)
+            token_ranges.append((computed, computed + scheduled))
+            offset += scheduled
+        if offset != total_rows:
+            raise RuntimeError("DMI vLLM packed offsets do not cover all rows")
+
+        state.layout = _VLLMRealLayout(
+            raw_req_ids=raw_req_ids,
+            req_ids=req_ids,
+            scheduled_counts=scheduled_counts,
+            computed_counts=computed_counts,
+            token_ranges=tuple(token_ranges),
+            dim0_offsets=tuple(offsets),
+            total_rows=total_rows,
+        )
+        state.phase = VLLMStepPhase.LAYOUT_READY
+
+    def _preview_exact_dispatch(
+        self,
+        model_runner: Any,
+        *,
+        num_tokens: int,
+        num_reqs: int,
+        max_num_scheduled_tokens: int,
+        use_cascade_attn: bool,
+        force_eager: bool,
+        force_uniform_decode: Optional[bool],
+        force_has_lora: Optional[bool],
+        force_num_active_loras: Optional[int],
+        num_encoder_reqs: int,
+    ) -> Tuple[Any, Any]:
+        """Run only vLLM's read-only dispatcher calculation."""
+        from vllm.config import CUDAGraphMode
+
+        uniform_decode = model_runner._is_uniform_decode(
+            max_num_scheduled_tokens=max_num_scheduled_tokens,
+            uniform_decode_query_len=model_runner.uniform_decode_query_len,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            force_uniform_decode=force_uniform_decode,
+        )
+        has_encoder_output = (
+            model_runner.model_config.is_encoder_decoder
+            and num_encoder_reqs > 0
+        )
+        num_active_loras = (
+            force_num_active_loras
+            if force_num_active_loras is not None
+            else len(model_runner.input_batch.lora_id_to_lora_request)
+        )
+        has_lora = (
+            num_active_loras > 0
+            if force_has_lora is None
+            else force_has_lora
+        )
+        valid_modes = (
+            {CUDAGraphMode.NONE}
+            if force_eager
+            else set(CUDAGraphMode.valid_runtime_modes())
+        )
+        invalid_modes = (
+            {CUDAGraphMode.FULL}
+            if use_cascade_attn or has_encoder_output
+            else set()
+        )
+        return model_runner.cudagraph_dispatcher.dispatch(
+            num_tokens=num_tokens,
+            has_lora=has_lora,
+            uniform_decode=uniform_decode,
+            num_active_loras=num_active_loras,
+            valid_modes=valid_modes,
+            invalid_modes=invalid_modes,
+        )
+
+    def _conservative_execution_bound(
+        self, num_tokens: int, num_reqs: int
+    ) -> Tuple[int, int, int]:
+        """Return bounded execution, real-row, and request-row counts."""
+        parallel = self.vllm_config.parallel_config
+        compilation = self.vllm_config.compilation_config
+        if parallel.data_parallel_size > 1:
+            real_rows = self._max_num_batched_tokens
+            request_rows = self._max_num_seqs
+        else:
+            real_rows = int(num_tokens)
+            request_rows = int(num_reqs)
+
+        dispatch_rows = real_rows
+        if compilation.pass_config.enable_sp:
+            tp_size = int(parallel.tensor_parallel_size)
+            dispatch_rows = (
+                (dispatch_rows + tp_size - 1) // tp_size
+            ) * tp_size
+
+        execution_rows = dispatch_rows
+        if (
+            self._capture_sizes
+            and dispatch_rows <= self._max_capture_size
+        ):
+            execution_rows = self._max_capture_size
+        if execution_rows < dispatch_rows:
+            raise RuntimeError(
+                "DMI vLLM conservative graph bound is not an upper bound"
+            )
+        return execution_rows, real_rows, request_rows
+
+    def _preflight_force_eager(
+        self,
+        model_runner: Any,
+        *,
+        num_tokens: int,
+        num_reqs: int,
+        max_num_scheduled_tokens: int,
+        use_cascade_attn: bool,
+        caller_force_eager: bool,
+        force_uniform_decode: Optional[bool],
+        force_has_lora: Optional[bool],
+        force_num_active_loras: Optional[int],
+        num_encoder_reqs: int,
+    ) -> bool:
+        """Evaluate cached worst-role formulas with no transport effects."""
+        state = self._step_state
+        parallel = self.vllm_config.parallel_config
+        compilation = self.vllm_config.compilation_config
+        exact = (
+            not compilation.pass_config.enable_sp
+            and parallel.data_parallel_size == 1
+            and not parallel.enable_expert_parallel
+        )
+
+        if exact:
+            capacity_candidate = self._preview_exact_dispatch(
+                model_runner,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_num_scheduled_tokens=max_num_scheduled_tokens,
+                use_cascade_attn=use_cascade_attn,
+                force_eager=(
+                    caller_force_eager or state.force_eager_latch
+                ),
+                force_uniform_decode=force_uniform_decode,
+                force_has_lora=force_has_lora,
+                force_num_active_loras=force_num_active_loras,
+                num_encoder_reqs=num_encoder_reqs,
+            )
+            state.capacity_candidate = capacity_candidate
+            state.execution_bound = None
+            state.real_rows_bound = None
+            state.request_rows_bound = None
+            execution_rows = int(capacity_candidate[1].num_tokens)
+            real_rows = int(num_tokens)
+            request_rows = int(num_reqs)
+        else:
+            (
+                execution_rows,
+                real_rows,
+                request_rows,
+            ) = self._conservative_execution_bound(
+                num_tokens, num_reqs
+            )
+            state.capacity_candidate = None
+            state.execution_bound = execution_rows
+            state.real_rows_bound = real_rows
+            state.request_rows_bound = request_rows
+
+        worst_bytes = max(
+            (
+                formula.bytes_for(
+                    execution_rows, real_rows, request_rows
+                )
+                for formula in self._role_formulas
+            ),
+            default=0,
+        )
+        force_eager = worst_bytes > self._byte_capacity
+
+        if (
+            exact
+            and self._validation_mode is VLLMValidationMode.VERIFY
+        ):
+            state.expected_dispatch = self._preview_exact_dispatch(
+                model_runner,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_num_scheduled_tokens=max_num_scheduled_tokens,
+                use_cascade_attn=use_cascade_attn,
+                force_eager=(
+                    caller_force_eager
+                    or state.force_eager_latch
+                    or force_eager
+                ),
+                force_uniform_decode=force_uniform_decode,
+                force_has_lora=force_has_lora,
+                force_num_active_loras=force_num_active_loras,
+                num_encoder_reqs=num_encoder_reqs,
+            )
+        else:
+            state.expected_dispatch = None
+        return force_eager
+
+    def _commit_actual_dispatch(
+        self,
+        scheduler_output: Any,
+        model_runner: Any,
+        cudagraph_mode: Any,
+        batch_descriptor: Any,
+        combined_force_eager: bool,
+    ) -> None:
+        """Commit metadata/reservation from the real layout and descriptor."""
+        state = self._step_state
+        layout = state.layout
+        if state.phase is not VLLMStepPhase.LAYOUT_READY or layout is None:
+            raise RuntimeError(
+                "DMI vLLM dispatch committed without one real layout"
+            )
+        if int(batch_descriptor.num_tokens) < layout.total_rows:
+            raise RuntimeError(
+                "DMI vLLM dispatch has fewer rows than the packed layout"
+            )
+
+        state.real_cudagraph_mode = cudagraph_mode
+        state.real_batch_descriptor = batch_descriptor
+
+        if self._validation_mode is VLLMValidationMode.VERIFY:
+            if state.expected_dispatch is not None:
+                if state.expected_dispatch != (
+                    cudagraph_mode,
+                    batch_descriptor,
+                ):
+                    raise RuntimeError(
+                        "DMI vLLM exact dispatch preview disagrees with vLLM"
+                    )
+            elif state.execution_bound is not None:
+                if int(batch_descriptor.num_tokens) > state.execution_bound:
+                    raise RuntimeError(
+                        "DMI vLLM execution rows exceed conservative bound"
+                    )
+                if (
+                    state.real_rows_bound is None
+                    or layout.total_rows > state.real_rows_bound
+                    or state.request_rows_bound is None
+                    or len(layout.req_ids) > state.request_rows_bound
+                ):
+                    raise RuntimeError(
+                        "DMI vLLM real layout exceeds conservative bound"
+                    )
+
+        ctx = self.build_step_context(scheduler_output, model_runner)
+        if ctx is None:
+            raise RuntimeError("DMI vLLM committed an empty armed step")
+        actual_plan = self._compute_step_plan(ctx)
+        actual_bytes, actual_hooks, actual_needs_eager = actual_plan
+        if actual_hooks > self._task_capacity:
+            raise RuntimeError(
+                "DMI vLLM actual hook count exceeds cached task capacity"
+            )
+        actual_requires_eager = (
+            actual_needs_eager
+            or actual_bytes > self._byte_capacity
+        )
+        if actual_requires_eager and not combined_force_eager:
+            raise RuntimeError(
+                "DMI vLLM eager preflight produced a false negative"
+            )
+
+        if self._validation_mode is VLLMValidationMode.VERIFY:
+            formula = self._local_role_formula
+            if formula is None:
+                raise RuntimeError("DMI vLLM local role formula is missing")
+            formula_plan = (
+                formula.bytes_for(
+                    int(batch_descriptor.num_tokens),
+                    layout.total_rows,
+                    len(layout.req_ids),
+                ),
+                formula.hook_count,
+            )
+            if formula_plan != actual_plan[:2] or actual_needs_eager:
+                raise RuntimeError(
+                    "DMI vLLM cached local formula disagrees with actual plan: "
+                    f"cached={formula_plan}, actual={actual_plan}"
+                )
+
+        self.before_forward(ctx, actual_plan)
+        state.phase = VLLMStepPhase.COMMITTED
+
+    def before_forward(
+        self, ctx: StepContext, step_plan: Tuple[int, int, bool]
+    ) -> None:
+        """Commit one precomputed plan, then update padding-strip rows."""
+        if self.transport is None or self.transport.null_offload:
+            return
+
+        total_bytes, n_hooks, needs_eager = step_plan
+        if n_hooks > 0:
+            result = self.ring_engine.prepare_step(total_bytes, n_hooks)
+            self.transport.force_eager = (result == 2) or needs_eager
+            if result == 2:
+                ctx = self.adapt_for_cpu_direct(ctx)
+                self.on_capacity_exceeded(ctx)
+                self._warn_once_capacity(ctx, total_bytes, n_hooks)
+        else:
+            self.transport.force_eager = False
+
+        self.transport.set_step_context(**ctx.transport_kwargs())
+        self.transport.pre_push_all_metas(
+            batch=ctx.batch,
+            q_len=ctx.q_len,
+            kv_dim=ctx.kv_dim,
+            logits_to_keep=ctx.logits_to_keep,
+            token_ids_dtype=ctx.token_ids_dtype,
+            actual_q_len=ctx.actual_q_len,
+        )
+
         if (self.gpu_padding_strip
                 and self._pinned_row_count is not None
                 and self._row_count_dev is not None
@@ -475,11 +1177,12 @@ class DMXGPUWorker(Worker):
 
     Lifecycle:
       ``init_device``           -- super + build engine + adaptor + null mode +
-                                    wrap _determine_batch_execution_and_padding.
+                                    wrap input preparation and dispatch.
       ``load_model``            -- arch remap + super + adaptor.attach_model.
       ``compile_or_warm_up_model`` -- super + clear null_mode (unless user
                                        opted-in via ``dmx_null_mode``).
-      ``execute_model``         -- adaptor.before_forward + super.
+      ``execute_model``         -- arm per-call state + super; the dispatch
+                                    wrapper commits DMI metadata before forward.
       ``stop_monitoring``       -- adaptor.close (CUDA sync, ring stop,
                                     deactivate transport, host engine stop).
       ``shutdown``              -- best-effort stop_monitoring + super.
@@ -555,7 +1258,7 @@ class DMXGPUWorker(Worker):
             65536))
         ring_cfg.drain_flush_timeout_us = int(_cfg(
             ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US",
-            100 * 1000))
+            0))
 
         # MonitoringEngine + ring transport.
         engine = MonitoringEngine(
@@ -585,21 +1288,136 @@ class DMXGPUWorker(Worker):
         # explicitly opted in to permanent null mode.
         self.adaptor.ring_engine.set_null_mode(True)
 
-        # Wrap _determine_batch_execution_and_padding so the adapter
-        # can request eager for the current batch via on_capacity_exceeded.
+        # DMI's transport and native active-engine slots are process/device
+        # global. This integration therefore assumes one active monitored
+        # engine/forward owner per process.
         adaptor = self.adaptor
+        model_runner = self.model_runner
+        orig_prepare = model_runner._prepare_inputs
         orig_fn = self.model_runner._determine_batch_execution_and_padding
 
-        def _wrapped_determine(*args: Any, **kwargs: Any) -> Any:
-            # Read-only.  transport.force_eager is owned by
-            # before_forward (per-batch reassignment); clearing here
-            # would hide this batch's force_eager from HookPoint.forward
-            # since the dispatch wrapper fires BEFORE the model forward.
-            if adaptor.transport.force_eager:
-                kwargs["force_eager"] = True
-            return orig_fn(*args, **kwargs)
+        def _wrapped_prepare(
+            scheduler_output: Any,
+            num_scheduled_tokens: np.ndarray,
+        ) -> Any:
+            result = orig_prepare(
+                scheduler_output,
+                num_scheduled_tokens,
+            )
+            phase = adaptor._step_state.phase
+            if phase is VLLMStepPhase.ARMED:
+                adaptor._record_real_layout(
+                    scheduler_output,
+                    model_runner,
+                    num_scheduled_tokens,
+                )
+            elif phase is not VLLMStepPhase.IDLE:
+                raise RuntimeError(
+                    "DMI vLLM observed a second _prepare_inputs in one step"
+                )
+            return result
 
-        self.model_runner._determine_batch_execution_and_padding = _wrapped_determine
+        def _wrapped_determine(
+            num_tokens: int,
+            num_reqs: int,
+            num_scheduled_tokens_np: np.ndarray,
+            max_num_scheduled_tokens: int,
+            use_cascade_attn: bool,
+            allow_microbatching: bool = True,
+            force_eager: bool = False,
+            force_uniform_decode: Optional[bool] = None,
+            force_has_lora: Optional[bool] = None,
+            force_num_active_loras: Optional[int] = None,
+            num_encoder_reqs: int = 0,
+        ) -> Any:
+            state = adaptor._step_state
+            if state.phase is VLLMStepPhase.IDLE:
+                return orig_fn(
+                    num_tokens=num_tokens,
+                    num_reqs=num_reqs,
+                    num_scheduled_tokens_np=num_scheduled_tokens_np,
+                    max_num_scheduled_tokens=max_num_scheduled_tokens,
+                    use_cascade_attn=use_cascade_attn,
+                    allow_microbatching=allow_microbatching,
+                    force_eager=force_eager,
+                    force_uniform_decode=force_uniform_decode,
+                    force_has_lora=force_has_lora,
+                    force_num_active_loras=force_num_active_loras,
+                    num_encoder_reqs=num_encoder_reqs,
+                )
+            if state.phase is VLLMStepPhase.COMMITTED:
+                raise RuntimeError(
+                    "DMI vLLM observed dispatch after metadata commit"
+                )
+            if state.phase not in {
+                VLLMStepPhase.ARMED,
+                VLLMStepPhase.LAYOUT_READY,
+            }:
+                raise RuntimeError(
+                    f"DMI vLLM invalid dispatch phase: {state.phase}"
+                )
+
+            state.force_eager_latch |= adaptor._preflight_force_eager(
+                model_runner,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_num_scheduled_tokens=max_num_scheduled_tokens,
+                use_cascade_attn=use_cascade_attn,
+                caller_force_eager=force_eager,
+                force_uniform_decode=force_uniform_decode,
+                force_has_lora=force_has_lora,
+                force_num_active_loras=force_num_active_loras,
+                num_encoder_reqs=num_encoder_reqs,
+            )
+            combined_force_eager = force_eager or state.force_eager_latch
+            result = orig_fn(
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                num_scheduled_tokens_np=num_scheduled_tokens_np,
+                max_num_scheduled_tokens=max_num_scheduled_tokens,
+                use_cascade_attn=use_cascade_attn,
+                allow_microbatching=allow_microbatching,
+                force_eager=combined_force_eager,
+                force_uniform_decode=force_uniform_decode,
+                force_has_lora=force_has_lora,
+                force_num_active_loras=force_num_active_loras,
+                num_encoder_reqs=num_encoder_reqs,
+            )
+
+            if state.phase is VLLMStepPhase.ARMED:
+                parallel = adaptor.vllm_config.parallel_config
+                compilation = adaptor.vllm_config.compilation_config
+                if (
+                    parallel.pipeline_parallel_size <= 1
+                    or not compilation.pass_config.enable_sp
+                    or state.prelayout_dispatch_seen
+                ):
+                    raise RuntimeError(
+                        "DMI vLLM observed unexpected pre-layout dispatch"
+                    )
+                state.prelayout_dispatch_seen = True
+                if (
+                    adaptor._validation_mode
+                    is VLLMValidationMode.VERIFY
+                    and state.execution_bound is not None
+                    and int(result[1].num_tokens) > state.execution_bound
+                ):
+                    raise RuntimeError(
+                        "DMI vLLM early dispatch exceeds conservative bound"
+                    )
+                return result
+
+            adaptor._commit_actual_dispatch(
+                state.scheduler_output,
+                model_runner,
+                result[0],
+                result[1],
+                combined_force_eager,
+            )
+            return result
+
+        model_runner._prepare_inputs = _wrapped_prepare
+        model_runner._determine_batch_execution_and_padding = _wrapped_determine
 
         # Backwards-compat attributes for external subclasses that read
         # the pre-refactor names (e.g. tests/compare_worker.py reads
@@ -650,12 +1468,35 @@ class DMXGPUWorker(Worker):
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:
+        adaptor = self.adaptor
         if (
-            self.adaptor is not None
-            and scheduler_output.total_num_scheduled_tokens > 0
+            adaptor is None
+            or scheduler_output.total_num_scheduled_tokens <= 0
+            or adaptor.transport is None
+            or adaptor.transport.null_offload
+            or not adaptor._has_global_hooks
+            # EC producers return after state update without preparing or
+            # executing a model batch, so there is no DMI step to commit.
+            or (has_ec_transfer() and get_ec_transfer().is_producer)
         ):
-            self.adaptor.before_forward(scheduler_output, self.model_runner)
-        return super().execute_model(scheduler_output)
+            return super().execute_model(scheduler_output)
+        if adaptor._step_state.phase is not VLLMStepPhase.IDLE:
+            raise RuntimeError("DMI vLLM execute_model calls overlap")
+
+        adaptor._step_state = _VLLMStepState(
+            phase=VLLMStepPhase.ARMED,
+            scheduler_output=scheduler_output,
+        )
+        state = adaptor._step_state
+        try:
+            result = super().execute_model(scheduler_output)
+            if state.phase is not VLLMStepPhase.COMMITTED:
+                raise RuntimeError(
+                    "DMI vLLM forward completed without metadata commit"
+                )
+            return result
+        finally:
+            adaptor._step_state = _VLLMStepState()
 
     def stop_monitoring(self) -> None:
         """Flush and stop DMI engine.  Reentrant: second call no-ops."""

--- a/monitoring/csrc/ring/ring_config.h
+++ b/monitoring/csrc/ring/ring_config.h
@@ -28,7 +28,7 @@ inline uint64_t align_up(uint64_t x, uint64_t a) {
 struct DrainFlushConfig {
     // Ratio thresholds (fraction of capacity; 0.0 = disabled)
     float task_ratio     = 0.0f;   // flush at N% task queue usage
-    float payload_ratio  = 0.0f;   // flush at N% payload ring usage
+    float payload_ratio  = 0.5f;   // flush at N% payload ring usage
 
     // Absolute thresholds (0 = disabled)
     uint64_t entry_threshold = 0;  // flush after N entries ready
@@ -36,7 +36,7 @@ struct DrainFlushConfig {
 
     // Time-based flush: if a complete tensor has been pending for longer
     // than this many microseconds, flush unconditionally.  0 = disabled.
-    uint64_t timeout_us = 100ULL * 1000;
+    uint64_t timeout_us = 0;
 };
 
 // ---------------------------------------------------------------------------

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -27,10 +27,10 @@ struct RingConfig {
     uint64_t drain_poll_timeout_us      = 100;
     // Drain flush thresholds
     float    drain_flush_task_ratio     = 0.0f;
-    float    drain_flush_payload_ratio  = 0.0f;
+    float    drain_flush_payload_ratio  = 0.5f;
     uint64_t drain_flush_entry_threshold = 0;
     uint64_t drain_flush_byte_threshold  = 0;
-    uint64_t drain_flush_timeout_us      = 100ULL * 1000;
+    uint64_t drain_flush_timeout_us      = 0;
     // Clone per-request slices
     bool     clone_slices               = false;
     // ClickHouse insert queue limits

--- a/monitoring/csrc/ring/tensor_meta.h
+++ b/monitoring/csrc/ring/tensor_meta.h
@@ -105,7 +105,7 @@ static constexpr HookDef HOOK_DEFS[] = {
     {HOOK_TYPE_MLP_IN,      "hook_mlp_in",              "mlp_in",       true,  GROUP_MLP,   false, SHAPE_HIDDEN,   PP_ANY  },
     {HOOK_TYPE_MLP_OUT,     "hook_mlp_out",             "mlp_out",      true,  GROUP_MLP,   false, SHAPE_HIDDEN,   PP_ANY  },
     {HOOK_TYPE_MLP_POST,    "hook_mlp_post",            "mlp_post",     true,  GROUP_MLP,   true,  SHAPE_MLP_POST, PP_ANY  },
-    {HOOK_TYPE_RESID_FINAL, "hook_resid_final",         "resid_final",  false, GROUP_OTHER, false, SHAPE_HIDDEN,   PP_ANY  },
+    {HOOK_TYPE_RESID_FINAL, "hook_resid_final",         "resid_final",  false, GROUP_OTHER, false, SHAPE_HIDDEN,   PP_LAST  },
     {HOOK_TYPE_EMBED,       "hook_embed",               "embed",        false, GROUP_OTHER, false, SHAPE_HIDDEN,   PP_FIRST},
     {HOOK_TYPE_POS_EMBED,   "hook_pos_embed",           "pos_embed",    false, GROUP_OTHER, false, SHAPE_HIDDEN,   PP_FIRST},
     {HOOK_TYPE_FINAL_LN,    "hook_final_ln",            "final_ln",     false, GROUP_OTHER, false, SHAPE_HIDDEN,   PP_LAST },

--- a/monitoring/engine.py
+++ b/monitoring/engine.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Sequence
 from .config import MonitoringConfig
 
 
-DEFAULT_DRAIN_FLUSH_TIMEOUT_US = 100 * 1000
+DEFAULT_DRAIN_FLUSH_TIMEOUT_US = 0
 
 
 @dataclass

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -16,6 +16,7 @@ All transport now uses the CUDA-graph-compatible forward-hook path.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -64,10 +65,28 @@ SHAPE_HIDDEN, SHAPE_QKV_Q, SHAPE_QKV_KV, SHAPE_QKV_Z = 0, 1, 2, 3
 SHAPE_ATTN_WT, SHAPE_MLP_POST, SHAPE_TOKEN_IDS, SHAPE_LOGITS = 4, 5, 6, 7
 PP_ANY, PP_FIRST, PP_LAST = 0, 1, 2
 
+
+class HookRowBasis(Enum):
+    """Per-step cardinality that scales a registered hook's payload.
+
+    ``TOKEN_ROWS`` means the shape scales with ``q_len``. In packed vLLM,
+    padding-strip eligibility separately decides whether the adapter uses the
+    actual token count or the padded execution count. ``REQUEST_ROWS`` means
+    the packed-vLLM shape scales with the request count supplied through
+    ``logits_to_keep``. This enum does not describe tensor dimension order,
+    rank ownership, or prefix-strip eligibility.
+    """
+
+    TOKEN_ROWS = auto()
+    REQUEST_ROWS = auto()
+
+
 # Auto-derive all mappings
 _id_by_short: Dict[str, int] = {}       # "q" -> 6
+_shape_class_by_type: Dict[int, int] = {}
 for _id, _act, _short, _pl, _grp, _tp, _sc, _pp in _HOOK_DEFS:
     _id_by_short[_short] = _id
+    _shape_class_by_type[_id] = _sc
     # Inject HOOK_TYPE_Q, HOOK_TYPE_RESID_PRE, etc. into module namespace
     globals()[f"HOOK_TYPE_{_short.upper()}"] = _id
 
@@ -97,6 +116,24 @@ PP_LAST_ONLY: frozenset = frozenset(
 )
 
 del _ext, _load_ext
+
+
+def hook_row_basis(hook_type: int) -> HookRowBasis:
+    """Return the canonical row basis derived from `_HOOK_DEFS.shape_class`.
+
+    The native hook-definition table is the sole mapping source. Logit-shaped
+    payloads are request-scaled; every other registered shape class is
+    token-scaled. An unregistered hook type is a configuration error.
+    """
+
+    try:
+        shape_class = _shape_class_by_type[hook_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown hook type: {hook_type!r}") from exc
+    if shape_class == SHAPE_LOGITS:
+        return HookRowBasis.REQUEST_ROWS
+    return HookRowBasis.TOKEN_ROWS
+
 
 # Hook selection (presets, resolve/apply, PP/TP filters) lives in
 # monitoring/selection.py -- that module imports the C++-mirror constants
@@ -163,7 +200,7 @@ class ModelShapeConfig:
 class HookSpec:
     """One monitoring hook: type, layer, shape convention, and module reference."""
     hook_type: int                        # HOOK_TYPE_* -- determines shape formula
-    module:    nn.Module                  # the HookPoint instance
+    module:    Optional[nn.Module]        # HookPoint, or None for model-wide specs
     layer_no:  int = -1                   # layer index (-1 for global hooks like embed, final_ln)
     dtype:     Optional[torch.dtype] = None  # override model dtype (e.g. int64 for token_ids)
     # True when the producer kernel may write fewer (or more) bytes than the
@@ -371,6 +408,10 @@ def install_ring_hooks(specs: List[HookSpec],
     """
     for spec in specs:
         hp = spec.module
+        if hp is None:
+            raise RuntimeError(
+                "install_ring_hooks received an unbound model-wide HookSpec"
+            )
         hp._ring_hook_type = spec.hook_type
         hp._ring_hook_id = spec.layer_no
         hp._ring_payload = ring_payload

--- a/monitoring/selection.py
+++ b/monitoring/selection.py
@@ -115,6 +115,29 @@ def resolve_hook_selection(mode: str) -> frozenset:
     return frozenset(result)
 
 
+def select_hook_specs(
+    specs: List["HookSpec"],
+    mode: str,
+    cfg: Optional["ModelShapeConfig"] = None,
+) -> List["HookSpec"]:
+    """Purely filter specs by selection and available shape configuration."""
+    allowed = resolve_hook_selection(mode)
+    unavailable = set()
+    if cfg is not None:
+        if cfg.intermediate_dim == 0:
+            unavailable.add(HOOK_TYPE_MLP_POST)
+        if cfg.num_experts == 0:
+            unavailable.add(HOOK_TYPE_ROUTER_LOGITS)
+        if cfg.top_k == 0:
+            unavailable.add(HOOK_TYPE_TOPK_IDS)
+            unavailable.add(HOOK_TYPE_TOPK_WEIGHTS)
+    return [
+        spec
+        for spec in specs
+        if spec.hook_type in allowed and spec.hook_type not in unavailable
+    ]
+
+
 def apply_hook_selection(
     specs: List["HookSpec"],
     mode: str,
@@ -131,33 +154,30 @@ def apply_hook_selection(
     Sets enabled=True on hooks in the set, enabled=False on others.
     Returns the filtered list of enabled specs (for _active_specs / metadata).
     """
-    allowed = resolve_hook_selection(mode)
-
-    # Hooks that require specific model config fields
-    _SKIP = set()
+    enabled_specs = select_hook_specs(specs, mode, cfg)
+    enabled_ids = {id(spec) for spec in enabled_specs}
+    unavailable = set()
     if cfg is not None:
         if cfg.intermediate_dim == 0:
-            _SKIP.add(HOOK_TYPE_MLP_POST)
+            unavailable.add(HOOK_TYPE_MLP_POST)
         if cfg.num_experts == 0:
-            _SKIP.add(HOOK_TYPE_ROUTER_LOGITS)
+            unavailable.add(HOOK_TYPE_ROUTER_LOGITS)
         if cfg.top_k == 0:
-            _SKIP.add(HOOK_TYPE_TOPK_IDS)
-            _SKIP.add(HOOK_TYPE_TOPK_WEIGHTS)
+            unavailable.add(HOOK_TYPE_TOPK_IDS)
+            unavailable.add(HOOK_TYPE_TOPK_WEIGHTS)
 
-    enabled_specs = []
     for spec in specs:
-        if spec.hook_type in _SKIP:
-            spec.module.enabled = False
+        if spec.module is None:
+            raise RuntimeError(
+                "apply_hook_selection requires bound executable HookSpecs"
+            )
+        spec.module.enabled = id(spec) in enabled_ids
+        if spec.hook_type in unavailable:
             import warnings
             warnings.warn(
                 f"[apply_hook_selection] Skipping hook_type={spec.hook_type} "
                 f"layer={spec.layer_no}: required model config unavailable "
                 f"(e.g. intermediate_dim=0)")
-        elif spec.hook_type in allowed:
-            spec.module.enabled = True
-            enabled_specs.append(spec)
-        else:
-            spec.module.enabled = False
     return enabled_specs
 
 
@@ -165,14 +185,31 @@ def apply_hook_selection(
 # PP / TP filters (used by adapters during attach_model)
 # ---------------------------------------------------------------------------
 
+def hook_belongs_to_pp_rank(
+    spec: "HookSpec", is_first_rank: bool, is_last_rank: bool
+) -> bool:
+    """Return whether a hook belongs to the given PP-stage role."""
+    if spec.hook_type in PP_FIRST_ONLY and not is_first_rank:
+        return False
+    if spec.hook_type in PP_LAST_ONLY and not is_last_rank:
+        return False
+    return True
+
+
+def hook_belongs_to_tp_rank(spec: "HookSpec", tp_rank: int) -> bool:
+    """Return whether a hook belongs to the given TP-rank role."""
+    return tp_rank == 0 or spec.hook_type in TP_SHARDED_TYPES
+
+
 def filter_by_pp_rank(specs: list, is_first_rank: bool, is_last_rank: bool) -> list:
     """Drop hooks that are PP-stage-restricted and not on this rank."""
     filtered = []
     for s in specs:
-        if s.hook_type in PP_FIRST_ONLY and not is_first_rank:
-            s.module.enabled = False
-            continue
-        if s.hook_type in PP_LAST_ONLY and not is_last_rank:
+        if not hook_belongs_to_pp_rank(s, is_first_rank, is_last_rank):
+            if s.module is None:
+                raise RuntimeError(
+                    "filter_by_pp_rank requires bound executable HookSpecs"
+                )
             s.module.enabled = False
             continue
         filtered.append(s)
@@ -186,7 +223,11 @@ def filter_by_tp_rank(specs: list, tp_rank: int) -> list:
         return specs
     filtered = []
     for s in specs:
-        if s.hook_type not in TP_SHARDED_TYPES:
+        if not hook_belongs_to_tp_rank(s, tp_rank):
+            if s.module is None:
+                raise RuntimeError(
+                    "filter_by_tp_rank requires bound executable HookSpecs"
+                )
             s.module.enabled = False
             continue
         filtered.append(s)
@@ -196,7 +237,10 @@ def filter_by_tp_rank(specs: list, tp_rank: int) -> list:
 __all__ = [
     "register_preset",
     "resolve_hook_selection",
+    "select_hook_specs",
     "apply_hook_selection",
+    "hook_belongs_to_pp_rank",
+    "hook_belongs_to_tp_rank",
     "filter_by_pp_rank",
     "filter_by_tp_rank",
 ]

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -56,23 +56,66 @@ class CompareWorker(DMXGPUWorker):
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:
-        # Collect per-request metadata BEFORE forward
         total_tokens = scheduler_output.total_num_scheduled_tokens
-        num_scheduled = scheduler_output.num_scheduled_tokens
-        req_ids = list(num_scheduled.keys())
-        num_per_req = list(num_scheduled.values())
-
-        computed_map: dict = {}
-        for new_req in scheduler_output.scheduled_new_reqs:
-            computed_map[new_req.req_id] = new_req.num_computed_tokens
-        cached = scheduler_output.scheduled_cached_reqs
-        for i, rid in enumerate(cached.req_ids):
-            computed_map[rid] = cached.num_computed_tokens[i]
+        should_save = bool(self._compare_output_dir and total_tokens > 0)
+        adaptor = self.adaptor
+        if should_save:
+            if adaptor is None or adaptor.transport is None:
+                raise RuntimeError(
+                    "CompareWorker requires active DMI transport"
+                )
+            step_before = adaptor._step_counter
 
         # Run forward (DMXGPUWorker.execute_model handles ring transport)
         result = super().execute_model(scheduler_output)
 
-        if self._compare_output_dir and total_tokens > 0:
+        if should_save:
+            if adaptor._step_counter != step_before + 1:
+                raise RuntimeError(
+                    "CompareWorker did not observe exactly one committed DMI step"
+                )
+
+            transport = adaptor.transport
+            req_ids = list(transport._current_req_ids or ())
+            token_ranges = list(transport._current_token_ranges or ())
+            dim0_offsets = list(transport._current_dim0_offsets or ())
+            if (
+                not transport._current_flattened
+                or not req_ids
+                or len(req_ids) != len(token_ranges)
+                or len(req_ids) != len(dim0_offsets)
+                or len(set(req_ids)) != len(req_ids)
+            ):
+                raise RuntimeError(
+                    "CompareWorker received an invalid committed DMI layout"
+                )
+
+            num_per_req: list[int] = []
+            computed_map: dict[str, int] = {}
+            expected_offset = 0
+            for req_id, token_range, offset in zip(
+                req_ids, token_ranges, dim0_offsets
+            ):
+                start, end = (int(value) for value in token_range)
+                if (
+                    not isinstance(req_id, str)
+                    or start < 0
+                    or end <= start
+                    or int(offset) != expected_offset
+                ):
+                    raise RuntimeError(
+                        "CompareWorker received an invalid committed DMI range"
+                    )
+                count = end - start
+                num_per_req.append(count)
+                computed_map[req_id] = start
+                expected_offset += count
+
+            if expected_offset != int(total_tokens):
+                raise RuntimeError(
+                    "CompareWorker committed DMI rows do not match scheduler total"
+                )
+
             self._save_compare_step(req_ids, num_per_req, computed_map)
             self._compare_step += 1
 

--- a/tests/test_e2e_correctness_vs_hf.py
+++ b/tests/test_e2e_correctness_vs_hf.py
@@ -174,10 +174,10 @@ def _make_ring_cfg():
     rc.pinned_staging_bytes       = int(os.environ.get("E2E_RING_PINNED_BYTES", str(4 * 1024**3)))
     rc.drain_poll_timeout_us      = int(os.environ.get("E2E_DRAIN_POLL_TIMEOUT_US", "100"))
     rc.drain_flush_task_ratio     = float(os.environ.get("E2E_DRAIN_FLUSH_TASK_RATIO", "0.0"))
-    rc.drain_flush_payload_ratio  = float(os.environ.get("E2E_DRAIN_FLUSH_PAYLOAD_RATIO", "0.0"))
+    rc.drain_flush_payload_ratio  = float(os.environ.get("E2E_DRAIN_FLUSH_PAYLOAD_RATIO", "0.5"))
     rc.drain_flush_entry_threshold = int(os.environ.get("E2E_DRAIN_FLUSH_ENTRY_THRESHOLD", "0"))
     rc.drain_flush_byte_threshold  = int(os.environ.get("E2E_DRAIN_FLUSH_BYTE_THRESHOLD", "0"))
-    rc.drain_flush_timeout_us      = int(os.environ.get("E2E_DRAIN_FLUSH_TIMEOUT_US", "100000"))
+    rc.drain_flush_timeout_us      = int(os.environ.get("E2E_DRAIN_FLUSH_TIMEOUT_US", "0"))
     rc.clone_slices               = int(os.environ.get("E2E_CLONE_SLICES", "0")) != 0
     rc.insert_queue_max_bytes     = int(os.environ.get("E2E_INSERT_QUEUE_MAX_BYTES", str(512 * 1024**2)))
     rc.insert_queue_max_items     = int(os.environ.get("E2E_INSERT_QUEUE_MAX_ITEMS", "4096"))

--- a/tests/test_vllm_request_order_fix.py
+++ b/tests/test_vllm_request_order_fix.py
@@ -1,0 +1,2134 @@
+"""Focused CPU tests for the vLLM real-layout/eager-preflight fix."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+import vllm
+import vllm._C
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.v1.worker.gpu_worker import Worker
+
+from benchmark import bench_vllm_transport
+from integration.vllm_adapter import (
+    DMXGPUWorker,
+    VLLMAdaptor,
+    VLLMStepPhase,
+    VLLMValidationMode,
+    _VLLMHookSelection,
+    _VLLMRealLayout,
+    _VLLMRoleFormula,
+    _VLLMStepState,
+)
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_MLP_POST,
+    HOOK_TYPE_POS_EMBED,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_ROUTER_LOGITS,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_TOPK_IDS,
+    HOOK_TYPE_TOPK_WEIGHTS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+    SHAPE_LOGITS,
+    HookRowBasis,
+    HookSpec,
+    ModelShapeConfig,
+    PP_LAST_ONLY,
+    PP_FIRST_ONLY,
+    _HOOK_DEFS,
+    hook_row_basis,
+)
+from monitoring.selection import (
+    filter_by_pp_rank,
+    hook_belongs_to_pp_rank,
+    hook_belongs_to_tp_rank,
+    select_hook_specs,
+)
+from tests.compare_worker import CompareWorker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PINNED_VLLM_ROOT = (REPO_ROOT / "integration" / "vllm").resolve()
+
+
+def test_runtime_uses_the_pinned_source_and_extension():
+    source = Path(vllm.__file__).resolve()
+    extension = Path(vllm._C.__file__).resolve()
+
+    assert source.is_relative_to(PINNED_VLLM_ROOT)
+    assert extension.is_relative_to(PINNED_VLLM_ROOT)
+
+
+def _scheduler(order=("A", "B"), counts=(2, 3), total=None):
+    mapping = dict(zip(order, counts))
+    return SimpleNamespace(
+        num_scheduled_tokens=mapping,
+        total_num_scheduled_tokens=(
+            sum(counts) if total is None else total
+        ),
+    )
+
+
+def _runner(order=("B", "A"), computed=(7, 11)):
+    return SimpleNamespace(
+        input_batch=SimpleNamespace(
+            num_reqs=len(order),
+            req_ids=list(order),
+            num_computed_tokens_cpu=list(computed),
+            lora_id_to_lora_request={},
+        ),
+        input_ids=None,
+    )
+
+
+def _armed_adaptor(scheduler_output):
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+    return adaptor
+
+
+def test_records_real_packed_order_not_scheduler_order():
+    scheduler_output = _scheduler()
+    adaptor = _armed_adaptor(scheduler_output)
+
+    adaptor._record_real_layout(
+        scheduler_output,
+        _runner(),
+        [3, 2],
+    )
+
+    layout = adaptor._step_state.layout
+    assert layout is not None
+    assert layout.raw_req_ids == ("B", "A")
+    assert layout.req_ids == ("B", "A")
+    assert layout.scheduled_counts == (3, 2)
+    assert layout.computed_counts == (7, 11)
+    assert layout.token_ranges == ((7, 10), (11, 13))
+    assert layout.dim0_offsets == (0, 3)
+    assert layout.total_rows == 5
+    assert adaptor._step_state.phase is VLLMStepPhase.LAYOUT_READY
+
+
+@pytest.mark.parametrize(
+    ("scheduler_output", "runner", "ordered_counts", "match"),
+    [
+        (
+            _scheduler(),
+            _runner(order=("A", "A")),
+            [2, 3],
+            "not unique",
+        ),
+        (
+            _scheduler(),
+            _runner(order=("A", 7)),
+            [2, 3],
+            "must be strings",
+        ),
+        (
+            _scheduler(
+                order=("A-12345678", "A-abcdef12"),
+                counts=(2, 3),
+            ),
+            _runner(order=("A-12345678", "A-abcdef12")),
+            [2, 3],
+            "normalized request IDs",
+        ),
+        (
+            _scheduler(),
+            _runner(order=("B", "C")),
+            [3, 2],
+            "scheduler membership",
+        ),
+        (
+            _scheduler(),
+            _runner(),
+            [2, 3],
+            "count mismatch",
+        ),
+        (
+            _scheduler(counts=(2, -1), total=1),
+            _runner(order=("A", "B")),
+            [2, -1],
+            "negative",
+        ),
+        (
+            _scheduler(),
+            _runner(computed=(7, -1)),
+            [3, 2],
+            "computed token count is negative",
+        ),
+        (
+            _scheduler(),
+            _runner(),
+            [3],
+            "lengths disagree",
+        ),
+        (
+            _scheduler(total=99),
+            _runner(),
+            [3, 2],
+            "scheduler total",
+        ),
+    ],
+)
+def test_real_layout_validation_failures(
+    scheduler_output, runner, ordered_counts, match
+):
+    adaptor = _armed_adaptor(scheduler_output)
+    with pytest.raises(RuntimeError, match=match):
+        adaptor._record_real_layout(
+            scheduler_output,
+            runner,
+            ordered_counts,
+        )
+
+
+def test_duplicate_prepare_observation_fails():
+    scheduler_output = _scheduler()
+    adaptor = _armed_adaptor(scheduler_output)
+    adaptor._record_real_layout(scheduler_output, _runner(), [3, 2])
+
+    with pytest.raises(RuntimeError, match="duplicate or unarmed"):
+        adaptor._record_real_layout(scheduler_output, _runner(), [3, 2])
+
+
+def test_real_layout_keeps_immutable_copies():
+    scheduler_output = _scheduler()
+    runner = _runner()
+    ordered = np.array([3, 2], dtype=np.int32)
+    adaptor = _armed_adaptor(scheduler_output)
+
+    adaptor._record_real_layout(scheduler_output, runner, ordered)
+    runner.input_batch.req_ids[:] = ["changed", "changed-again"]
+    runner.input_batch.num_computed_tokens_cpu[:] = [99, 100]
+    ordered[:] = [0, 0]
+
+    layout = adaptor._step_state.layout
+    assert layout is not None
+    assert layout.raw_req_ids == ("B", "A")
+    assert layout.computed_counts == (7, 11)
+    assert layout.scheduled_counts == (3, 2)
+
+
+def test_compare_worker_saves_committed_real_layout(
+    monkeypatch, tmp_path
+):
+    transport = SimpleNamespace(
+        _current_req_ids=["stale"],
+        _current_token_ranges=[(0, 1)],
+        _current_dim0_offsets=[0],
+        _current_flattened=True,
+    )
+    adaptor = SimpleNamespace(transport=transport, _step_counter=4)
+    buffers = {
+        "resid_pre_L0": torch.tensor(
+            [[100], [101], [102], [200], [201]],
+            dtype=torch.int32,
+        ),
+        "final_logits": torch.tensor(
+            [[300], [400]],
+            dtype=torch.int32,
+        ),
+    }
+    model = SimpleNamespace(get_ref_buffers=lambda: buffers)
+
+    worker = CompareWorker.__new__(CompareWorker)
+    worker.adaptor = adaptor
+    worker.model_runner = SimpleNamespace(model=model)
+    worker._compare_output_dir = str(tmp_path)
+    worker._compare_step = 0
+    worker._dmx_tp_rank = 0
+    worker._dmx_tp_size = 1
+
+    def monitored_forward(self, scheduler_output):
+        assert list(scheduler_output.num_scheduled_tokens) == ["A", "B"]
+        self.adaptor.transport._current_req_ids = ["B", "A"]
+        self.adaptor.transport._current_token_ranges = [(24, 27), (10, 12)]
+        self.adaptor.transport._current_dim0_offsets = [0, 3]
+        self.adaptor.transport._current_flattened = True
+        self.adaptor._step_counter += 1
+        return "ok"
+
+    monkeypatch.setattr(
+        DMXGPUWorker,
+        "execute_model",
+        monitored_forward,
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"A": 2, "B": 3},
+        total_num_scheduled_tokens=5,
+    )
+
+    assert worker.execute_model(scheduler_output) == "ok"
+    assert worker._compare_step == 1
+    assert torch.equal(
+        torch.load(
+            tmp_path / "B" / "resid_pre_L0_T24_27.pt",
+            weights_only=True,
+        ),
+        buffers["resid_pre_L0"][:3],
+    )
+    assert torch.equal(
+        torch.load(
+            tmp_path / "A" / "resid_pre_L0_T10_12.pt",
+            weights_only=True,
+        ),
+        buffers["resid_pre_L0"][3:],
+    )
+    assert torch.equal(
+        torch.load(
+            tmp_path / "B" / "final_logits_T26_27.pt",
+            weights_only=True,
+        ),
+        buffers["final_logits"][:1],
+    )
+    assert torch.equal(
+        torch.load(
+            tmp_path / "A" / "final_logits_T11_12.pt",
+            weights_only=True,
+        ),
+        buffers["final_logits"][1:2],
+    )
+
+
+@pytest.mark.parametrize(
+    ("step_increment", "flattened", "offsets", "total", "match"),
+    [
+        (0, True, [0, 3], 5, "exactly one committed"),
+        (1, False, [0, 3], 5, "invalid committed DMI layout"),
+        (1, True, [0, 2], 5, "invalid committed DMI range"),
+        (1, True, [0, 3], 6, "do not match scheduler total"),
+    ],
+)
+def test_compare_worker_rejects_invalid_committed_layout(
+    monkeypatch,
+    tmp_path,
+    step_increment,
+    flattened,
+    offsets,
+    total,
+    match,
+):
+    transport = SimpleNamespace(
+        _current_req_ids=["B", "A"],
+        _current_token_ranges=[(24, 27), (10, 12)],
+        _current_dim0_offsets=offsets,
+        _current_flattened=flattened,
+    )
+    adaptor = SimpleNamespace(transport=transport, _step_counter=4)
+    worker = CompareWorker.__new__(CompareWorker)
+    worker.adaptor = adaptor
+    worker._compare_output_dir = str(tmp_path)
+    worker._compare_step = 0
+
+    def monitored_forward(self, scheduler_output):
+        self.adaptor._step_counter += step_increment
+        return "ok"
+
+    monkeypatch.setattr(
+        DMXGPUWorker,
+        "execute_model",
+        monitored_forward,
+    )
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=total,
+    )
+
+    with pytest.raises(RuntimeError, match=match):
+        worker.execute_model(scheduler_output)
+    assert worker._compare_step == 0
+
+
+def test_build_context_uses_real_layout_and_real_descriptor():
+    scheduler_output = _scheduler()
+    adaptor = _armed_adaptor(scheduler_output)
+    adaptor._record_real_layout(scheduler_output, _runner(), [3, 2])
+    adaptor._step_state.real_batch_descriptor = BatchDescriptor(
+        num_tokens=8
+    )
+    adaptor.model_id = "model"
+    adaptor.gpu_padding_strip = True
+    adaptor._step_counter = 0
+    adaptor._debug_step = False
+    adaptor.detect_parallel_ranks = lambda: (1, 0, 0, 1)
+
+    ctx = adaptor.build_step_context(scheduler_output, _runner())
+
+    assert ctx is not None
+    assert ctx.req_ids == ["B", "A"]
+    assert ctx.token_ranges == [(7, 10), (11, 13)]
+    assert ctx.dim0_offsets == [0, 3]
+    assert ctx.q_len == 8
+    assert ctx.actual_q_len == 5
+    assert ctx.logits_to_keep == 2
+    assert (ctx.tp_rank, ctx.pp_rank) == (1, 1)
+
+
+def test_role_formula_alignment_and_row_sources():
+    formula = _VLLMRoleFormula(
+        real_terms=((10, 2),),
+        execution_terms=((7, 1),),
+        request_terms=((13, 1),),
+        hook_count=4,
+    )
+
+    assert formula.bytes_for(
+        execution_rows=5,
+        real_rows=3,
+        request_rows=2,
+    ) == 2 * 32 + 48 + 32
+
+
+class _Dispatcher:
+    def __init__(self, padded_tokens=8):
+        self.padded_tokens = padded_tokens
+        self.calls = []
+
+    def dispatch(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs["valid_modes"] == {CUDAGraphMode.NONE}:
+            return (
+                CUDAGraphMode.NONE,
+                BatchDescriptor(num_tokens=kwargs["num_tokens"]),
+            )
+        return (
+            CUDAGraphMode.FULL,
+            BatchDescriptor(
+                num_tokens=self.padded_tokens,
+                num_reqs=kwargs["num_tokens"],
+            ),
+        )
+
+
+def _preflight_adaptor(
+    *,
+    byte_capacity=128,
+    validation=VLLMValidationMode.OFF,
+    enable_sp=False,
+    dp_size=1,
+    enable_ep=False,
+):
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED
+    )
+    adaptor._validation_mode = validation
+    adaptor._byte_capacity = byte_capacity
+    adaptor._role_formulas = (
+        _VLLMRoleFormula(
+            execution_terms=((16, 1),),
+            hook_count=1,
+        ),
+    )
+    adaptor._max_num_batched_tokens = 32
+    adaptor._max_num_seqs = 8
+    adaptor._capture_sizes = (1, 2, 4, 8, 16, 32)
+    adaptor._max_capture_size = 32
+    adaptor.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=2,
+            data_parallel_size=dp_size,
+            enable_expert_parallel=enable_ep,
+        ),
+        compilation_config=SimpleNamespace(
+            pass_config=SimpleNamespace(enable_sp=enable_sp),
+        ),
+    )
+    dispatcher = _Dispatcher()
+    runner = SimpleNamespace(
+        uniform_decode_query_len=1,
+        _is_uniform_decode=lambda **kwargs: False,
+        model_config=SimpleNamespace(is_encoder_decoder=False),
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        cudagraph_dispatcher=dispatcher,
+    )
+    return adaptor, runner, dispatcher
+
+
+def _call_preflight(adaptor, runner):
+    return adaptor._preflight_force_eager(
+        runner,
+        num_tokens=5,
+        num_reqs=2,
+        max_num_scheduled_tokens=3,
+        use_cascade_attn=False,
+        caller_force_eager=False,
+        force_uniform_decode=None,
+        force_has_lora=None,
+        force_num_active_loras=None,
+        num_encoder_reqs=0,
+    )
+
+
+def test_exact_preflight_is_one_read_only_dispatch_when_validation_off():
+    adaptor, runner, dispatcher = _preflight_adaptor(
+        byte_capacity=127
+    )
+    adaptor.ring_engine = SimpleNamespace(
+        prepare_step=lambda *_: pytest.fail("preflight touched ring")
+    )
+
+    assert _call_preflight(adaptor, runner) is True
+    assert len(dispatcher.calls) == 1
+    assert adaptor._step_state.capacity_candidate == (
+        CUDAGraphMode.FULL,
+        BatchDescriptor(num_tokens=8, num_reqs=5),
+    )
+    assert adaptor._step_state.expected_dispatch is None
+
+
+def test_exact_preflight_verify_predicts_final_eager_dispatch():
+    adaptor, runner, dispatcher = _preflight_adaptor(
+        byte_capacity=127,
+        validation=VLLMValidationMode.VERIFY,
+    )
+
+    assert _call_preflight(adaptor, runner) is True
+    assert len(dispatcher.calls) == 2
+    assert adaptor._step_state.expected_dispatch == (
+        CUDAGraphMode.NONE,
+        BatchDescriptor(num_tokens=5),
+    )
+
+
+def test_exact_preflight_capacity_boundary():
+    fit, runner, _ = _preflight_adaptor(byte_capacity=128)
+    over, runner2, _ = _preflight_adaptor(byte_capacity=127)
+
+    assert _call_preflight(fit, runner) is False
+    assert _call_preflight(over, runner2) is True
+
+
+def _real_dispatch_runner(mode):
+    dispatcher = CudagraphDispatcher.__new__(CudagraphDispatcher)
+    dispatcher.compilation_config = SimpleNamespace(
+        max_cudagraph_capture_size=8,
+    )
+    dispatcher.vllm_config = SimpleNamespace(
+        lora_config=SimpleNamespace(max_loras=4),
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+    )
+    dispatcher.uniform_decode_query_len = 1
+    dispatcher.keys_initialized = True
+    dispatcher.specialize_lora_count = False
+    dispatcher.captured_lora_counts = []
+    dispatcher.cudagraph_mode = mode
+    dispatcher._bs_to_padded_graph_size = [0, 1, 2, 4, 4, 8, 8, 8, 8]
+    dispatcher.cudagraph_keys = {
+        CUDAGraphMode.PIECEWISE: set(),
+        CUDAGraphMode.FULL: set(),
+    }
+    if mode is not CUDAGraphMode.NONE:
+        for size in (1, 2, 4, 8):
+            for has_lora, lora_count in ((False, 0), (True, 5)):
+                descriptor = dispatcher._create_padded_batch_descriptor(
+                    size,
+                    uniform_decode=False,
+                    has_lora=has_lora,
+                    num_active_loras=lora_count,
+                )
+                if mode is CUDAGraphMode.FULL:
+                    dispatcher.cudagraph_keys[CUDAGraphMode.FULL].add(
+                        descriptor
+                    )
+                else:
+                    dispatcher.cudagraph_keys[
+                        CUDAGraphMode.PIECEWISE
+                    ].add(
+                        BatchDescriptor(
+                            num_tokens=descriptor.num_tokens,
+                            num_reqs=None,
+                            uniform=False,
+                            has_lora=descriptor.has_lora,
+                            num_active_loras=descriptor.num_active_loras,
+                        )
+                    )
+
+    parallel = SimpleNamespace(
+        tensor_parallel_size=1,
+        data_parallel_size=1,
+        enable_expert_parallel=False,
+    )
+    compilation = SimpleNamespace(
+        pass_config=SimpleNamespace(enable_sp=False),
+    )
+    runner = SimpleNamespace(
+        uniform_decode_query_len=1,
+        _is_uniform_decode=GPUModelRunner._is_uniform_decode,
+        _pad_for_sequence_parallelism=lambda value: value,
+        model_config=SimpleNamespace(is_encoder_decoder=True),
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}),
+        cudagraph_dispatcher=dispatcher,
+        compilation_config=compilation,
+        parallel_config=parallel,
+        vllm_config=SimpleNamespace(
+            parallel_config=parallel,
+            observability_config=SimpleNamespace(
+                cudagraph_metrics=False
+            ),
+        ),
+        observability_config=SimpleNamespace(cudagraph_metrics=False),
+    )
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor.vllm_config = SimpleNamespace(
+        parallel_config=parallel,
+        compilation_config=compilation,
+        observability_config=SimpleNamespace(cudagraph_metrics=False),
+    )
+    return adaptor, runner
+
+
+def _real_dispatch(
+    runner,
+    *,
+    num_tokens=3,
+    num_reqs=2,
+    max_num_scheduled_tokens=2,
+    use_cascade_attn=False,
+    force_eager=False,
+    force_uniform_decode=None,
+    force_has_lora=None,
+    force_num_active_loras=None,
+    num_encoder_reqs=0,
+):
+    kwargs = dict(
+        num_tokens=num_tokens,
+        num_reqs=num_reqs,
+        num_scheduled_tokens_np=np.array([2, 1], dtype=np.int32),
+        max_num_scheduled_tokens=max_num_scheduled_tokens,
+        use_cascade_attn=use_cascade_attn,
+        force_eager=force_eager,
+        force_uniform_decode=force_uniform_decode,
+        force_has_lora=force_has_lora,
+        force_num_active_loras=force_num_active_loras,
+        num_encoder_reqs=num_encoder_reqs,
+    )
+    return GPUModelRunner._determine_batch_execution_and_padding(
+        runner, **kwargs
+    )[:2]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        CUDAGraphMode.FULL,
+        CUDAGraphMode.PIECEWISE,
+        CUDAGraphMode.NONE,
+    ],
+)
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"force_uniform_decode": True},
+        {"use_cascade_attn": True},
+        {"num_encoder_reqs": 1},
+        {"force_has_lora": True, "force_num_active_loras": 1},
+        {"force_eager": True},
+    ],
+)
+def test_exact_preview_matches_pinned_determine(mode, overrides):
+    adaptor, runner = _real_dispatch_runner(mode)
+    args = dict(
+        num_tokens=3,
+        num_reqs=2,
+        max_num_scheduled_tokens=2,
+        use_cascade_attn=False,
+        force_eager=False,
+        force_uniform_decode=None,
+        force_has_lora=None,
+        force_num_active_loras=None,
+        num_encoder_reqs=0,
+    )
+    args.update(overrides)
+
+    preview = adaptor._preview_exact_dispatch(runner, **args)
+    actual = _real_dispatch(runner, **args)
+
+    assert preview == actual
+
+
+def test_exact_preview_distinguishes_equal_rows_with_different_modes():
+    adaptor, runner = _real_dispatch_runner(CUDAGraphMode.FULL)
+    graph = adaptor._preview_exact_dispatch(
+        runner,
+        num_tokens=4,
+        num_reqs=2,
+        max_num_scheduled_tokens=2,
+        use_cascade_attn=False,
+        force_eager=False,
+        force_uniform_decode=None,
+        force_has_lora=None,
+        force_num_active_loras=None,
+        num_encoder_reqs=0,
+    )
+    eager = _real_dispatch(
+        runner,
+        num_tokens=4,
+        num_reqs=2,
+        force_eager=True,
+    )
+
+    assert graph[0] is CUDAGraphMode.FULL
+    assert eager[0] is CUDAGraphMode.NONE
+    assert graph[1].num_tokens == eager[1].num_tokens == 4
+    assert graph != eager
+
+
+def test_preflight_has_no_transport_tensor_or_collective_side_effects(
+    monkeypatch,
+):
+    adaptor, runner = _real_dispatch_runner(CUDAGraphMode.FULL)
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED
+    )
+    adaptor._validation_mode = VLLMValidationMode.OFF
+    adaptor._byte_capacity = 10_000
+    adaptor._role_formulas = (
+        _VLLMRoleFormula(
+            execution_terms=((16, 1),),
+            hook_count=1,
+        ),
+    )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("forbidden preflight side effect")
+
+    adaptor.ring_engine = SimpleNamespace(
+        prepare_step=forbidden,
+        payload_cap=forbidden,
+        staging_cap=forbidden,
+        task_cap=forbidden,
+        reserve=forbidden,
+        flush=forbidden,
+    )
+    adaptor.transport = SimpleNamespace(
+        set_step_context=forbidden,
+        pre_push_all_metas=forbidden,
+        flush=forbidden,
+    )
+
+    class ForbiddenSpecs:
+        def __iter__(self):
+            forbidden()
+
+    adaptor.active_specs = ForbiddenSpecs()
+    monkeypatch.setattr(
+        "integration.vllm_adapter._compute_hook_shape",
+        forbidden,
+    )
+    monkeypatch.setattr(torch, "empty", forbidden)
+    monkeypatch.setattr(torch, "tensor", forbidden)
+    monkeypatch.setattr(torch, "as_tensor", forbidden)
+    monkeypatch.setattr(torch.cuda, "synchronize", forbidden)
+    monkeypatch.setattr(torch.distributed, "all_reduce", forbidden)
+    monkeypatch.setattr(torch.distributed, "barrier", forbidden)
+
+    assert (
+        adaptor._preflight_force_eager(
+            runner,
+            num_tokens=3,
+            num_reqs=2,
+            max_num_scheduled_tokens=2,
+            use_cascade_attn=False,
+            caller_force_eager=False,
+            force_uniform_decode=None,
+            force_has_lora=None,
+            force_num_active_loras=None,
+            num_encoder_reqs=0,
+        )
+        is False
+    )
+
+
+def test_nonlocal_worst_role_forces_the_same_decision_on_every_rank():
+    adaptor, runner, _dispatcher = _preflight_adaptor(
+        byte_capacity=128
+    )
+    adaptor._role_formulas = (
+        _VLLMRoleFormula(
+            execution_terms=((8, 1),),
+            hook_count=1,
+        ),
+        _VLLMRoleFormula(
+            execution_terms=((32, 1),),
+            hook_count=1,
+        ),
+    )
+
+    decisions = []
+    for _simulated_tp_rank in (0, 1):
+        for _simulated_pp_rank in (0, 1):
+            adaptor._step_state = _VLLMStepState(
+                phase=VLLMStepPhase.ARMED
+            )
+            decisions.append(_call_preflight(adaptor, runner))
+
+    assert decisions == [True, True, True, True]
+
+
+def test_conservative_bound_uses_dp_max_and_sp_rounding():
+    adaptor, _runner_obj, _dispatcher_obj = _preflight_adaptor(
+        enable_sp=True,
+        dp_size=2,
+        enable_ep=True,
+    )
+
+    assert adaptor._conservative_execution_bound(5, 2) == (
+        32,
+        32,
+        8,
+    )
+
+
+def test_conservative_bound_uses_graph_ceiling_not_mutable_size_table():
+    adaptor, _runner_obj, _dispatcher_obj = _preflight_adaptor(
+        enable_sp=True,
+        dp_size=1,
+        enable_ep=True,
+    )
+    adaptor._capture_sizes = (1, 4, 8)
+    adaptor._max_capture_size = 32
+
+    assert adaptor._conservative_execution_bound(5, 2) == (
+        32,
+        5,
+        2,
+    )
+
+
+@pytest.mark.parametrize("local_tokens", [0, 1, 2, 3, 7, 8, 15, 31])
+def test_dp_conservative_bounds_are_rank_independent(local_tokens):
+    adaptor, _runner_obj, _dispatcher_obj = _preflight_adaptor(
+        enable_sp=True,
+        dp_size=4,
+        enable_ep=True,
+    )
+    adaptor._max_num_batched_tokens = 31
+    adaptor._max_num_seqs = 7
+    adaptor._max_capture_size = 32
+
+    assert adaptor._conservative_execution_bound(
+        local_tokens, max(1, local_tokens // 2)
+    ) == (32, 31, 7)
+
+
+@pytest.mark.parametrize("dp_size", [1, 4])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_ep", [False, True])
+def test_conservative_bound_exhausts_graph_sp_and_dp_boundaries(
+    dp_size,
+    enable_sp,
+    enable_ep,
+):
+    capture_cases = (
+        ((), 0),
+        ((1, 2, 4, 8), 8),
+        ((1, 4, 7, 16), 16),
+    )
+    for capture_sizes, max_capture_size in capture_cases:
+        dispatcher = CudagraphDispatcher.__new__(CudagraphDispatcher)
+        dispatcher.compilation_config = SimpleNamespace(
+            max_cudagraph_capture_size=max_capture_size,
+            cudagraph_capture_sizes=list(capture_sizes),
+            compile_sizes=[],
+        )
+        dispatcher.cudagraph_mode = (
+            CUDAGraphMode.FULL
+            if capture_sizes
+            else CUDAGraphMode.NONE
+        )
+        if capture_sizes:
+            dispatcher._compute_bs_to_padded_graph_size()
+        dispatcher.vllm_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_seqs=9),
+        )
+        dispatcher.uniform_decode_query_len = 1
+
+        for tp_size in (1, 2, 4, 8):
+            for max_tokens in (1, 7, 8, 9, 15, 16, 17, 31, 32, 33):
+                adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+                adaptor._max_num_batched_tokens = max_tokens
+                adaptor._max_num_seqs = 9
+                adaptor._capture_sizes = capture_sizes
+                adaptor._max_capture_size = max_capture_size
+                adaptor.vllm_config = SimpleNamespace(
+                    parallel_config=SimpleNamespace(
+                        tensor_parallel_size=tp_size,
+                        data_parallel_size=dp_size,
+                        enable_expert_parallel=enable_ep,
+                    ),
+                    compilation_config=SimpleNamespace(
+                        pass_config=SimpleNamespace(
+                            enable_sp=enable_sp
+                        ),
+                    ),
+                )
+                roles = (
+                    _VLLMRoleFormula(
+                        real_terms=((6, 2),),
+                        execution_terms=((10, 1),),
+                        request_terms=((14, 1),),
+                        hook_count=4,
+                    ),
+                    _VLLMRoleFormula(
+                        real_terms=((18, 1),),
+                        execution_terms=((4, 3),),
+                        request_terms=((8, 2),),
+                        hook_count=6,
+                    ),
+                )
+                boundary_tokens = {0, 1, max_tokens - 1, max_tokens}
+                for size in capture_sizes:
+                    boundary_tokens.update((size - 1, size, size + 1))
+                for multiple in range(0, max_tokens + tp_size, tp_size):
+                    boundary_tokens.update(
+                        (multiple - 1, multiple, multiple + 1)
+                    )
+                boundary_tokens = {
+                    value
+                    for value in boundary_tokens
+                    if 0 <= value <= max_tokens
+                }
+
+                dp_decisions = []
+                for local_tokens in sorted(boundary_tokens):
+                    local_reqs = min(9, max(0, local_tokens))
+                    (
+                        execution_bound,
+                        real_bound,
+                        request_bound,
+                    ) = adaptor._conservative_execution_bound(
+                        local_tokens,
+                        local_reqs,
+                    )
+                    bounded_role_bytes = max(
+                        role.bytes_for(
+                            execution_bound,
+                            real_bound,
+                            request_bound,
+                        )
+                        for role in roles
+                    )
+                    bounded_hook_count = max(
+                        role.hook_count for role in roles
+                    )
+                    dp_decisions.append(bounded_role_bytes > 4096)
+
+                    actual_real_candidates = (
+                        range(max_tokens + 1)
+                        if dp_size > 1
+                        else (local_tokens,)
+                    )
+                    actual_request_candidates = (
+                        range(10)
+                        if dp_size > 1
+                        else (local_reqs,)
+                    )
+                    for actual_real_rows in actual_real_candidates:
+                        dispatch_rows = actual_real_rows
+                        if enable_sp:
+                            dispatch_rows = (
+                                (
+                                    dispatch_rows
+                                    + tp_size
+                                    - 1
+                                )
+                                // tp_size
+                            ) * tp_size
+                        execution_candidates = [dispatch_rows]
+                        if (
+                            capture_sizes
+                            and dispatch_rows <= max_capture_size
+                        ):
+                            execution_candidates.append(
+                                dispatcher._create_padded_batch_descriptor(
+                                    dispatch_rows,
+                                    uniform_decode=False,
+                                    has_lora=False,
+                                ).num_tokens
+                            )
+
+                        for actual_execution_rows in execution_candidates:
+                            assert (
+                                actual_execution_rows
+                                <= execution_bound
+                            )
+                            assert actual_real_rows <= real_bound
+                            for actual_request_rows in (
+                                actual_request_candidates
+                            ):
+                                assert (
+                                    actual_request_rows
+                                    <= request_bound
+                                )
+                                for role in roles:
+                                    assert role.bytes_for(
+                                        actual_execution_rows,
+                                        actual_real_rows,
+                                        actual_request_rows,
+                                    ) <= role.bytes_for(
+                                        execution_bound,
+                                        real_bound,
+                                        request_bound,
+                                    )
+                                    assert (
+                                        role.hook_count
+                                        <= bounded_hook_count
+                                    )
+
+                if dp_size > 1:
+                    assert len(set(dp_decisions)) == 1
+
+
+class _Ring:
+    def __init__(self, result=0):
+        self.result = result
+        self.prepare_calls = []
+
+    def prepare_step(self, total_bytes, n_hooks):
+        self.prepare_calls.append((total_bytes, n_hooks))
+        return self.result
+
+
+class _Transport:
+    def __init__(self):
+        self.null_offload = False
+        self.force_eager = False
+        self.contexts = []
+        self.metas = []
+
+    def set_step_context(self, **kwargs):
+        self.contexts.append(kwargs)
+
+    def pre_push_all_metas(self, **kwargs):
+        self.metas.append(kwargs)
+
+
+def _commit_adaptor(byte_capacity=80, task_capacity=8):
+    scheduler_output = _scheduler()
+    layout = _VLLMRealLayout(
+        raw_req_ids=("B", "A"),
+        req_ids=("B", "A"),
+        scheduled_counts=(3, 2),
+        computed_counts=(7, 11),
+        token_ranges=((7, 10), (11, 13)),
+        dim0_offsets=(0, 3),
+        total_rows=5,
+    )
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.LAYOUT_READY,
+        scheduler_output=scheduler_output,
+        layout=layout,
+    )
+    adaptor.model_id = "model"
+    adaptor.gpu_padding_strip = True
+    adaptor._step_counter = 0
+    adaptor._debug_step = False
+    adaptor._byte_capacity = byte_capacity
+    adaptor._task_capacity = task_capacity
+    adaptor._validation_mode = VLLMValidationMode.VERIFY
+    adaptor._local_role_formula = _VLLMRoleFormula(
+        real_terms=((16, 1),),
+        hook_count=1,
+    )
+    adaptor.model_cfg = ModelShapeConfig(
+        hidden_dim=4,
+        num_heads=1,
+        num_kv_heads=1,
+        head_dim=4,
+        dtype=torch.float32,
+    )
+    adaptor.active_specs = [
+        HookSpec(
+            HOOK_TYPE_RESID_PRE,
+            nn.Identity(),
+            layer_no=0,
+            dim0_is_actual_tokens=True,
+        )
+    ]
+    adaptor.transport = _Transport()
+    adaptor.ring_engine = _Ring()
+    adaptor._row_count_dev = None
+    adaptor._pinned_row_count = None
+    adaptor._last_total_q = 0
+    adaptor._warned_shapes = set()
+    adaptor.detect_parallel_ranks = lambda: (0, 0, 0, 0)
+    return adaptor, scheduler_output
+
+
+def test_actual_commit_reserves_and_pushes_real_order_once():
+    adaptor, scheduler_output = _commit_adaptor()
+    runner = _runner()
+    adaptor._step_state.capacity_candidate = (
+        CUDAGraphMode.FULL,
+        BatchDescriptor(num_tokens=999),
+    )
+    original_plan = adaptor._compute_step_plan
+    plan_calls = 0
+
+    def counted_plan(ctx):
+        nonlocal plan_calls
+        plan_calls += 1
+        return original_plan(ctx)
+
+    adaptor._compute_step_plan = counted_plan
+
+    adaptor._commit_actual_dispatch(
+        scheduler_output,
+        runner,
+        CUDAGraphMode.FULL,
+        BatchDescriptor(num_tokens=8),
+        combined_force_eager=False,
+    )
+
+    assert adaptor._step_state.phase is VLLMStepPhase.COMMITTED
+    assert adaptor.ring_engine.prepare_calls == [(80, 1)]
+    assert adaptor.transport.contexts[0]["req_ids"] == ["B", "A"]
+    assert adaptor.transport.metas[0]["q_len"] == 8
+    assert adaptor.transport.metas[0]["actual_q_len"] == 5
+    assert plan_calls == 1
+
+
+def test_false_negative_fails_before_any_ring_operation():
+    adaptor, scheduler_output = _commit_adaptor(byte_capacity=79)
+
+    with pytest.raises(RuntimeError, match="false negative"):
+        adaptor._commit_actual_dispatch(
+            scheduler_output,
+            _runner(),
+            CUDAGraphMode.FULL,
+            BatchDescriptor(num_tokens=8),
+            combined_force_eager=False,
+        )
+
+    assert adaptor.ring_engine.prepare_calls == []
+    assert adaptor.transport.contexts == []
+    assert adaptor.transport.metas == []
+
+
+def test_actual_task_overflow_and_short_descriptor_fail_before_ring():
+    task_overflow, scheduler_output = _commit_adaptor(
+        task_capacity=0
+    )
+    with pytest.raises(RuntimeError, match="hook count"):
+        task_overflow._commit_actual_dispatch(
+            scheduler_output,
+            _runner(),
+            CUDAGraphMode.FULL,
+            BatchDescriptor(num_tokens=8),
+            combined_force_eager=True,
+        )
+    assert task_overflow.ring_engine.prepare_calls == []
+
+    too_short, scheduler_output = _commit_adaptor()
+    with pytest.raises(RuntimeError, match="fewer rows"):
+        too_short._commit_actual_dispatch(
+            scheduler_output,
+            _runner(),
+            CUDAGraphMode.FULL,
+            BatchDescriptor(num_tokens=4),
+            combined_force_eager=True,
+        )
+    assert too_short.ring_engine.prepare_calls == []
+
+
+def test_worker_arms_and_resets_per_call(monkeypatch):
+    adaptor = SimpleNamespace(
+        transport=SimpleNamespace(null_offload=False),
+        _has_global_hooks=True,
+        _step_state=_VLLMStepState(),
+    )
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = adaptor
+    scheduler_output = _scheduler()
+    monkeypatch.setattr(
+        "integration.vllm_adapter.has_ec_transfer",
+        lambda: False,
+    )
+
+    def fake_execute(_self, received):
+        assert received is scheduler_output
+        assert adaptor._step_state.phase is VLLMStepPhase.ARMED
+        assert adaptor._step_state.scheduler_output is scheduler_output
+        adaptor._step_state.phase = VLLMStepPhase.COMMITTED
+        return "ok"
+
+    monkeypatch.setattr(Worker, "execute_model", fake_execute)
+
+    assert worker.execute_model(scheduler_output) == "ok"
+    assert adaptor._step_state.phase is VLLMStepPhase.IDLE
+
+
+class _FakeNativeRingConfig:
+    pass
+
+
+class _FakeAdaptor:
+    def __init__(self, events, preflight_eager=False):
+        self.events = events
+        self.preflight_eager = preflight_eager
+        self._step_state = _VLLMStepState()
+        self.transport = SimpleNamespace(null_offload=False)
+        self.ring_engine = SimpleNamespace(
+            set_null_mode=lambda value: events.append(
+                ("null", value)
+            )
+        )
+        self._validation_mode = VLLMValidationMode.OFF
+        self.user_wants_null_mode = False
+
+    def detect_parallel_ranks(self):
+        return (0, 0, 0, 0)
+
+    def _record_real_layout(
+        self, scheduler_output, model_runner, ordered_counts
+    ):
+        self.events.append(
+            (
+                "record",
+                tuple(model_runner.input_batch.req_ids),
+                tuple(int(value) for value in ordered_counts),
+            )
+        )
+        self._step_state.layout = object()
+        self._step_state.phase = VLLMStepPhase.LAYOUT_READY
+
+    def _preflight_force_eager(self, _model_runner, **kwargs):
+        self.events.append(("preflight", kwargs))
+        return self.preflight_eager
+
+    def _commit_actual_dispatch(
+        self,
+        scheduler_output,
+        _model_runner,
+        mode,
+        descriptor,
+        combined_force_eager,
+    ):
+        self.events.append(
+            (
+                "commit",
+                scheduler_output,
+                mode,
+                descriptor,
+                combined_force_eager,
+            )
+        )
+        self._step_state.phase = VLLMStepPhase.COMMITTED
+
+
+def _install_worker_wrappers(
+    monkeypatch,
+    *,
+    pipeline_parallel_size=1,
+    enable_sp=False,
+    preflight_eager=False,
+):
+    import integration.vllm_adapter as adapter_module
+    import monitoring.engine as engine_module
+    import monitoring._native_engine as native_module
+    import vllm.distributed.parallel_state as parallel_state
+
+    events = []
+    scheduler_output = _scheduler()
+    model_runner = _runner()
+
+    def original_prepare(received, ordered_counts):
+        events.append(("prepare", received, tuple(ordered_counts)))
+        model_runner.input_batch.req_ids[:] = ["B", "A"]
+        return "prepared"
+
+    def original_determine(**kwargs):
+        events.append(("determine", kwargs))
+        descriptor = BatchDescriptor(num_tokens=kwargs["num_tokens"])
+        return CUDAGraphMode.NONE, descriptor, False, None, None
+
+    model_runner._prepare_inputs = original_prepare
+    model_runner._determine_batch_execution_and_padding = (
+        original_determine
+    )
+
+    parallel = SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=pipeline_parallel_size,
+        data_parallel_size=1,
+        enable_expert_parallel=False,
+    )
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.model_runner = model_runner
+    worker.adaptor = None
+    worker.vllm_config = SimpleNamespace(
+        additional_config={},
+        model_config=SimpleNamespace(model="model"),
+        parallel_config=parallel,
+        compilation_config=SimpleNamespace(
+            pass_config=SimpleNamespace(enable_sp=enable_sp)
+        ),
+    )
+
+    fake_adaptor = _FakeAdaptor(events, preflight_eager)
+    fake_adaptor.vllm_config = worker.vllm_config
+    monkeypatch.setattr(Worker, "init_device", lambda _self: None)
+    monkeypatch.setattr(native_module, "RingConfig", _FakeNativeRingConfig)
+    monkeypatch.setattr(engine_module, "MonitoringEngine", lambda **_kw: object())
+    monkeypatch.setattr(
+        adapter_module,
+        "VLLMAdaptor",
+        lambda *_args, **_kwargs: fake_adaptor,
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+
+    worker.init_device()
+    return worker, fake_adaptor, model_runner, scheduler_output, events
+
+
+def _determine_kwargs(force_eager=False):
+    return dict(
+        num_tokens=5,
+        num_reqs=2,
+        num_scheduled_tokens_np=np.array([3, 2], dtype=np.int32),
+        max_num_scheduled_tokens=3,
+        use_cascade_attn=False,
+        allow_microbatching=False,
+        force_eager=force_eager,
+        force_uniform_decode=False,
+        force_has_lora=False,
+        force_num_active_loras=0,
+        num_encoder_reqs=0,
+    )
+
+
+def test_wrappers_record_after_real_prepare_then_commit_real_dispatch(
+    monkeypatch,
+):
+    (
+        _worker,
+        adaptor,
+        runner,
+        scheduler_output,
+        events,
+    ) = _install_worker_wrappers(monkeypatch, preflight_eager=True)
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+
+    assert runner._prepare_inputs(
+        scheduler_output,
+        np.array([3, 2], dtype=np.int32),
+    ) == "prepared"
+    result = runner._determine_batch_execution_and_padding(
+        **_determine_kwargs()
+    )
+
+    names = [event[0] for event in events if event[0] != "null"]
+    assert names == [
+        "prepare",
+        "record",
+        "preflight",
+        "determine",
+        "commit",
+    ]
+    determine_call = next(
+        event[1] for event in events if event[0] == "determine"
+    )
+    expected = _determine_kwargs()
+    expected["force_eager"] = True
+    np.testing.assert_array_equal(
+        determine_call.pop("num_scheduled_tokens_np"),
+        expected.pop("num_scheduled_tokens_np"),
+    )
+    assert determine_call == expected
+    assert result[0] is CUDAGraphMode.NONE
+    assert adaptor._step_state.phase is VLLMStepPhase.COMMITTED
+    commit = next(event for event in events if event[0] == "commit")
+    assert commit[4] is True
+    assert commit[3] is result[1]
+
+
+def test_wrappers_preserve_pinned_parameter_contract(monkeypatch):
+    _, _adaptor, runner, _scheduler_output, _events = (
+        _install_worker_wrappers(monkeypatch)
+    )
+
+    wrapped_prepare = list(
+        inspect.signature(runner._prepare_inputs).parameters.values()
+    )
+    pinned_prepare = list(
+        inspect.signature(GPUModelRunner._prepare_inputs).parameters.values()
+    )[1:]
+    wrapped_determine = list(
+        inspect.signature(
+            runner._determine_batch_execution_and_padding
+        ).parameters.values()
+    )
+    pinned_determine = list(
+        inspect.signature(
+            GPUModelRunner._determine_batch_execution_and_padding
+        ).parameters.values()
+    )[1:]
+
+    assert [
+        (parameter.name, parameter.kind, parameter.default)
+        for parameter in wrapped_prepare
+    ] == [
+        (parameter.name, parameter.kind, parameter.default)
+        for parameter in pinned_prepare
+    ]
+    assert [
+        (parameter.name, parameter.kind, parameter.default)
+        for parameter in wrapped_determine
+    ] == [
+        (parameter.name, parameter.kind, parameter.default)
+        for parameter in pinned_determine
+    ]
+
+
+def test_wrapper_preserves_caller_eager_and_passes_idle_unchanged(
+    monkeypatch,
+):
+    _, adaptor, runner, scheduler_output, events = _install_worker_wrappers(
+        monkeypatch
+    )
+
+    runner._determine_batch_execution_and_padding(
+        **_determine_kwargs(force_eager=True)
+    )
+    assert [event[0] for event in events].count("preflight") == 0
+    idle_call = next(
+        event[1] for event in events if event[0] == "determine"
+    )
+    assert idle_call["force_eager"] is True
+
+    events.clear()
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+    runner._prepare_inputs(
+        scheduler_output,
+        np.array([3, 2], dtype=np.int32),
+    )
+    runner._determine_batch_execution_and_padding(
+        **_determine_kwargs(force_eager=True)
+    )
+    active_call = next(
+        event[1] for event in events if event[0] == "determine"
+    )
+    assert active_call["force_eager"] is True
+
+
+def test_early_pp_sp_dispatch_latches_without_commit(monkeypatch):
+    _, adaptor, runner, scheduler_output, events = _install_worker_wrappers(
+        monkeypatch,
+        pipeline_parallel_size=2,
+        enable_sp=True,
+        preflight_eager=True,
+    )
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+
+    runner._determine_batch_execution_and_padding(
+        **_determine_kwargs()
+    )
+
+    assert adaptor._step_state.phase is VLLMStepPhase.ARMED
+    assert adaptor._step_state.force_eager_latch is True
+    assert adaptor._step_state.prelayout_dispatch_seen is True
+    assert not any(event[0] == "commit" for event in events)
+
+
+def test_wrapper_rejects_duplicate_prepare_and_invalid_dispatch_phases(
+    monkeypatch,
+):
+    _, adaptor, runner, scheduler_output, _events = (
+        _install_worker_wrappers(monkeypatch)
+    )
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+    runner._prepare_inputs(
+        scheduler_output,
+        np.array([3, 2], dtype=np.int32),
+    )
+    with pytest.raises(RuntimeError, match="second _prepare_inputs"):
+        runner._prepare_inputs(
+            scheduler_output,
+            np.array([3, 2], dtype=np.int32),
+        )
+
+    adaptor._step_state.phase = VLLMStepPhase.COMMITTED
+    with pytest.raises(RuntimeError, match="after metadata commit"):
+        runner._determine_batch_execution_and_padding(
+            **_determine_kwargs()
+        )
+
+    adaptor._step_state = _VLLMStepState(
+        phase=VLLMStepPhase.ARMED,
+        scheduler_output=scheduler_output,
+    )
+    with pytest.raises(RuntimeError, match="unexpected pre-layout"):
+        runner._determine_batch_execution_and_padding(
+            **_determine_kwargs()
+        )
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "null_offload", "has_hooks"),
+    [
+        (0, False, True),
+        (5, True, True),
+        (5, False, False),
+    ],
+)
+def test_worker_passthrough_paths_never_arm(
+    monkeypatch, total_tokens, null_offload, has_hooks
+):
+    adaptor = SimpleNamespace(
+        transport=SimpleNamespace(null_offload=null_offload),
+        _has_global_hooks=has_hooks,
+        _step_state=_VLLMStepState(),
+    )
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = adaptor
+    scheduler_output = _scheduler(total=total_tokens)
+    monkeypatch.setattr(
+        "integration.vllm_adapter.has_ec_transfer",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        Worker,
+        "execute_model",
+        lambda _self, _output: "passthrough",
+    )
+
+    assert worker.execute_model(scheduler_output) == "passthrough"
+    assert adaptor._step_state.phase is VLLMStepPhase.IDLE
+
+
+def test_public_null_attach_skips_active_formula_compilation(monkeypatch):
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor.gpu_padding_strip = False
+    adaptor.transport = SimpleNamespace(null_offload=True)
+    monkeypatch.setattr(
+        "monitoring.adaptor_base.BackendAdaptor.attach_model",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        adaptor,
+        "_compile_role_formulas",
+        lambda *_args, **_kwargs: pytest.fail(
+            "public null mode compiled active formulas"
+        ),
+    )
+
+    adaptor.attach_model(SimpleNamespace(), "vllm-full")
+
+
+def test_worker_resets_state_when_upstream_raises(monkeypatch):
+    adaptor = SimpleNamespace(
+        transport=SimpleNamespace(null_offload=False),
+        _has_global_hooks=True,
+        _step_state=_VLLMStepState(),
+    )
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = adaptor
+    monkeypatch.setattr(
+        "integration.vllm_adapter.has_ec_transfer",
+        lambda: False,
+    )
+
+    def fail(_self, _output):
+        raise RuntimeError("upstream failure")
+
+    monkeypatch.setattr(Worker, "execute_model", fail)
+    with pytest.raises(RuntimeError, match="upstream failure"):
+        worker.execute_model(_scheduler())
+    assert adaptor._step_state.phase is VLLMStepPhase.IDLE
+
+
+def test_ec_transfer_producer_passthrough_never_arms(monkeypatch):
+    adaptor = SimpleNamespace(
+        transport=SimpleNamespace(null_offload=False),
+        _has_global_hooks=True,
+        _step_state=_VLLMStepState(),
+    )
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = adaptor
+    monkeypatch.setattr(
+        "integration.vllm_adapter.has_ec_transfer",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "integration.vllm_adapter.get_ec_transfer",
+        lambda: SimpleNamespace(is_producer=True),
+    )
+    monkeypatch.setattr(
+        Worker,
+        "execute_model",
+        lambda _self, _output: "ec-producer",
+    )
+
+    assert worker.execute_model(_scheduler()) == "ec-producer"
+    assert adaptor._step_state.phase is VLLMStepPhase.IDLE
+
+
+class _FakeOutput:
+    def __init__(self, token_count=2):
+        self.outputs = [
+            SimpleNamespace(token_ids=list(range(token_count)))
+        ]
+
+
+class _FakeLLM:
+    instances = []
+    shutdown_error = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.rpc_calls = []
+        self.__class__.instances.append(self)
+
+    def generate(self, prompts, params):
+        return [_FakeOutput() for _ in prompts]
+
+    def collective_rpc(self, method):
+        self.rpc_calls.append(method)
+        if self.shutdown_error is not None:
+            raise self.shutdown_error
+
+
+@pytest.fixture
+def fake_benchmark(monkeypatch):
+    import vllm
+
+    _FakeLLM.instances.clear()
+    _FakeLLM.shutdown_error = None
+    monkeypatch.setattr(vllm, "LLM", _FakeLLM)
+    monkeypatch.setattr(
+        vllm,
+        "SamplingParams",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    return _FakeLLM
+
+
+def _bench_config():
+    return bench_vllm_transport.BenchConfig(
+        warmup=0,
+        iters=1,
+        num_prompts=1,
+        tensor_parallel_size=2,
+        pipeline_parallel_size=3,
+    )
+
+
+def test_benchmark_baseline_is_monitoring_off(fake_benchmark):
+    bench_vllm_transport._run_mode("baseline", _bench_config())
+    instance = fake_benchmark.instances[-1]
+
+    assert instance.kwargs["tensor_parallel_size"] == 2
+    assert instance.kwargs["pipeline_parallel_size"] == 3
+    assert "worker_cls" not in instance.kwargs
+    assert "additional_config" not in instance.kwargs
+    assert instance.rpc_calls == []
+
+
+def test_benchmark_ring_active_is_on_without_database(fake_benchmark):
+    bench_vllm_transport._run_mode("ring_active", _bench_config())
+    instance = fake_benchmark.instances[-1]
+
+    assert (
+        instance.kwargs["worker_cls"]
+        == "integration.vllm_adapter.DMXGPUWorker"
+    )
+    assert instance.kwargs["additional_config"]["dmx_null_mode"] is False
+    assert instance.kwargs["additional_config"]["dmx_db_host"] == ""
+    assert instance.rpc_calls == ["stop_monitoring"]
+
+
+def test_benchmark_public_null_skips_monitoring_shutdown(fake_benchmark):
+    bench_vllm_transport._run_mode("ring_null", _bench_config())
+    instance = fake_benchmark.instances[-1]
+
+    assert instance.kwargs["additional_config"]["dmx_null_mode"] is True
+    assert instance.rpc_calls == []
+
+
+def test_benchmark_active_shutdown_failure_propagates(fake_benchmark):
+    fake_benchmark.shutdown_error = RuntimeError("shutdown failed")
+
+    with pytest.raises(RuntimeError, match="shutdown failed"):
+        bench_vllm_transport._run_mode(
+            "ring_active",
+            _bench_config(),
+        )
+
+
+def test_benchmark_ring_db_uses_checked_shutdown(fake_benchmark):
+    bench_vllm_transport._run_mode("ring_db", _bench_config())
+    instance = fake_benchmark.instances[-1]
+
+    assert instance.rpc_calls == ["stop_monitoring"]
+
+
+def test_benchmark_cli_keeps_defaults_and_parses_tp_pp(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bench",
+            "--tensor-parallel-size",
+            "2",
+            "--pipeline-parallel-size",
+            "3",
+        ],
+    )
+
+    cfg = bench_vllm_transport._parse_args()
+
+    assert cfg.modes == ["baseline", "ring_null"]
+    assert cfg.tensor_parallel_size == 2
+    assert cfg.pipeline_parallel_size == 3
+    assert cfg.warmup == 2
+    assert cfg.iters == 5
+
+
+def test_hook_row_basis_uses_native_shape_classes():
+    for hook_type, _act, _short, _pl, _grp, _tp, shape_class, _pp in _HOOK_DEFS:
+        expected = (
+            HookRowBasis.REQUEST_ROWS
+            if shape_class == SHAPE_LOGITS
+            else HookRowBasis.TOKEN_ROWS
+        )
+        assert hook_row_basis(hook_type) is expected
+
+    unknown_hook_type = max(row[0] for row in _HOOK_DEFS) + 1
+    with pytest.raises(ValueError, match="Unknown hook type"):
+        hook_row_basis(unknown_hook_type)
+
+
+def test_resid_final_is_last_stage_only():
+    assert HOOK_TYPE_RESID_FINAL in PP_LAST_ONLY
+    assert HOOK_TYPE_RESID_FINAL not in PP_FIRST_ONLY
+    first = HookSpec(HOOK_TYPE_RESID_FINAL, nn.Identity())
+    last = HookSpec(HOOK_TYPE_RESID_FINAL, nn.Identity())
+
+    assert filter_by_pp_rank([first], True, False) == []
+    assert filter_by_pp_rank([last], False, True) == [last]
+
+
+class _ModelWideHookInventory:
+    def __init__(self, specs):
+        self.specs = tuple(specs)
+
+    def get_hook_specs(self, *, model_wide=False):
+        if not model_wide:
+            raise AssertionError("formula compilation requested local specs")
+        return list(self.specs)
+
+
+def _model_wide_specs(num_layers=4):
+    specs = [
+        HookSpec(
+            HOOK_TYPE_TOKEN_IDS,
+            None,
+            dtype=torch.int32,
+            dim0_is_actual_tokens=True,
+        ),
+        HookSpec(
+            HOOK_TYPE_EMBED,
+            None,
+            dim0_is_actual_tokens=True,
+        ),
+    ]
+    for layer_no in range(num_layers):
+        specs.extend([
+            HookSpec(
+                HOOK_TYPE_RESID_PRE,
+                None,
+                layer_no=layer_no,
+                dim0_is_actual_tokens=True,
+            ),
+            HookSpec(
+                HOOK_TYPE_Q,
+                None,
+                layer_no=layer_no,
+                dim0_is_actual_tokens=True,
+            ),
+        ])
+        if layer_no % 2 == 0:
+            specs.append(
+                HookSpec(
+                    HOOK_TYPE_MLP_POST,
+                    None,
+                    layer_no=layer_no,
+                    dim0_is_actual_tokens=True,
+                )
+            )
+        else:
+            specs.extend([
+                HookSpec(
+                    HOOK_TYPE_ROUTER_LOGITS,
+                    None,
+                    layer_no=layer_no,
+                    dim0_is_actual_tokens=True,
+                ),
+                HookSpec(
+                    HOOK_TYPE_TOPK_IDS,
+                    None,
+                    layer_no=layer_no,
+                    dtype=torch.int32,
+                    dim0_is_actual_tokens=True,
+                ),
+                HookSpec(
+                    HOOK_TYPE_TOPK_WEIGHTS,
+                    None,
+                    layer_no=layer_no,
+                    dtype=torch.float32,
+                    dim0_is_actual_tokens=True,
+                ),
+            ])
+        specs.append(
+            HookSpec(
+                HOOK_TYPE_MLP_OUT,
+                None,
+                layer_no=layer_no,
+                dim0_is_actual_tokens=True,
+            )
+        )
+    specs.extend([
+        HookSpec(
+            HOOK_TYPE_RESID_FINAL,
+            None,
+            dim0_is_actual_tokens=True,
+        ),
+        HookSpec(
+            HOOK_TYPE_FINAL_LN,
+            None,
+            dim0_is_actual_tokens=True,
+        ),
+        HookSpec(HOOK_TYPE_FINAL_LOGITS, None),
+    ])
+    return specs
+
+
+def _bind_spec(spec):
+    return HookSpec(
+        spec.hook_type,
+        nn.Identity(),
+        layer_no=spec.layer_no,
+        dtype=spec.dtype,
+        allow_token_cnt_mismatch=spec.allow_token_cnt_mismatch,
+        dim0_is_actual_tokens=spec.dim0_is_actual_tokens,
+    )
+
+
+def _formula_adaptor(
+    *,
+    tp_size,
+    tp_rank,
+    pp_rank,
+    gpu_padding_strip,
+    task_capacity=10_000,
+    use_ubatching=False,
+    data_parallel_size=1,
+    speculative_config=None,
+    hook_selection="vllm-full",
+):
+    from vllm.distributed.utils import get_pp_indices
+
+    num_layers = 4
+    pp_size = 2
+    cfg = ModelShapeConfig(
+        hidden_dim=8,
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=4,
+        dtype=torch.float16,
+        vocab_size=16,
+        intermediate_dim=12,
+        num_experts=4,
+        top_k=2,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+    )
+    hf_config = SimpleNamespace(num_hidden_layers=num_layers)
+    parallel = SimpleNamespace(
+        tensor_parallel_size=tp_size,
+        pipeline_parallel_size=pp_size,
+        data_parallel_size=data_parallel_size,
+        use_ubatching=use_ubatching,
+        enable_expert_parallel=False,
+    )
+    adaptor = VLLMAdaptor.__new__(VLLMAdaptor)
+    adaptor.model_cfg = cfg
+    adaptor.vllm_config = SimpleNamespace(
+        parallel_config=parallel,
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=32,
+            max_num_seqs=8,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_capture_sizes=[1, 2, 4, 8, 16, 32],
+            max_cudagraph_capture_size=32,
+        ),
+        speculative_config=speculative_config,
+        model_config=SimpleNamespace(hf_config=hf_config),
+    )
+    adaptor.ring_engine = SimpleNamespace(
+        payload_cap=lambda: 1_000_000,
+        staging_cap=lambda: 1_000_000,
+        task_cap=lambda: task_capacity,
+    )
+    adaptor.gpu_padding_strip = gpu_padding_strip
+    adaptor.detect_parallel_ranks = lambda: (
+        tp_rank,
+        0,
+        0,
+        pp_rank,
+    )
+
+    model = _ModelWideHookInventory(_model_wide_specs(num_layers))
+    selected = select_hook_specs(
+        model.get_hook_specs(model_wide=True),
+        hook_selection,
+        cfg,
+    )
+    start, end = get_pp_indices(num_layers, pp_rank, pp_size)
+    adaptor.active_specs = [
+        _bind_spec(spec)
+        for spec in selected
+        if (
+            (spec.layer_no < 0 or start <= spec.layer_no < end)
+            and hook_belongs_to_pp_rank(
+                spec,
+                is_first_rank=(pp_rank == 0),
+                is_last_rank=(pp_rank == pp_size - 1),
+            )
+            and hook_belongs_to_tp_rank(spec, tp_rank)
+        )
+    ]
+    return adaptor, model
+
+
+def _compile_formula_adaptor(adaptor, model, hook_selection):
+    selection = _VLLMHookSelection.from_model(
+        model=model,
+        local_hooks=tuple(adaptor.active_specs),
+        hook_selection=hook_selection,
+        cfg=adaptor.model_cfg,
+        parallel_config=adaptor.vllm_config.parallel_config,
+        hf_config=adaptor.vllm_config.model_config.hf_config,
+    )
+    adaptor._compile_role_formulas(selection)
+
+
+@pytest.mark.parametrize(
+    "hook_selection",
+    ["vllm-full", "resid_pre,final_logits"],
+)
+@pytest.mark.parametrize("gpu_padding_strip", [False, True])
+@pytest.mark.parametrize(("tp_size", "tp_rank"), [(1, 0), (2, 0), (2, 1)])
+@pytest.mark.parametrize("pp_rank", [0, 1])
+def test_compiled_role_formula_matches_concrete_actual_plan(
+    hook_selection,
+    gpu_padding_strip,
+    tp_size,
+    tp_rank,
+    pp_rank,
+):
+    adaptor, model = _formula_adaptor(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        pp_rank=pp_rank,
+        gpu_padding_strip=gpu_padding_strip,
+        hook_selection=hook_selection,
+    )
+
+    _compile_formula_adaptor(adaptor, model, hook_selection)
+
+    ctx = SimpleNamespace(
+        batch=0,
+        q_len=8,
+        actual_q_len=5 if gpu_padding_strip else None,
+        kv_dim=0,
+        logits_to_keep=2,
+    )
+    actual = adaptor._compute_step_plan(ctx)
+    formula = adaptor._local_role_formula
+    assert formula is not None
+    assert (
+        formula.bytes_for(8, 5, 2),
+        formula.hook_count,
+        False,
+    ) == actual
+    assert len(adaptor._role_formulas) == (2 if tp_size == 1 else 3)
+    assert len(adaptor._role_formulas) == len(
+        set(adaptor._role_formulas)
+    )
+
+
+def test_compiled_role_formula_unwraps_vllm_cudagraph_wrapper():
+    plain, plain_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+    )
+    wrapped, wrapped_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+    )
+    wrapper = object.__new__(CUDAGraphWrapper)
+    wrapper.runnable = wrapped_model
+
+    _compile_formula_adaptor(plain, plain_model, "vllm-full")
+    _compile_formula_adaptor(wrapped, wrapper, "vllm-full")
+
+    assert wrapped._role_formulas == plain._role_formulas
+    assert wrapped._local_role_formula == plain._local_role_formula
+    assert wrapped._has_global_hooks == plain._has_global_hooks
+
+
+def test_task_capacity_exact_fit_and_one_extra_hook_fail_attachment():
+    adaptor, model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+    )
+    _compile_formula_adaptor(adaptor, model, "vllm-full")
+    maximum = max(
+        formula.hook_count for formula in adaptor._role_formulas
+    )
+
+    exact, exact_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+        task_capacity=maximum,
+    )
+    _compile_formula_adaptor(exact, exact_model, "vllm-full")
+
+    overflow, overflow_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+        task_capacity=maximum - 1,
+    )
+    with pytest.raises(RuntimeError, match="task-ring capacity"):
+        _compile_formula_adaptor(overflow, overflow_model, "vllm-full")
+
+
+def test_compile_rejects_dp_ubatching_and_speculative_logits():
+    dbo, dbo_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+        data_parallel_size=2,
+        use_ubatching=True,
+    )
+    with pytest.raises(RuntimeError, match="DBO"):
+        _compile_formula_adaptor(dbo, dbo_model, "vllm-full")
+
+    speculative, speculative_model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+        speculative_config=object(),
+    )
+    with pytest.raises(RuntimeError, match="speculative"):
+        _compile_formula_adaptor(
+            speculative, speculative_model, "vllm-full"
+        )
+
+
+def test_absent_model_wide_hook_selection_produces_zero_plan():
+    adaptor, model = _formula_adaptor(
+        tp_size=2,
+        tp_rank=1,
+        pp_rank=1,
+        gpu_padding_strip=True,
+        hook_selection="pos_embed",
+    )
+
+    _compile_formula_adaptor(adaptor, model, "pos_embed")
+
+    assert adaptor.active_specs == []
+    assert adaptor._role_formulas == (_VLLMRoleFormula(),)
+    assert adaptor._local_role_formula == _VLLMRoleFormula()
+    assert adaptor._has_global_hooks is False
+
+
+def test_selection_requires_model_wide_inventory_api():
+    adaptor, _model = _formula_adaptor(
+        tp_size=1,
+        tp_rank=0,
+        pp_rank=0,
+        gpu_padding_strip=True,
+    )
+
+    with pytest.raises(RuntimeError, match="get_hook_specs"):
+        _compile_formula_adaptor(
+            adaptor, SimpleNamespace(), "vllm-full"
+        )
+
+
+def test_qwen2_moe_rejects_zero_sparse_step():
+    from vllm.model_executor.models.qwen2_moe_p import (
+        _is_sparse_moe_layer,
+    )
+
+    config = SimpleNamespace(
+        decoder_sparse_step=0,
+        mlp_only_layers=[],
+        num_experts=4,
+    )
+    with pytest.raises(RuntimeError, match="decoder_sparse_step"):
+        _is_sparse_moe_layer(config, 0)

--- a/tests/vllm_request_order_fix_gpu.py
+++ b/tests/vllm_request_order_fix_gpu.py
@@ -1,0 +1,437 @@
+"""Focused GPU ground truth for the vLLM request-order fix.
+
+Run once per topology:
+  python tests/vllm_request_order_fix_gpu.py --tp 1 --pp 1 --evidence-dir /tmp/...
+  python tests/vllm_request_order_fix_gpu.py --tp 2 --pp 1 --evidence-dir /tmp/...
+  python tests/vllm_request_order_fix_gpu.py --tp 1 --pp 2 --evidence-dir /tmp/...
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+from vllm import LLM, SamplingParams
+
+from integration.vllm_adapter import DMXGPUWorker, VLLMStepPhase
+from monitoring import _native_engine
+from monitoring.ring_transport import (
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_TO_SHORT_NAME,
+    PP_LAST_ONLY,
+)
+
+
+def _evidence_path(tp_rank: int, pp_rank: int) -> Path:
+    root = Path(os.environ["DMI_ORDER_EVIDENCE_DIR"])
+    return root / f"tp{tp_rank}-pp{pp_rank}.jsonl"
+
+
+class ProbeWorker(DMXGPUWorker):
+    """Test-only worker that observes the two already-wrapped boundaries."""
+
+    def _emit(self, payload: dict[str, Any]) -> None:
+        payload.update(tp_rank=self._dmx_tp_rank, pp_rank=self._dmx_pp_rank)
+        with _evidence_path(
+            self._dmx_tp_rank, self._dmx_pp_rank
+        ).open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    def init_device(self) -> None:
+        super().init_device()
+        self._probe_step = 0
+        self._probe_plan_calls = 0
+        self._probe_last_plan = None
+        runner = self.model_runner
+        original_prepare = runner._prepare_inputs
+        original_determine = (
+            runner._determine_batch_execution_and_padding
+        )
+
+        def observed_prepare(scheduler_output, ordered_counts):
+            result = original_prepare(scheduler_output, ordered_counts)
+            state = self.adaptor._step_state
+            layout = state.layout
+            if (
+                state.phase is not VLLMStepPhase.LAYOUT_READY
+                or layout is None
+            ):
+                return result
+
+            self._probe_step += 1
+            total = layout.total_rows
+            cpu_rows = runner.input_ids.cpu[:total].tolist()
+            gpu_rows = runner.input_ids.gpu[:total].cpu().tolist()
+            expected_by_req = {}
+            for index, req_id in enumerate(layout.raw_req_ids):
+                start = layout.computed_counts[index]
+                end = start + layout.scheduled_counts[index]
+                expected_by_req[req_id] = (
+                    runner.input_batch.token_ids_cpu[
+                        index, start:end
+                    ].tolist()
+                )
+            real_flat = [
+                token
+                for req_id in layout.raw_req_ids
+                for token in expected_by_req[req_id]
+            ]
+            scheduler_order = list(
+                scheduler_output.num_scheduled_tokens
+            )
+            old_flat = [
+                token
+                for req_id in scheduler_order
+                for token in expected_by_req[req_id]
+            ]
+            self._emit(
+                {
+                    "event": "layout",
+                    "step": self._probe_step,
+                    "scheduler_order": scheduler_order,
+                    "raw_req_ids": list(layout.raw_req_ids),
+                    "req_ids": list(layout.req_ids),
+                    "scheduled_counts": list(layout.scheduled_counts),
+                    "computed_counts": list(layout.computed_counts),
+                    "token_ranges": list(layout.token_ranges),
+                    "dim0_offsets": list(layout.dim0_offsets),
+                    "cpu_token_rows": cpu_rows,
+                    "gpu_token_rows": gpu_rows,
+                    "expected_by_req": expected_by_req,
+                    "expected_real_rows": real_flat,
+                    "old_scheduler_rows": old_flat,
+                }
+            )
+            return result
+
+        def observed_determine(*args, **kwargs):
+            result = original_determine(*args, **kwargs)
+            state = self.adaptor._step_state
+            layout = state.layout
+            if state.phase is VLLMStepPhase.COMMITTED and layout is not None:
+                formula = self.adaptor._local_role_formula
+                descriptor = state.real_batch_descriptor
+                formula_plan = [
+                    formula.bytes_for(
+                        descriptor.num_tokens,
+                        layout.total_rows,
+                        len(layout.req_ids),
+                    ),
+                    formula.hook_count,
+                    False,
+                ]
+                self._emit(
+                    {
+                        "event": "dispatch",
+                        "step": self._probe_step,
+                        "mode": str(result[0]),
+                        "execution_rows": descriptor.num_tokens,
+                        "dmi_force_eager": state.force_eager_latch,
+                        "actual_plan": self._probe_last_plan,
+                        "formula_plan": formula_plan,
+                        "plan_calls": self._probe_plan_calls,
+                    }
+                )
+            return result
+
+        runner._prepare_inputs = observed_prepare
+        runner._determine_batch_execution_and_padding = observed_determine
+
+    def load_model(self) -> None:
+        super().load_model()
+        from vllm.distributed.utils import get_pp_indices
+
+        adaptor = self.adaptor
+        original_plan = adaptor._compute_step_plan
+
+        def observed_plan(ctx):
+            result = original_plan(ctx)
+            self._probe_plan_calls += 1
+            self._probe_last_plan = list(result)
+            return result
+
+        adaptor._compute_step_plan = observed_plan
+        hf_config = self.vllm_config.model_config.hf_config
+        num_layers = getattr(hf_config, "num_hidden_layers", None)
+        if num_layers is None:
+            num_layers = hf_config.n_layer
+        num_layers = int(num_layers)
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        interval = get_pp_indices(
+            num_layers, self._dmx_pp_rank, pp_size
+        )
+        self._emit(
+            {
+                "event": "model",
+                "pp_size": pp_size,
+                "num_layers": num_layers,
+                "layer_interval": list(interval),
+                "hooks": [
+                    HOOK_TYPE_TO_SHORT_NAME[spec.hook_type]
+                    for spec in adaptor.active_specs
+                ],
+                "resid_final_pp_last": (
+                    HOOK_TYPE_RESID_FINAL in PP_LAST_ONLY
+                ),
+            }
+        )
+
+
+def _outputs(outputs) -> list[list[int]]:
+    return [list(output.outputs[0].token_ids) for output in outputs]
+
+
+def _load_evidence(root: Path) -> dict[str, list[dict[str, Any]]]:
+    records = {}
+    for path in sorted(root.glob("tp*-pp*.jsonl")):
+        records[path.stem] = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+    return records
+
+
+def _validate(
+    records: dict[str, list[dict[str, Any]]],
+    *,
+    tp: int,
+    pp: int,
+) -> dict[str, Any]:
+    assert len(records) == tp * pp, records.keys()
+    models = {
+        rank: next(row for row in rows if row["event"] == "model")
+        for rank, rows in records.items()
+    }
+    layouts = {
+        rank: [row for row in rows if row["event"] == "layout"]
+        for rank, rows in records.items()
+    }
+    dispatches = {
+        rank: [row for row in rows if row["event"] == "dispatch"]
+        for rank, rows in records.items()
+    }
+    assert all(layouts.values())
+    assert all(len(layouts[r]) == len(dispatches[r]) for r in records)
+
+    reference_rank = next(iter(records))
+    reference_layouts = layouts[reference_rank]
+    for rank in records:
+        assert [
+            (
+                row["raw_req_ids"],
+                row["scheduled_counts"],
+                row["token_ranges"],
+                row["dim0_offsets"],
+            )
+            for row in layouts[rank]
+        ] == [
+            (
+                row["raw_req_ids"],
+                row["scheduled_counts"],
+                row["token_ranges"],
+                row["dim0_offsets"],
+            )
+            for row in reference_layouts
+        ]
+        assert [row["dmi_force_eager"] for row in dispatches[rank]] == [
+            row["dmi_force_eager"]
+            for row in dispatches[reference_rank]
+        ]
+        for layout in layouts[rank]:
+            assert layout["gpu_token_rows"] == layout["cpu_token_rows"]
+            assert layout["gpu_token_rows"] == layout["expected_real_rows"]
+            assert sum(layout["scheduled_counts"]) == len(
+                layout["gpu_token_rows"]
+            )
+            reconstructed_rows = []
+            for req_id, computed, count, token_range, offset in zip(
+                layout["raw_req_ids"],
+                layout["computed_counts"],
+                layout["scheduled_counts"],
+                layout["token_ranges"],
+                layout["dim0_offsets"],
+            ):
+                expected_rows = layout["expected_by_req"][req_id]
+                assert token_range == [computed, computed + count]
+                assert offset == len(reconstructed_rows)
+                assert len(expected_rows) == count
+                assert (
+                    layout["gpu_token_rows"][offset : offset + count]
+                    == expected_rows
+                )
+                reconstructed_rows.extend(expected_rows)
+            assert reconstructed_rows == layout["gpu_token_rows"]
+        for dispatch in dispatches[rank]:
+            assert dispatch["actual_plan"] == dispatch["formula_plan"]
+            assert dispatch["plan_calls"] == dispatch["step"]
+        assert any(
+            not dispatch["mode"].endswith("NONE")
+            for dispatch in dispatches[rank]
+        ), f"{rank} never used a CUDA graph"
+
+    divergences = [
+        row
+        for row in reference_layouts
+        if row["scheduler_order"] != row["raw_req_ids"]
+    ]
+    assert divergences, "workload did not expose scheduler/packed divergence"
+    assert any(
+        row["old_scheduler_rows"] != row["gpu_token_rows"]
+        for row in divergences
+    ), "old scheduler order was not a negative control"
+    assert any(
+        set(previous["raw_req_ids"]) & set(current["raw_req_ids"])
+        and set(current["raw_req_ids"]) - set(previous["raw_req_ids"])
+        for previous, current in zip(
+            reference_layouts, reference_layouts[1:]
+        )
+    ), "workload did not retain one request while admitting another"
+    assert any(
+        any(
+            index < len(previous["raw_req_ids"])
+            and previous["raw_req_ids"][index] != req_id
+            for index, req_id in enumerate(current["raw_req_ids"])
+            if req_id not in previous["raw_req_ids"]
+        )
+        for previous, current in zip(
+            reference_layouts, reference_layouts[1:]
+        )
+    ), "workload did not reuse a packed request slot"
+
+    if pp == 2:
+        pp_models = {
+            model["pp_rank"]: model for model in models.values()
+        }
+        assert set(pp_models) == {0, 1}
+        intervals = [
+            tuple(pp_models[rank]["layer_interval"]) for rank in (0, 1)
+        ]
+        assert intervals[0][0] == 0
+        assert intervals[0][1] == intervals[1][0]
+        assert intervals[1][1] == pp_models[0]["num_layers"]
+        first_hooks = pp_models[0]["hooks"]
+        last_hooks = pp_models[1]["hooks"]
+        assert "resid_final" not in first_hooks
+        assert "final_ln" not in first_hooks
+        assert "final_logits" not in first_hooks
+        assert last_hooks.count("resid_final") == 1
+        assert last_hooks.count("final_ln") == 1
+        assert last_hooks.count("final_logits") == 1
+        assert "token_ids" not in last_hooks
+        assert "embed" not in last_hooks
+        assert "pos_embed" not in last_hooks
+        assert all(
+            model["resid_final_pp_last"] for model in pp_models.values()
+        )
+
+    return {
+        "ranks": sorted(records),
+        "steps": len(reference_layouts),
+        "divergences": len(divergences),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tp", type=int, required=True)
+    parser.add_argument("--pp", type=int, required=True)
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    parser.add_argument("--model", default="gpt2")
+    args = parser.parse_args()
+    if args.tp * args.pp > 2:
+        raise ValueError("focused validation uses at most two GPUs")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    pinned_root = (repo_root / "integration" / "vllm").resolve()
+    import vllm
+    import vllm._C
+
+    assert Path(vllm.__file__).resolve().is_relative_to(pinned_root)
+    assert Path(vllm._C.__file__).resolve().is_relative_to(pinned_root)
+    native = _native_engine._load_extension()
+    assert Path(native.__file__).resolve().is_relative_to(repo_root)
+    assert HOOK_TYPE_RESID_FINAL in PP_LAST_ONLY
+
+    args.evidence_dir.mkdir(parents=True, exist_ok=False)
+    os.environ["DMI_ORDER_EVIDENCE_DIR"] = str(args.evidence_dir)
+    os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "1"
+
+    prompts = [
+        "Alpha beta gamma",
+        "One two three four",
+        "Red green blue yellow orange",
+        "The capital of France is",
+    ]
+    params = [
+        SamplingParams(
+            temperature=0.0, max_tokens=count, ignore_eos=True
+        )
+        for count in (1, 2, 5, 4)
+    ]
+    common = dict(
+        model=args.model,
+        tensor_parallel_size=args.tp,
+        pipeline_parallel_size=args.pp,
+        max_num_seqs=2,
+        max_model_len=64,
+        enforce_eager=False,
+        async_scheduling=False,
+        gpu_memory_utilization=0.35,
+    )
+
+    reference_llm = LLM(**common)
+    reference = _outputs(
+        reference_llm.generate(prompts, params, use_tqdm=False)
+    )
+    del reference_llm
+    torch.cuda.empty_cache()
+
+    active_llm = LLM(
+        **common,
+        worker_cls="tests.vllm_request_order_fix_gpu.ProbeWorker",
+        additional_config={
+            "dmx_hook_selection": "vllm-full",
+            "dmx_ring_payload_mb": 256,
+            "dmx_ring_pinned_mb": 256,
+            "dmx_ring_task_entries": 4096,
+            "dmx_null_mode": False,
+            "dmx_db_host": "",
+        },
+    )
+    active = _outputs(
+        active_llm.generate(prompts, params, use_tqdm=False)
+    )
+    active_llm.collective_rpc("stop_monitoring")
+    del active_llm
+    torch.cuda.empty_cache()
+
+    assert active == reference, {
+        "active": active,
+        "reference": reference,
+    }
+    summary = _validate(
+        _load_evidence(args.evidence_dir),
+        tp=args.tp,
+        pp=args.pp,
+    )
+    print(
+        json.dumps(
+            {
+                "status": "PASS",
+                "tp": args.tp,
+                "pp": args.pp,
+                "outputs": active,
+                **summary,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Under vLLM V1 continuous batching, each per-request capture slice carried the correct metadata (req_id/start_token/end_token) but the WRONG activation value: it got another concurrent request's row out of the batched [num_tokens, hidden] forward. ~60% of concurrent requests affected; single-request unaffected. Silent -- tensors and metadata look valid, only an accuracy/AUROC measurement exposes it.

Root cause (two parts):
- build_step_context ordered req_ids by scheduler_output.num_scheduled_tokens DICT order, but vLLM lays the flattened hidden rows out in input_batch.req_ids order (_prepare_inputs: np.repeat over num_scheduled in input_batch order).
- before_forward ran in execute_model BEFORE super().execute_model -> before the model_runner's _update_states (remove_request/add_request/condense), so it read the PREVIOUS step's input_batch order. Under continuous batching the two orderings diverge (freed-slot reuse/condense), so request i's metadata was attached to request j's row.

Fix:
- build_step_context orders req_ids by model_runner.input_batch.req_ids (the true row order), falling back to dict order when there is no input_batch.
- before_forward is driven from a _update_states wrapper installed in load_model, so the step context is built AFTER input_batch reflects this step and before the forward; removed the pre-super() call.

Pure-Python, no native rebuild. Verified (Qwen3-8B, held-out TriviaQA, exact- position selection): continuous-batch AUROC 0.52 -> 0.802; single-request 0.811 -> 0.811 (both == offline HF 0.811). A standalone reproducer (repro_continuous_batch_row_mismatch.py) goes BUG -> PASS across this change: token-matched cosine(single, continuous) mean 0.555 (81% < 0.9) -> 0.9998 (0%).

Refs #67