### PR TITLE
Runtime reconfiguration (node-toggle): low-overhead per-hook monitoring switch (CUDA-graph node enable/disable)

### DIFF
--- a/docs/node_toggle_implementation.md
+++ b/docs/node_toggle_implementation.md
@@ -1,0 +1,347 @@
+# Runtime CUDA-Graph Node-Toggle — Implementation & Optimizations
+
+> Branch: `feature/dmi_kernel_node_toggle`
+>
+> This document explains **how** DMI enables/disables individual monitoring
+> (producer) kernels inside an *already-captured* CUDA graph at runtime — with no
+> re-capture and no re-instantiation — and **which optimizations** make it cheap
+> enough to be "free to have, pay only for what you enable."
+>
+> For the user-facing API and the interactive walkthrough see
+> `docs/node_toggle_mechanism_api.html` / `docs/node_toggle_interactive.html`.
+> For raw numbers see `docs/node_toggle_local_perf.md`.
+
+---
+
+## 1. The problem
+
+DMI captures model internals by inserting `HookPoint` modules into the forward
+graph. Each one calls `torch.ops.ring.producer(x, hook_type, hook_id)`, a custom
+CUDA op that does a D2D copy of the tensor into the Ring² payload buffer and
+publishes a task descriptor. Under vLLM the decode path runs as a **full CUDA
+graph**, so every producer becomes a kernel *node* baked into the captured graph.
+
+Originally hook selection was **static**: which producers exist is decided once,
+*before* graph capture. To change what you monitor you had to tear down and
+re-capture the graph — far too expensive to do online, per request, or
+adaptively (e.g. "only turn on hidden-state capture for the last 4 layers when a
+hallucination detector flags a request").
+
+CUDA 12.2+ exposes `cudaGraphNodeSetEnabled(exec, node, 0|1)`: it flips a single
+node in an *instantiated* graph exec on or off between replays, in microseconds,
+with no re-instantiate. A **disabled kernel node is still traversed** by the
+replay engine but launches as a grid-0 no-op (~0.18–0.34 µs/node residual on
+H100/4090). That primitive is the foundation of node-toggle.
+
+The hard part is not calling that function. It is keeping the **three lanes that
+must agree** in lockstep, and doing the flip safely with respect to in-flight
+GPU work.
+
+---
+
+## 2. The three lanes that must stay in lockstep
+
+A producer firing is not a self-contained event. Each producer that fires must
+have:
+
+1. **A device kernel that actually runs** — the producer node enabled in the exec.
+2. **A metadata entry** pushed to the C++ `TensorMetaFifo` *before* the forward,
+   so the p2p thread can pop it and slice/route the payload the kernel wrote.
+   FIFO pop order must match producer firing order.
+3. **Reserved ring capacity** — `prepare_step(bytes, num_hooks)` advances the
+   payload/task ring head by exactly what the producers will write. The drain
+   thread advances the tail as it consumes *actual* producer task entries.
+
+If these three diverge, you get silent corruption:
+
+- Enabled device node but **no meta** → p2p has a payload with no descriptor → desync.
+- Meta pushed but **node disabled** → descriptor with no payload → desync.
+- Reserve for hooks that **don't fire** (or vice versa) → the ring
+  `head − tail` gap drifts monotonically → eventually a uint64 underflow in the
+  capacity check → a spurious "ring full" flush storm (measured ~+16% TPOT before
+  the fix).
+
+The design therefore funnels all three lanes through **one source of truth**.
+
+### 2.1 The single source of truth: `effective_specs`
+
+```
+effective_specs = active_specs  ∩  enabled_hooks  ∩  registered_hooks
+```
+
+- `active_specs` — hooks installed for this model/preset.
+- `enabled_hooks` — the runtime on-set (last value passed to `set_active_hooks`).
+- `registered_hooks` — hooks that actually captured a producer node during
+  capture (the `#14` guard: enabled-but-uncaptured hooks must NOT be gated on,
+  else a meta is pushed with no kernel behind it).
+
+The C++ engine owns `enabled_hooks` and `registered_hooks`. It is asked **once**
+per reconfigure (not per step) for the resulting mask, and the Python transport
+caches the surviving specs in `_effective_enabled_specs`
+(`ring_transport.py:548`, property at `:624`). Every lane reads it:
+
+- **capacity-reserve** → `vllm_integration.execute_model` sizes the step from
+  `transport.effective_specs` (version-keyed cache, `:534`).
+- **meta-push** → `pre_push_all_metas` iterates `effective_specs` (`:661`).
+- **device-enable** → `apply_toggle` / `ensure_graph_current` flip exactly the
+  registered nodes whose `(ht, layer)` is in `enabled_hooks`.
+
+Because all three derive from the same set, recomputed atomically when the
+enabled-set changes, they can never diverge by construction.
+
+---
+
+## 3. Lifecycle
+
+### 3.1 Capture: record each producer's graph node
+
+During warmup, vLLM captures the decode graph. We open a recording window and,
+inside the producer op, snapshot the node CUDA just created:
+
+```cpp
+// ring_torch_op.cpp — after launching the producer kernel, if capturing:
+if (g_toggle_capture) {
+    cudaStreamCaptureStatus st; cudaGraph_t cap_graph; const cudaGraphNode_t* deps; size_t nd;
+    if (cudaStreamGetCaptureInfo(stream, &st, &id, &cap_graph, &deps, &edges, &nd) == cudaSuccess
+        && st == cudaStreamCaptureStatusActive && nd >= 1) {
+        // the just-added producer kernel is the current tail dependency
+        g_active_engine->register_capture_node(cap_graph, hook_type, hook_id, deps[nd - 1]);
+    }
+}
+```
+
+`cudaStreamGetCaptureInfo` returns the current capture graph plus its tail
+dependency nodes; the producer kernel we just enqueued is `deps[nd-1]`. We store
+`(graph → [{hook_type, layer, node}])` in `reg_nodes`, plus the global
+`registered_hooks` set (`ring_engine_py.cu:169`).
+
+**`keep_graph=True` (`vllm_integration.py:108`).** vLLM creates
+`torch.cuda.CUDAGraph()` with `keep_graph=False`, which frees the captured
+*template* graph right after `instantiate()` — the node handles we recorded would
+dangle. We monkeypatch `torch.cuda.CUDAGraph` to force `keep_graph=True`
+(host-memory only; no device or latency cost), as a subclass so
+`isinstance(x, torch.cuda.CUDAGraph)` still holds. Applied only when node-toggle
+is on.
+
+### 3.2 Bind: associate each captured graph with its exec
+
+After warmup, before serving (no replay in flight), we walk vLLM's
+`CUDAGraphWrapper.concrete_cudagraph_entries` (one `CUDAGraph` per batch size),
+unwrap nested wrappers, and bind each `(graph → exec)` into the registry
+(`_dmx_bind_captured_graphs`, `:406`). We instantiate exactly once if needed
+(`raw_cuda_graph_exec()` raises until instantiated — guard `#3`: never
+re-instantiate an existing exec, that would destroy it). Then we **close the
+capture window** (guard `#1`).
+
+A typical Qwen3-8B run binds ~35 graphs (one per captured batch size).
+
+### 3.3 Reconfigure: `set_active_hooks(enabled)`
+
+The single entry point (`ring_transport.py:695`). At a step boundary with the
+prior replay complete it:
+
+1. **Guards** — refuse to arm the host gate if nothing is bound / nothing
+   captured (`#1`, would filter metas while every default-enabled producer still
+   fires → desync); refuse if captured graphs have **non-uniform** hook sets
+   (`#4`, the meta gate keys on `(ht,layer)` globally, so a hook present in one
+   graph but not the one replayed this step would push an orphan meta). vLLM
+   captures all hooks in every graph, so uniform holds.
+2. `eng.set_enabled_hooks(pairs)` — updates `enabled_hooks`, bumps
+   `target_version`.
+3. `eng.apply_toggle()` — flips the device nodes (eager path).
+4. Activates the host meta gate and recomputes `_effective_enabled_specs` via
+   **one** batched `effective_enabled_mask` call, bumps `_enabled_version`
+   (invalidates the worker's capacity cache).
+
+### 3.4 Replay
+
+Each step: `prepare_step` reserves capacity for `effective_specs`,
+`pre_push_all_metas` pushes metas for `effective_specs`, the graph replays —
+enabled producers run, disabled ones are grid-0 no-ops — the drain/p2p threads
+route the payloads exactly as in always-on DMI.
+
+---
+
+## 4. Optimizations
+
+### Opt 1 — Per-node diff (`last_enabled`)
+
+`apply_toggle` only calls `cudaGraphNodeSetEnabled` for nodes whose desired state
+**changed** since the last apply (`ring_engine_py.cu:198`). Each `RegEntry`
+tracks `last_enabled` (DMI is the sole toggler of its own nodes, so this mirrors
+the exec's real state). An adaptive flip of 4 hooks costs O(4) SetEnabled calls,
+not O(all nodes × all graphs).
+
+### Opt 2 — Batched pybind crossing (`effective_enabled_mask`)
+
+**The reconfigure bottleneck was the Python↔C++ boundary, not the C++ walk.**
+The original code called `is_hook_enabled(ht, layer)` once per spec to recompute
+the effective set — N pybind round-trips, each taking a lock. We replaced that
+with a single `effective_enabled_mask(query)` call that takes one lock and
+returns the whole mask (`ring_engine_py.cu:299`, used at `ring_transport.py:744`).
+C++ stays the source of truth; the host just stops crossing the boundary N times.
+
+> An earlier attempt ("eager-delta": making `apply_toggle` itself diff harder)
+> gave **zero** benefit because it optimized the wrong layer — the C++ walk was
+> already cheap. It was reverted. Batching the pybind crossings was the real win.
+
+### Opt 3 — Lazy per-graph apply (Phase 4)
+
+Eager `apply_toggle` touches **every bound graph** (~35) on every reconfigure,
+even graphs that may not be replayed again soon. Lazy mode defers the device flip
+to the moment a graph is *actually about to replay*:
+
+- `set_enabled_hooks` bumps a global `target_version`; each graph tracks its own
+  `applied_version`.
+- `ensure_graph_current(graph)` (`ring_engine_py.cu:253`) runs in the patched
+  `CUDAGraph.replay()` just before replay. If `applied_version == target_version`
+  it's a fast no-op (the common path); otherwise it applies the diff to *that one
+  graph* and stamps it current.
+- A reconfigure then costs **O(changed × graphs-actually-used)** instead of
+  **O(changed × all-graphs)**.
+
+Measured: pure reconfigure host cost dropped **6.1×** (≈80 µs → ≈13 µs).
+Opt-in via `dmx_lazy_toggle` (eager is default; lazy only matters for high-
+frequency per-step reconfigure, not static configs).
+
+### Opt 3a — Event guard (safety for lazy)
+
+Mutating an exec while a prior replay of it is still running is **undefined
+behavior** — and the host can run ahead of the GPU. So after each lazy replay we
+record a timing-disabled CUDA event on the stream (`record_replay_event`,
+`:285`); the next `ensure_graph_current` for that graph calls
+`cudaEventSynchronize` on it before mutating (`:270`). This serializes
+"mutate exec" strictly after "prior replay of that exec finished," only when a
+mutation is actually pending.
+
+(The eager `null_mode` device-flag path has a *different* discipline — full
+`cudaDeviceSynchronize` around a `cudaMemcpyToSymbol` on the legacy default
+stream — documented at `set_null_mode`, `ring_engine_py.cu:134`.)
+
+### Opt 4 — `effective_specs` single-source (correctness *and* speed)
+
+Folding active∩enabled∩registered into one cached list (§2.1) removed a per-step
+`is_hook_enabled` loop from the meta-push hot path **and** closed the reserve-
+invariant bug. It is the optimization that makes "toggle off ≈ baseline"
+possible: when nothing is enabled, `effective_specs` is empty, so reserve is 0
+bytes / 0 hooks and meta-push pushes nothing — the host floor collapses to almost
+nothing and only the disabled graph nodes remain (traversed, not launched).
+
+### Opt 5 — Reserve-invariant fix + two-sided clamp
+
+`prepare_step` (`ring_engine_py.cu:385`) must never under/over-reserve relative to
+what producers write. Two robustness fixes:
+
+- **`reserve()` keyed on `effective_specs`** — not all `active_specs`. Reserving
+  for disabled hooks was the original integration bug (monotonic gap drift →
+  underflow).
+- **Two-sided saturating clamp** on `used = head − tail`:
+  - `head < tail`: a small benign skew exists because producers that fire during
+    *capture* get drained (tail advances) with no matching `reserve()` (which
+    only runs per real step). Naive `head − tail` underflows uint64 → avail=0 →
+    spurious flush every step. Clamp `used = 0` (avail = full cap).
+  - `head − tail > cap`: over-reserve drift; fail safe with avail = 0 rather than
+    underflowing to a huge bogus "available."
+
+This removed the flush storm and made the capacity check robust to warmup skew.
+
+### Opt 6 — Low-volume drain latency
+
+Unrelated to toggle topology but on the same path: the drain thread's flush
+thresholds were tuned so low-volume steps (e.g. a few enabled hooks) don't sit
+waiting on a byte/entry threshold that never trips. See the drain-flush config in
+`init_device` and `docs/node_toggle_local_perf.md` "Low-volume drain latency."
+
+---
+
+## 5. Correctness guards (numbered, as in code)
+
+| # | Guard | Where | Prevents |
+|---|-------|-------|----------|
+| #1 | Refuse to arm host gate with no exec bound / nothing captured | `set_active_hooks` `:715` + close window after bind `:375` | host filters metas while default-on producers still fire → desync |
+| #2 | `clear_toggle` resets enabled-set + deactivates gate together | `clear_toggle_registry` `:322`, `clear_toggle` `:788` | stale gate skipping every meta after a clear |
+| #3 | Never re-instantiate an existing exec | `_dmx_bind_captured_graphs` `:431` | destroying a live exec |
+| #4 | Require uniform hook sets across captured graphs | `toggle_registry_uniform` `:225`, checked `:724` | orphan meta when the replayed graph lacks a globally-gated hook |
+| #14 | Gate on enabled **AND** registered | `is_hook_enabled` `:242`, `effective_enabled_mask` `:299` | meta pushed for an enabled-but-uncaptured hook (no kernel behind it) |
+
+A debug accessor `get_stats()` (`:118`) exposes live `payload/task head & tail`
+so a long-running probe can confirm `reserve == actually-written` across configs.
+
+---
+
+## 6. Measured results (Qwen3-8B, H100)
+
+Per-step decode overhead, batch=1, `cudagraph_mode=FULL`, 100 steps × 30 reps,
+median. Baseline per-step = 6.5220 ms.
+
+| Config | per-step (ms) | Δ µs/step | overhead |
+|--------|--------------:|----------:|---------:|
+| baseline (no DMI)         | 6.5220 | —      | —      |
+| **toggle off** (0/36)     | 6.5282 | +6.3   | +0.10% |
+| DMI null mode             | 6.5455 | +23.5  | +0.36% |
+| **toggle partial** (4/36) | 6.5490 | +27.0  | +0.41% |
+| DMI on (full transport)   | 6.6411 | +119.2 | +1.83% |
+| **toggle full** (36/36)   | 6.6543 | +132.4 | +2.03% |
+
+1. **toggle off ≈ baseline (+0.10%)** — armed-but-idle is essentially free.
+2. **toggle off (+0.10%) < null_mode (+0.36%)** — disabling removes the kernel
+   *launch*, not just the work; ~3.7× cheaper idle than the old `null_mode`.
+3. **Scales with #enabled** — 0/4/36 → +0.10/+0.41/+2.03% (~3.5 µs/enabled hook;
+   ~0.18 µs residual per disabled node).
+4. **toggle full ≈ DMI on** (+2.03% vs +1.83%) — toggle is ~free to have
+   (~13 µs machinery over plain always-on) and recovers **~95%** of the transport
+   overhead when idle.
+
+The host costs overlap GPU replay, so these are not pure single-stream TPOT
+deltas — the host-CPU savings matter most for throughput under concurrency. See
+`node_toggle_local_perf.md` for the per-block host-path decomposition (RTX 4090 /
+Qwen3-0.6B).
+
+---
+
+## 7. API summary
+
+Three engine calls span capture → bind → toggle; the transport wraps them.
+
+```python
+# capture (warmup): record producer nodes
+engine.enable_toggle_capture(True)        # producer op records nodes via GetCaptureInfo
+...super().compile_or_warm_up_model()...   # vLLM captures graphs (keep_graph forced True)
+# bind (post-warmup, no replay in flight)
+engine.bind_graph_exec(raw_graph, raw_exec)   # per captured graph
+engine.enable_toggle_capture(False)           # close the window (#1)
+# reconfigure (any step boundary)
+transport.set_active_hooks([(ht, layer), ...])      # eager  (set_enabled_hooks + apply_toggle)
+transport.set_active_hooks_lazy([(ht, layer), ...]) # lazy   (defer device flip to replay)
+transport.clear_toggle()                            # paired teardown
+```
+
+vLLM config (`--additional-config`):
+
+```json
+{
+  "dmx_node_toggle": true,
+  "dmx_enabled_hooks": "0:32,0:33,0:34,0:35",   // hook_type:layer; "0:99" => all off
+  "dmx_lazy_toggle": false                       // true => Phase 4 lazy apply
+}
+```
+
+Requires `cudagraph_mode=FULL` (decode) so producer nodes are captured + bindable;
+`DMXGPUWorker` raises if a subset is requested but nothing bound.
+
+---
+
+## 8. File map
+
+| Concern | File / symbol |
+|---------|---------------|
+| Capture-time node recording | `csrc/ring/ring_torch_op.cpp` — `g_toggle_capture`, `cudaStreamGetCaptureInfo`, `register_capture_node` |
+| Toggle registry + apply + lazy | `csrc/ring/ring_engine_py.cu` — `Impl` registry, `apply_toggle`, `set_enabled_hooks`, `ensure_graph_current`, `record_replay_event`, `effective_enabled_mask`, `prepare_step` clamp, `get_stats` |
+| Bindings / decls | `csrc/bindings.cpp`, `csrc/ring/ring_engine_py.h` |
+| Host single-source + gate | `ring_transport.py` — `effective_specs`, `set_active_hooks`, `set_active_hooks_lazy`, `pre_push_all_metas`, `clear_toggle` |
+| vLLM wiring | `vllm_integration.py` — `_patch_cudagraph_keep_graph`, `_KeepGraphCUDAGraph.replay`, `compile_or_warm_up_model`, `_dmx_bind_captured_graphs`, `execute_model` capacity loop |
+| Tests | `tests/ring/test_rings.cu`, `tests/test_reconfig_sequence_e2e.py`, `test_reconfig_multigraph_e2e.py`, `test_reconfig_lazy_e2e.py` |
+| Experiments | `experiments/online_serving/script/sbatch/adapt_toggle_{qwen4b,llama8b,qwen14b}.sbatch` |
+| Perf / showcase | `docs/node_toggle_local_perf.md`, `docs/node_toggle_mechanism_api.html`, `docs/node_toggle_interactive.html` |
+</content>
+</invoke>

--- a/docs/node_toggle_implementation.md
+++ b/docs/node_toggle_implementation.md
@@ -204,6 +204,37 @@ Measured: pure reconfigure host cost dropped **6.1×** (≈80 µs → ≈13 µs)
 Opt-in via `dmx_lazy_toggle` (eager is default; lazy only matters for high-
 frequency per-step reconfigure, not static configs).
 
+### Opt 4 — Reconfigure caches (guard verdict + preset memo)
+
+Per-step reconfigure is the access pattern of the planned consumers (graduated
+hallucination monitoring, per-layer profiler sweeps, debugging), and at
+production scale the dominant reconfigure cost turned out to be **re-validating
+an immutable registry**: the `set_active_hooks[_lazy]` guards (uniformity /
+completeness, O(graphs × hooks)) scale with bound graphs — measured host-only
+lazy cost 9.9 / 15.5 / 36.6 µs at 1 / 8 / 35 graphs
+(`docs/node_toggle_probe/probe_reconfig_scaling.py`).
+
+The registry only mutates at capture / bind / clear time, so the engine keeps a
+`registry_version` bumped by **every** mutation, and the transport memoizes on
+it:
+
+- **Guard verdict**: a guard PASS is cached per registry version; the next
+  reconfigure on an unchanged registry skips the checks entirely. Failures are
+  never cached, and any mutation (including `note_capture_anomaly`) forces full
+  re-validation — the fail-loud semantics are unchanged, gated by
+  `test_toggle_reconfig_cache_e2e.py`.
+- **Preset memo**: `(registry version, enabled set, active_specs identity) →
+  effective_specs`, so cycling presets skips the batched-mask recompute.
+
+Measured after: lazy reconfigure **4–6 µs flat, independent of graph count**
+(35 graphs: 36.6 → 4.4 µs); per-step full lazy price (call + ensure + event)
+17.8 → 10.5 µs on the ~4 ms probe step.
+
+> A fifth idea — **exec ping-pong** (two execs per template; apply to the idle
+> one to hide the ensure event-wait) — was probed and rejected: the event-wait
+> bubble is only ~6 µs, while a second exec costs ~7 KiB/node of device memory
+> (≈0.25–0.5 GiB across 35 production graphs).
+
 ### Opt 3a — Event guard (safety for lazy)
 
 Mutating an exec while a prior replay of it is still running is **undefined

--- a/docs/node_toggle_migration_scope.md
+++ b/docs/node_toggle_migration_scope.md
@@ -1,0 +1,135 @@
+# Node-Toggle Migration Scope — Layer 1 (C++ engine) vs current `origin/main`
+
+> Target: re-apply the node-toggle feature onto `feature/node-toggle-v2`
+> (branched from `origin/main` @ `5c3906e`). This doc scopes the **C++ engine
+> layer** conflicts — the layer with the highest risk because main's #40 (Ring²)
+> and #51 (GPU-strip + MoE) rewrote the same files the toggle modifies.
+>
+> Source branch (old lineage): `feature/dmi_kernel_node_toggle`.
+> Status: scoping only — no code ported yet.
+
+## TL;DR
+
+The C++ toggle delta is **mostly pure-add** (registry struct members + ~12 new
+methods + bindings + a new header). There are **three real conflict points**:
+
+1. **🔴 CRITICAL — producer fan-out (#51).** Main now has **3** producer ops
+   (`producer` / `producer_prefix` / `producer_chunked`). With the default
+   `gpu_padding_strip=True`, hidden-state hooks dispatch to **`producer_prefix`**,
+   not the basic `producer` the toggle records. **Out of the box, toggle would
+   record 0 nodes → `set_active_hooks` raises.** Must resolve before anything works.
+2. **🟠 prepare_step diverged.** Main rewrote `prepare_step` (device
+   `actual_bytes_counter` delta snapshot, `STEP_OVERSIZED` rename, **no two-sided
+   clamp**). The branch's clamp fix (reserve-invariant safety) must be *merged*
+   into main's version, not pasted.
+3. **🟡 enum rename.** `STEP_CPU_DIRECT` → `STEP_OVERSIZED`. Touches the toggle's
+   Python references.
+
+Everything else slots in cleanly. `null_mode` (toggle's dependency) already
+exists on main.
+
+---
+
+## Per-file scope
+
+### `csrc/ring/node_toggle.h` — PURE-ADD
+New file. No main counterpart. Drops in unchanged.
+
+### `csrc/ring/ring_engine_py.cu`
+main 316 lines → branch 458 (different lineage).
+
+| Toggle piece | Port type | Notes |
+|---|---|---|
+| `Impl` registry members (`reg_nodes`, `reg_exec`, `enabled_hooks`, `registered_hooks`, `target_version`, `applied_version`, `replay_event`, `toggle_mu`) | **PURE-ADD** | slot into main's `Impl` (which already carries `payload_view`, `last_counter_read`) |
+| `~Impl` event cleanup | PURE-ADD | main's Impl has no dtor; add one |
+| ~12 methods (`enable_toggle_capture`, `register_capture_node`, `bind_graph_exec`, `set_enabled_hooks`, `apply_toggle`, `is_hook_enabled`, `effective_enabled_mask`, `ensure_graph_current`, `record_replay_event`, `toggle_registry_uniform`, `clear_toggle_registry`, `bound_graph_count`/`toggle_node_count`, `get_stats`) | **PURE-ADD** | no main equivalents (all 8 toggle symbols = 0 hits on main) |
+| `prepare_step` two-sided clamp + reserve | **🟠 SEMANTIC-MERGE** | see below |
+
+**`prepare_step` merge detail.** Main's version (lines 184–236) computes
+`payload_avail = pcap - (head - tail)` and `task_avail = tcap - (head - tail)`
+**raw, unclamped** — the exact underflow the branch fixed. Main also added a
+device `actual_bytes_counter` delta read (for future strip reclamation) and
+renamed the oversize return to `STEP_OVERSIZED`. Port = re-apply the branch's
+**two-sided saturating clamp** onto main's `payload_avail`/`task_avail` lines,
+keeping main's counter-delta block intact. The "reserve from the *effective* set"
+half is driven from Python (the `step_total_bytes`/`num_hooks` args already carry
+the effective counts), so `prepare_step` itself only needs the clamp.
+
+### `csrc/ring/ring_engine_py.h`
+| Piece | Port type | Notes |
+|---|---|---|
+| toggle method declarations | PURE-ADD | mirror the .cu additions |
+| `STEP_CPU_DIRECT` → `STEP_OVERSIZED` | **🟡 RENAME** | toggle's Python (`vllm` capacity loop) must use main's name (result `== 2`) |
+| `hook_no_notify` (3 variants on main) | no change | toggle's `current_hook_idx` reset stays in `prepare_step` |
+
+### `csrc/ring/ring_torch_op.cpp` — 🔴 EXPANDED
+main 156 lines → branch 128 (main is *longer*: it has 3 producer impls).
+
+| Toggle piece | Port type | Notes |
+|---|---|---|
+| `g_toggle_capture` static + `ring_set_toggle_capture()` | PURE-ADD | module-global; clean |
+| capture-record block (`cudaStreamGetCaptureInfo` + `register_capture_node` after the producer launch) | **🔴 EXPAND ×3** | branch added it to the *one* `ring_producer_impl`. Main has **`ring_producer_impl` / `ring_producer_prefix_impl` / `ring_producer_chunked_impl`** — each launches a kernel node. The block must be replicated into all three (or strip disabled, see decision). |
+| op schema gained `Tensor(a!) ring_payload` first arg | no toggle change | lineage detail; toggle reads node via `GetCaptureInfo`, not the args |
+
+### `csrc/bindings.cpp` — PURE-ADD
+Add `.def(...)` for each new method into main's `RingEnginePy` class binding
+(main already binds `prepare_step`, `push_all_metas`, `set_null_mode`). The toggle
+meta-gate calls `push_all_metas`, which exists on main with a compatible
+signature.
+
+### `csrc/ring/producer.cu` — NO TOGGLE CHANGE
+Toggle depends only on `null_mode` (`g_ring_null_mode` / `set_ring_null_mode`),
+which **already exists on main**. #51's heavy `producer.cu` rewrite (+335) is a
+lineage concern for the strip path, not for toggle.
+
+---
+
+## 🔴 The producer fan-out decision (blocks everything)
+
+`hook_points.py::_dispatch_producer` on main:
+```
+_strip_tensor is None                    -> torch.ops.ring.producer          (basic)
+_strip_tensor set, _strip_row_bytes > 0  -> torch.ops.ring.producer_prefix   (strip)
+_strip_tensor set, _strip_row_bytes == 0 -> torch.ops.ring.producer_chunked
+```
+`VLLMAdaptor.attach_model` sets `_strip_tensor` + `_strip_row_bytes>0` on every
+spec with `dim0_is_actual_tokens` (hidden-states in vLLM flat layout) **when
+`gpu_padding_strip=True` (the default)**. So under default config the producer
+that actually fires for hidden-states is `producer_prefix` — whose node the
+current toggle capture recording never sees.
+
+**Two resolutions:**
+
+- **(A) Extend capture recording to all 3 impls** *(keeps the strip optimization)*.
+  Add the same `if (g_toggle_capture) { GetCaptureInfo + register_capture_node }`
+  block to `ring_producer_prefix_impl` and `ring_producer_chunked_impl`. The node
+  recorded is still "the producer kernel for (hook_type, layer)", so the
+  registry/apply/meta-gate logic is unchanged — only the recording sites grow
+  from 1 to 3. Modest, and the *correct* long-term answer.
+- **(B) Run toggle with `gpu_padding_strip=False`** *(simplest, smaller patch)*.
+  Forces every hook through the basic `producer`, so the existing 1-site recording
+  works as-is. Cost: producers capture padded bytes (the strip optimization is
+  off) while toggle is in use. Clean combination; good for a first landing.
+
+Recommendation: **start with (B)** to get the migration green end-to-end (the
+toggle + strip-off combo is independently valid), then do **(A)** as a follow-up
+so toggle composes with the strip optimization.
+
+---
+
+## Layer-1 conflict summary
+
+| Conflict | Severity | Effort |
+|---|---|---|
+| producer fan-out (record prefix/chunked, or strip-off) | 🔴 blocks | (B) trivial / (A) ~1 block ×2 |
+| `prepare_step` clamp semantic-merge | 🟠 | small, careful |
+| `STEP_CPU_DIRECT`→`STEP_OVERSIZED` rename | 🟡 | trivial (Python side) |
+| registry + 12 methods + bindings + header | ✅ pure-add | mechanical |
+| `producer.cu` / `null_mode` | ✅ none | — |
+
+**Verdict:** Layer 1 is tractable. No deep redesign required — the only design
+decision is the producer fan-out (A vs B), and (B) unblocks immediately. After
+this layer builds + `tests/ring/test_node_toggle*.cu` pass, Layers 2–4
+(transport / adaptor_base / vLLM) are the mechanical re-targeting already scoped
+in `docs/node_toggle_implementation.md` and the prior migration analysis.
+</content>

--- a/docs/node_toggle_usage.md
+++ b/docs/node_toggle_usage.md
@@ -80,6 +80,25 @@ until the ring fills or shutdown. The default `dmx_drain_flush_timeout_us=50000`
 (50 ms, when toggle is on) forces a periodic flush. Lower it for tighter export
 latency; raise/zero it if you batch large volumes and prefer threshold-only.
 
+## Scope: decode-gated, prefill-passthrough
+
+The toggle gates only the **decode** path (producers that run inside a replayed
+full-decode CUDA graph, via `cudaGraphNodeSetEnabled`). **Prefill** steps run
+eager — there is no graph to gate — so they are **not** toggled: prefill emits
+the **full active hook set** regardless of the enabled subset (stock monitoring
+behavior, unchanged). Concretely, with `dmx_enabled_hooks="0:24,..,0:27"`:
+
+- **decode** rows (one token/step) → only layers 24–27,
+- **prefill** rows (the prompt) → **all active layers**.
+
+So enabling a small decode subset does **not** reduce prefill data volume. This
+is by construction: gating prefill would require either per-step graph
+prediction (fragile) or gating the eager producers (changes prefill semantics).
+The meta-push and capacity-reserve follow the same per-step split, so the ring
+stays in lockstep on both paths (a prefill step that pushed only the decode
+subset's metas while firing all producers would desync — guarded by
+`test_toggle_prefill_passthrough_e2e`).
+
 ## Scope (current)
 
 The enabled set is **engine/step-level**, applied at a step boundary — **not

--- a/docs/node_toggle_usage.md
+++ b/docs/node_toggle_usage.md
@@ -53,10 +53,12 @@ Comma-separated `hook_type:layer` pairs. `hook_type` 0 = hidden-states
   graphs, and if an unregistered (runtime-captured) graph ever replays the worker
   **fails loud** rather than silently desyncing.
 - **`gpu_padding_strip` composes with node-toggle** for the basic and **prefix**
-  producers (both record their kernel node at capture). The **chunked/MoE**
-  producer is *not* toggle-managed yet: if any fires under capture,
-  `set_active_hooks` fails loud — run toggle on MoE with
-  `dmx_gpu_padding_strip=False` so every hook routes through the basic producer.
+  producers (both record their kernel node at capture) — this covers the dense
+  hidden-states case, including MoE models (their hooks go through prefix). The
+  **chunked** producer is *not* toggle-managed and is not dispatched by the vLLM
+  adapter today (dormant infra); if one ever fires under capture,
+  `set_active_hooks` fails loud — `dmx_gpu_padding_strip=False` routes every hook
+  through the basic producer.
 - Model code needs **no changes** — toggle is entirely backend + adaptor; hooked
   models only place `HookPoint`s and declare `get_hook_specs()`.
 

--- a/docs/node_toggle_usage.md
+++ b/docs/node_toggle_usage.md
@@ -1,0 +1,107 @@
+# Node-Toggle — Usage & Configuration
+
+Runtime enable/disable of individual monitoring (producer) hooks inside an
+already-captured CUDA graph, between replays, via `cudaGraphNodeSetEnabled` — no
+re-capture. Idle (all hooks off) is near-baseline; cost scales with the number of
+*enabled* hooks. vLLM decode path only.
+
+## Quick start (vLLM)
+
+Pass node-toggle options in `--additional-config` (or the matching `DMX_*` env
+vars). Node-toggle **requires full-decode CUDA graphs**:
+
+```bash
+vllm serve <model> \
+  --compilation-config '{"cudagraph_mode": "FULL"}' \
+  --worker-cls integration.vllm_adapter.DMXGPUWorker \
+  --additional-config '{
+    "dmx_hook_selection": "hidden-states",
+    "dmx_node_toggle": true,
+    "dmx_enabled_hooks": "0:24,0:25,0:26,0:27",
+    "dmx_db_host": "localhost", "dmx_db_port": 9000, "dmx_db_table": "offload"
+  }'
+```
+
+## Configuration keys
+
+| Key (`additional_config`) | Env | Default | Meaning |
+|---|---|---|---|
+| `dmx_node_toggle` | `DMX_NODE_TOGGLE` | `false` | Master switch. Off → stock always-on behaviour (unchanged). |
+| `dmx_enabled_hooks` | `DMX_ENABLED_HOOKS` | `""` | Which hooks fire. See **enabled-set semantics** below. |
+| `dmx_lazy_toggle` | `DMX_LAZY_TOGGLE` | `false` | Defer the device apply to each graph's first replay (per-graph lazy). See **eager vs lazy**. |
+| `dmx_drain_flush_timeout_us` | `DMX_DRAIN_FLUSH_TIMEOUT_US` | **50000 when toggle on**, else 0 | Bound export latency for sparse-hook monitoring (see **sparse-hook export**). |
+
+### Enabled-set semantics (`dmx_enabled_hooks`)
+
+Comma-separated `hook_type:layer` pairs. `hook_type` 0 = hidden-states
+(`resid_pre`); layer omitted (`"14"`) → global hook (layer −1).
+
+- **unset / `""`** → toggle gate **inactive**: every active hook fires (all-on).
+- **`"none"`** → explicit **empty set**: every hook disabled (toggle-0, near-baseline).
+- **`"0:24,0:25"`** → exactly those hooks fire; all others disabled.
+
+(Do **not** use a nonexistent layer like `"0:99"` to mean all-off — use `"none"`.)
+
+## Requirements & constraints
+
+- **`cudagraph_mode=FULL`** for decode. The worker raises at startup if a subset
+  is requested but no full-decode graph was bound. *Piecewise* graphs hold only a
+  model subset, so different graphs capture different hook subsets and fail the
+  uniform-hook-set requirement. Note: vLLM may **auto-downgrade FULL →
+  FULL_AND_PIECEWISE** if the attention backend lacks full-graph support
+  (e.g. FlashAttention `UNIFORM_BATCH`); node-toggle still binds the full *decode*
+  graphs, and if an unregistered (runtime-captured) graph ever replays the worker
+  **fails loud** rather than silently desyncing.
+- **`gpu_padding_strip` is auto-forced off** when node-toggle is on (only the
+  basic producer's kernel node is toggle-recorded; the prefix/chunked strip
+  producers are not). A warning is emitted if you set it on explicitly.
+- Model code needs **no changes** — toggle is entirely backend + adaptor; hooked
+  models only place `HookPoint`s and declare `get_hook_specs()`.
+
+## eager vs lazy
+
+- **Eager** (default): `set_active_hooks` flips every bound exec immediately.
+  Safe **only at a quiescent point** (no replay of any bound exec in flight) —
+  i.e. a static config applied once after warmup. It does **not** wait on replay
+  events, so mutating an exec mid-replay is UB.
+- **Lazy** (`dmx_lazy_toggle=true`): the device flip is deferred to each graph's
+  next replay (`ensure_graph_current`), guarded by a per-graph replay event. Use
+  this for **dynamic / per-step reconfigure** (adaptive toggling at runtime).
+
+## Sparse-hook export
+
+With a small enabled set, per-step data volume is low; without a timed flush the
+drain waits on byte/entry thresholds that sparse steps never hit, so data buffers
+until the ring fills or shutdown. The default `dmx_drain_flush_timeout_us=50000`
+(50 ms, when toggle is on) forces a periodic flush. Lower it for tighter export
+latency; raise/zero it if you batch large volumes and prefer threshold-only.
+
+## Runtime (programmatic) reconfigure
+
+For dynamic toggling from your own code (e.g. an adaptive monitor), the transport
+exposes:
+
+```python
+from monitoring import ring_transport
+t = ring_transport.get_active()
+t.set_active_hooks([(0, 24), (0, 25)])        # eager: flip now (quiescent only)
+t.set_active_hooks_lazy([(0, 26)])            # lazy: deferred per-graph apply
+t.clear_toggle()                              # teardown: gate off, registry cleared
+```
+
+`(hook_type, layer)` pairs; the enabled set is the single source of truth driving
+capacity-reserve, meta-push, and device node-enable in lockstep.
+
+## Fail-loud guards (what raises)
+
+Node-toggle treats any desync risk as fatal (the worker must terminate):
+- requesting a subset with no bound full-decode graph,
+- captured graphs with non-uniform hook sets, or an incomplete graph↔exec registry,
+- a runtime-captured (unregistered) graph reaching replay,
+- a lazy device apply / replay-event error.
+
+## Mechanism / internals
+
+See `docs/node_toggle_implementation.md` (design + optimizations) and
+`docs/node_toggle_migration_scope.md`. The self-checking end-to-end test is
+`tests/ring/smoke_toggle_vllm.py`.

--- a/docs/node_toggle_usage.md
+++ b/docs/node_toggle_usage.md
@@ -52,9 +52,11 @@ Comma-separated `hook_type:layer` pairs. `hook_type` 0 = hidden-states
   (e.g. FlashAttention `UNIFORM_BATCH`); node-toggle still binds the full *decode*
   graphs, and if an unregistered (runtime-captured) graph ever replays the worker
   **fails loud** rather than silently desyncing.
-- **`gpu_padding_strip` is auto-forced off** when node-toggle is on (only the
-  basic producer's kernel node is toggle-recorded; the prefix/chunked strip
-  producers are not). A warning is emitted if you set it on explicitly.
+- **`gpu_padding_strip` composes with node-toggle** for the basic and **prefix**
+  producers (both record their kernel node at capture). The **chunked/MoE**
+  producer is *not* toggle-managed yet: if any fires under capture,
+  `set_active_hooks` fails loud — run toggle on MoE with
+  `dmx_gpu_padding_strip=False` so every hook routes through the basic producer.
 - Model code needs **no changes** — toggle is entirely backend + adaptor; hooked
   models only place `HookPoint`s and declare `get_hook_specs()`.
 

--- a/docs/node_toggle_usage.md
+++ b/docs/node_toggle_usage.md
@@ -76,6 +76,16 @@ until the ring fills or shutdown. The default `dmx_drain_flush_timeout_us=50000`
 (50 ms, when toggle is on) forces a periodic flush. Lower it for tighter export
 latency; raise/zero it if you batch large volumes and prefer threshold-only.
 
+## Scope (current)
+
+The enabled set is **engine/step-level**, applied at a step boundary — **not
+per-request-within-a-batch**. When multiple requests are batched into one decode
+step, a hook is either on or off for the whole batch tensor. True per-request
+adaptive monitoring (different hooks per request in the same step) would need a
+request → step-union → graph layering plus row-sparse producer copy; that's a
+future feature, not implemented here. For now, take the per-step union of what
+any request needs and route/filter downstream.
+
 ## Runtime (programmatic) reconfigure
 
 For dynamic toggling from your own code (e.g. an adaptive monitor), the transport

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -734,16 +734,11 @@ class DMXGPUWorker(Worker):
         # DMX_GPU_PADDING_STRIP=0 if needed for debugging.
         gpu_padding_strip = _cfg(
             ac, "dmx_gpu_padding_strip", "DMX_GPU_PADDING_STRIP", True)
-        # Option B: node-toggle records nodes only from the BASIC producer op.
-        # gpu_padding_strip routes eligible hooks to producer_prefix instead,
-        # whose nodes are not toggle-recorded -> 0 bound nodes. Force strip off
-        # when toggle is on so every hook dispatches to the basic producer.
-        if self._dmx_node_toggle and gpu_padding_strip:
-            warnings.warn(
-                "[DMX] node-toggle: forcing gpu_padding_strip=False (toggle records "
-                "only basic-producer nodes; prefix/chunked producers are not "
-                "toggle-recorded). Set dmx_gpu_padding_strip=False to silence.")
-            gpu_padding_strip = False
+        # Node-toggle composes with gpu_padding_strip for the basic + prefix
+        # producers (both record their kernel node at capture). Chunked/MoE
+        # producers are NOT toggle-managed yet: if any fire under capture,
+        # set_active_hooks fails loud -- run toggle on MoE with
+        # dmx_gpu_padding_strip=False (everything routes to the basic producer).
         self.adaptor = VLLMAdaptor(
             engine, resolved_model_id, self.vllm_config,
             gpu_padding_strip=bool(gpu_padding_strip))

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -366,8 +366,13 @@ class VLLMAdaptor(BackendAdaptor):
         # dispatch condition: a uniform-decode batch (every req scheduled exactly
         # uniform_decode_query_len tokens) whose token count fits a captured
         # size. Same private-attr risk surface as predict_padded_q_len.
-        self.transport._gated_step = self._step_uses_decode_graph(
-            model_runner, total_q, num_scheduled_per_req)
+        #
+        # Only compute it when the toggle gate is active: with the gate off,
+        # specs_for_step() returns active_specs regardless of _gated_step, so the
+        # non-toggle path pays nothing for this.
+        if self.transport.toggle_gate_active:
+            self.transport._gated_step = self._step_uses_decode_graph(
+                model_runner, total_q, num_scheduled_per_req)
 
         # Per-request offsets and token ranges.
         computed_map: dict = {}
@@ -613,9 +618,9 @@ class DMXGPUWorker(Worker):
         # nonzero timeout forces the drain to flush pending entries after that
         # idle window.
         # Default: 50 ms when node-toggle is ON (sparse by design, so partial
-        # toggle exports promptly without manual tuning); 0 (threshold-only)
+        # toggle exports promptly without manual tuning); main's 100 ms
         # otherwise. Override via dmx_drain_flush_timeout_us.
-        _default_flush_us = 50000 if node_toggle else 0
+        _default_flush_us = 50000 if node_toggle else 100 * 1000
         ring_cfg.drain_flush_timeout_us = int(_cfg(
             ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US",
             _default_flush_us))
@@ -625,9 +630,6 @@ class DMXGPUWorker(Worker):
         ring_cfg.insert_queue_max_items = int(_cfg(
             ac, "dmx_insert_queue_max_items", "DMX_INSERT_QUEUE_MAX_ITEMS",
             65536))
-        ring_cfg.drain_flush_timeout_us = int(_cfg(
-            ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US",
-            100 * 1000))
 
         # MonitoringEngine + ring transport.
         engine = MonitoringEngine(

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -736,10 +736,9 @@ class DMXGPUWorker(Worker):
             ac, "dmx_gpu_padding_strip", "DMX_GPU_PADDING_STRIP", True)
         # Node-toggle composes with gpu_padding_strip for the basic + prefix
         # producers (both record their kernel node at capture). The chunked
-        # producer is NOT toggle-managed (and is not dispatched by this adapter
-        # today -- dormant infra); if one ever fires under capture, set_active_hooks
-        # fails loud. dmx_gpu_padding_strip=False routes everything to the basic
-        # producer.
+        # producer is NOT toggle-managed (and this adapter never dispatches it);
+        # if one fires under capture, set_active_hooks fails loud.
+        # dmx_gpu_padding_strip=False routes every hook to the basic producer.
         self.adaptor = VLLMAdaptor(
             engine, resolved_model_id, self.vllm_config,
             gpu_padding_strip=bool(gpu_padding_strip))

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -696,6 +696,14 @@ class DMXGPUWorker(Worker):
         ring_cfg.payload_ring_bytes = ring_payload_mb * 1024 * 1024
         ring_cfg.pinned_staging_bytes = ring_pinned_mb * 1024 * 1024
         ring_cfg.task_ring_entries = ring_entries
+        # Bound export latency for LOW-VOLUME / sparse-hook monitoring (e.g.
+        # node-toggle with a small enabled set): without a timed flush the drain
+        # waits on byte/entry thresholds that sparse steps never hit, so data
+        # sits in the ring until the buffer fills or a final flush-on-close. A
+        # nonzero timeout forces the drain to flush pending entries after that
+        # idle window. 0 (default) = threshold-only (legacy behaviour).
+        ring_cfg.drain_flush_timeout_us = int(_cfg(
+            ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US", 0))
         ring_cfg.insert_queue_max_bytes = int(_cfg(
             ac, "dmx_insert_queue_max_bytes", "DMX_INSERT_QUEUE_MAX_BYTES",
             4096 * 1024 * 1024))

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -887,6 +887,21 @@ class DMXGPUWorker(Worker):
                     g = getattr(entry, "cudagraph", None)
                     if g is None:
                         continue
+                    # A graph not created by the keep_graph patch means vLLM
+                    # resolved torch.cuda.CUDAGraph before (or without) the
+                    # patch -- its template is freed on instantiate, so the
+                    # capture-recorded node handles dangle and SetEnabled on
+                    # them is UB. Refuse before any handle is touched.
+                    if not getattr(type(g), "_dmx_keep_graph", False):
+                        raise RuntimeError(
+                            "[DMX] node-toggle FATAL: a captured CUDA graph was "
+                            "created from the UNPATCHED torch.cuda.CUDAGraph "
+                            "(keep_graph=False), so its template graph is already "
+                            "freed and the recorded producer-node handles dangle. "
+                            "vLLM likely binds the CUDAGraph class at import time "
+                            "in this version, bypassing _patch_cudagraph_keep_graph. "
+                            "Refusing to bind; fix the patch injection point before "
+                            "serving with node-toggle.")
                     # Don't re-instantiate if an exec already exists (that would
                     # destroy it). raw_cuda_graph_exec() raises until the graph
                     # is instantiated -> instantiate exactly once in that case.

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -285,6 +285,38 @@ class VLLMAdaptor(BackendAdaptor):
             return pad_table[total_q]
         return total_q
 
+    def _step_uses_decode_graph(
+        self, model_runner: Any, total_q: int, num_scheduled_per_req: list
+    ) -> bool:
+        """True iff this step will replay a captured FULL decode graph -- the
+        only steps where node-toggle's SetEnabled actually gates producers.
+
+        Mirrors vLLM's dispatch condition (cudagraph_dispatcher): a uniform
+        decode batch (every request scheduled exactly uniform_decode_query_len
+        tokens) whose total token count is within the captured-size range.
+        Anything else (prefill, mixed, oversize) runs eager -> producers fire
+        ungated -> the caller uses the full active set for meta + reserve.
+
+        Risk surface (same as predict_padded_q_len): reads
+        cudagraph_dispatcher.uniform_decode_query_len and
+        compilation_config.max_cudagraph_capture_size. On a vLLM upgrade,
+        verify these still gate FULL-graph dispatch. Conservative on failure:
+        any unexpected shape returns False (full set -> never under-reserves).
+        """
+        if not num_scheduled_per_req:
+            return False
+        uniform_q = getattr(
+            getattr(model_runner, "cudagraph_dispatcher", None),
+            "uniform_decode_query_len", 1) or 1
+        if any(n != uniform_q for n in num_scheduled_per_req):
+            return False  # prefill / mixed -> eager
+        max_cap = getattr(
+            getattr(self.vllm_config, "compilation_config", None),
+            "max_cudagraph_capture_size", None)
+        if max_cap is not None and total_q > max_cap:
+            return False  # oversize uniform decode -> eager
+        return True
+
     def build_step_context(
         self, scheduler_output: Any, model_runner: Any
     ) -> Optional[StepContext]:
@@ -325,6 +357,17 @@ class VLLMAdaptor(BackendAdaptor):
 
         padded_q = self.predict_padded_q_len(model_runner, total_q)
         self._last_total_q = total_q
+
+        # Per-step node-toggle gate selector. The toggle (SetEnabled on captured
+        # nodes) only governs producers running INSIDE a replayed decode graph.
+        # A prefill / mixed / oversize step runs eager -- producers fire ungated
+        # -- so meta-push + reserve must use the FULL active set that step, not
+        # the toggle subset, or they desync. This mirrors vLLM's own FULL-graph
+        # dispatch condition: a uniform-decode batch (every req scheduled exactly
+        # uniform_decode_query_len tokens) whose token count fits a captured
+        # size. Same private-attr risk surface as predict_padded_q_len.
+        self.transport._gated_step = self._step_uses_decode_graph(
+            model_runner, total_q, num_scheduled_per_req)
 
         # Per-request offsets and token ranges.
         computed_map: dict = {}

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -21,8 +21,8 @@ Key pieces:
     ``VLLMAdaptor`` and delegates per-step work to it.  Architecture
     remap (GPT2LMHeadModel -> GPT2PLMHeadModel etc.) stays here.
   * Module-level ``register_preset("vllm-full", ...)`` -- relocated
-    from ``monitoring/selection.py``'s default ``_HOOK_SELECTIONS``.
-    Lands as
+    from ``monitoring/selection.py``'s default ``_HOOK_SELECTIONS``
+    (deferred from Phase 1.5 per the unified-adaptor plan).  Lands as
     a side-effect of importing this module.
 
 """
@@ -66,7 +66,7 @@ from monitoring.internal_mapper import make_lazy_internal
 
 
 # ---------------------------------------------------------------------------
-# vLLM-full preset registration.
+# vLLM-full preset registration (deferred from Phase 1.5).
 #
 # Moved out of monitoring/selection.py's default _HOOK_SELECTIONS so the
 # core selection module is framework-neutral.  Registers when this
@@ -162,8 +162,8 @@ class VLLMAdaptor(BackendAdaptor):
         self._step_counter: int = 0
         # gpu_padding_strip mode: when True, the producer copies only
         # actual_q_len * row_bytes per eligible hook (instead of the
-        # full padded captured tensor).  Default False = no strip.
-        # When True, attach_model allocates the
+        # full padded captured tensor).  Default False = today's
+        # behavior verbatim.  When True, attach_model allocates the
         # shared row_count tensor pair and wires each eligible
         # HookPoint's _strip_tensor + _strip_row_bytes; build_step_context
         # populates ctx.actual_q_len; before_forward does the per-step

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -467,6 +467,87 @@ def _row_bytes_for_spec(spec, model_cfg) -> int:
 # ---------------------------------------------------------------------------
 # DMXGPUWorker
 # ---------------------------------------------------------------------------
+# Node-toggle (Phase 3b) helpers
+# ---------------------------------------------------------------------------
+
+# Phase 4 lazy per-graph toggle: when True, the keep_graph CUDAGraph.replay()
+# override applies the deferred toggle to the graph about to replay (and records
+# an event after). Set only when dmx_lazy_toggle is requested.
+_DMX_LAZY_REPLAY_HOOK = False
+_CUDAGRAPH_KEEP_PATCHED = False
+
+
+def _parse_enabled_hooks(s: Any):
+    """Parse 'hook_type:layer,hook_type:layer,...' -> [(ht, ln), ...]; '' -> None."""
+    if not s:
+        return None
+    out = []
+    for tok in str(s).split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        ht, _, ln = tok.partition(":")
+        out.append((int(ht), int(ln if ln != "" else -1)))
+    return out or None
+
+
+def _patch_cudagraph_keep_graph() -> None:
+    """Monkeypatch torch.cuda.CUDAGraph to default keep_graph=True.
+
+    vLLM's CUDAGraphWrapper creates ``torch.cuda.CUDAGraph()`` (keep_graph=False),
+    which frees the captured template graph after instantiate -> the node handles
+    DMI records via cudaStreamGetCaptureInfo would dangle. keep_graph=True keeps
+    the template alive (host memory only; no device/latency cost). Idempotent,
+    process-global; only applied when node-toggle is enabled.
+    """
+    global _CUDAGRAPH_KEEP_PATCHED
+    if _CUDAGRAPH_KEEP_PATCHED:
+        return
+    Orig = torch.cuda.CUDAGraph
+    if getattr(Orig, "_dmx_keep_graph", False):
+        _CUDAGRAPH_KEEP_PATCHED = True
+        return
+
+    class _KeepGraphCUDAGraph(Orig):
+        # Force keep_graph=True in BOTH __new__ and __init__: vLLM calls
+        # ``CUDAGraph()`` with no args, so __init__ (builtin) would otherwise
+        # reset keep_graph to its False default after __new__ set it. Subclass
+        # (not a factory) so isinstance(x, torch.cuda.CUDAGraph) still holds.
+        _dmx_keep_graph = True
+        _dmx_lazy_logged = False
+
+        def __new__(cls, *args, **kwargs):
+            kwargs["keep_graph"] = True
+            return Orig.__new__(cls, **kwargs)
+
+        def __init__(self, *args, **kwargs):
+            kwargs["keep_graph"] = True
+            super().__init__(**kwargs)
+
+        def replay(self):
+            # Phase 4 lazy: apply the deferred toggle to THIS graph just before
+            # it replays (and record an event after, so the next ensure waits for
+            # this replay before mutating the exec). Gated by _DMX_LAZY_REPLAY_HOOK
+            # and an active toggle gate; otherwise stock replay (the common case,
+            # incl. all eager-toggle and non-toggle runs).
+            if _DMX_LAZY_REPLAY_HOOK:
+                t = ring_transport.get_active()
+                if t is not None and getattr(t, "_toggle_gate_active", False):
+                    raw = self.raw_cuda_graph()
+                    t.ensure_graph_current(raw)   # apply deferred toggle if stale
+                    super().replay()
+                    t.record_replay_event(raw)    # event guard for the next ensure
+                    if not _KeepGraphCUDAGraph._dmx_lazy_logged:
+                        _KeepGraphCUDAGraph._dmx_lazy_logged = True
+                        print("[DMX] node-toggle: lazy replay hook active", flush=True)
+                    return
+            super().replay()
+
+    torch.cuda.CUDAGraph = _KeepGraphCUDAGraph
+    _CUDAGRAPH_KEEP_PATCHED = True
+
+
+# ---------------------------------------------------------------------------
 
 
 class DMXGPUWorker(Worker):
@@ -516,6 +597,16 @@ class DMXGPUWorker(Worker):
         ch_parallelism = int(
             _cfg(ac, "dmx_ch_parallelism", "DMX_CH_PARALLELISM", 10)
         )
+        # Runtime node-toggle (Phase 3b). Default off -> behaviour unchanged.
+        # dmx_enabled_hooks: optional static enabled set "hook_type:layer,..."
+        # applied once after warmup; empty -> toggle armed but gate inactive.
+        node_toggle = _cfg(ac, "dmx_node_toggle", "DMX_NODE_TOGGLE", False)
+        enabled_hooks_s = _cfg(ac, "dmx_enabled_hooks", "DMX_ENABLED_HOOKS", "")
+        # Phase 4 lazy per-graph toggle (defer device apply to per-graph replay).
+        lazy_toggle = _cfg(ac, "dmx_lazy_toggle", "DMX_LAZY_TOGGLE", False)
+        self._dmx_node_toggle = bool(node_toggle)
+        self._dmx_lazy_toggle = bool(lazy_toggle)
+        self._dmx_enabled_hooks = _parse_enabled_hooks(enabled_hooks_s)
 
         resolved_model_id = model_id or str(self.vllm_config.model_config.model)
 
@@ -572,6 +663,16 @@ class DMXGPUWorker(Worker):
         # DMX_GPU_PADDING_STRIP=0 if needed for debugging.
         gpu_padding_strip = _cfg(
             ac, "dmx_gpu_padding_strip", "DMX_GPU_PADDING_STRIP", True)
+        # Option B: node-toggle records nodes only from the BASIC producer op.
+        # gpu_padding_strip routes eligible hooks to producer_prefix instead,
+        # whose nodes are not toggle-recorded -> 0 bound nodes. Force strip off
+        # when toggle is on so every hook dispatches to the basic producer.
+        if self._dmx_node_toggle and gpu_padding_strip:
+            warnings.warn(
+                "[DMX] node-toggle: forcing gpu_padding_strip=False (toggle records "
+                "only basic-producer nodes; prefix/chunked producers are not "
+                "toggle-recorded). Set dmx_gpu_padding_strip=False to silence.")
+            gpu_padding_strip = False
         self.adaptor = VLLMAdaptor(
             engine, resolved_model_id, self.vllm_config,
             gpu_padding_strip=bool(gpu_padding_strip))
@@ -632,6 +733,16 @@ class DMXGPUWorker(Worker):
         )
 
     def compile_or_warm_up_model(self) -> float:
+        toggle = (getattr(self, "_dmx_node_toggle", False)
+                  and self.adaptor is not None
+                  and self.adaptor.ring_engine is not None)
+        if toggle:
+            # Scope node recording + keep_graph to the REAL capture that
+            # super() performs. Clear any stale registry first.
+            self.adaptor.ring_engine.clear_toggle_registry()
+            self.adaptor.ring_engine.enable_toggle_capture(True)
+            _patch_cudagraph_keep_graph()
+
         # Warmup runs with null_mode=True (set in init_device).
         # Producer kernels fire but are no-ops -- ring stays clean.
         result = super().compile_or_warm_up_model()
@@ -646,7 +757,80 @@ class DMXGPUWorker(Worker):
         ):
             self.adaptor.ring_engine.set_null_mode(False)
 
+        # Node-toggle: bind each captured graph's exec, close the capture window,
+        # and (optionally) apply the static enabled set. Done here -- after
+        # warmup, before serving -- so no replay is in flight.
+        if toggle:
+            eng = self.adaptor.ring_engine
+            n_bound = self._dmx_bind_captured_graphs()
+            eng.enable_toggle_capture(False)   # close the window (#1)
+            print(f"[DMX] node-toggle: bound {n_bound} captured graph(s), "
+                  f"{eng.toggle_node_count()} nodes registered")
+            if self._dmx_enabled_hooks is not None:
+                if n_bound == 0:
+                    # Requested a subset but nothing bound (e.g. cudagraph_mode not
+                    # FULL) -> refuse to serve silently with all hooks on (#2).
+                    raise RuntimeError(
+                        "dmx_node_toggle + dmx_enabled_hooks were set but no CUDA graph "
+                        "was bound (is cudagraph_mode FULL/FULL_AND_PIECEWISE for decode?). "
+                        "Refusing to serve with node-toggle silently inert.")
+                transport = self.adaptor.transport
+                if self._dmx_lazy_toggle:
+                    # Phase 4: arm the replay() hook; defer device apply to each
+                    # graph's first replay (lazy per-graph).
+                    global _DMX_LAZY_REPLAY_HOOK
+                    _DMX_LAZY_REPLAY_HOOK = True
+                    transport.set_active_hooks_lazy(self._dmx_enabled_hooks)
+                    print(f"[DMX] node-toggle: LAZY active hooks set to "
+                          f"{self._dmx_enabled_hooks}")
+                else:
+                    transport.set_active_hooks(self._dmx_enabled_hooks)
+                    print(f"[DMX] node-toggle: active hooks set to {self._dmx_enabled_hooks}")
+            elif n_bound == 0:
+                print("[DMX] node-toggle: WARNING no graph bound; toggle is inert "
+                      "(no dmx_enabled_hooks requested, so serving continues all-on).")
+
         return result
+
+    def _dmx_bind_captured_graphs(self) -> int:
+        """Find vLLM's captured CUDA graphs and bind each exec to the toggle
+        registry. Returns the number bound. FULL-cudagraph path only (decode);
+        the model is wrapped as CUDAGraphWrapper whose concrete_cudagraph_entries
+        hold one torch.cuda.CUDAGraph per batch size."""
+        try:
+            from vllm.compilation.cuda_graph import CUDAGraphWrapper
+        except Exception:
+            return 0
+        eng = self.adaptor.ring_engine
+        model = getattr(self.model_runner, "model", None)
+        n = 0
+        # Unwrap nested wrappers (UBatchWrapper etc.) to find CUDAGraphWrapper(s).
+        seen = set()
+        stack = [model]
+        while stack:
+            obj = stack.pop()
+            if id(obj) in seen or obj is None:
+                continue
+            seen.add(id(obj))
+            if isinstance(obj, CUDAGraphWrapper):
+                for entry in obj.concrete_cudagraph_entries.values():
+                    g = getattr(entry, "cudagraph", None)
+                    if g is None:
+                        continue
+                    # Don't re-instantiate if an exec already exists (that would
+                    # destroy it, #3). raw_cuda_graph_exec() raises until the graph
+                    # is instantiated -> instantiate exactly once in that case.
+                    try:
+                        exec_ptr = g.raw_cuda_graph_exec()
+                    except RuntimeError:
+                        g.instantiate()
+                        exec_ptr = g.raw_cuda_graph_exec()
+                    eng.bind_graph_exec(g.raw_cuda_graph(), exec_ptr)
+                    n += 1
+            inner = getattr(obj, "runnable", None)
+            if inner is not None:
+                stack.append(inner)
+        return n
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -735,10 +735,11 @@ class DMXGPUWorker(Worker):
         gpu_padding_strip = _cfg(
             ac, "dmx_gpu_padding_strip", "DMX_GPU_PADDING_STRIP", True)
         # Node-toggle composes with gpu_padding_strip for the basic + prefix
-        # producers (both record their kernel node at capture). Chunked/MoE
-        # producers are NOT toggle-managed yet: if any fire under capture,
-        # set_active_hooks fails loud -- run toggle on MoE with
-        # dmx_gpu_padding_strip=False (everything routes to the basic producer).
+        # producers (both record their kernel node at capture). The chunked
+        # producer is NOT toggle-managed (and is not dispatched by this adapter
+        # today -- dormant infra); if one ever fires under capture, set_active_hooks
+        # fails loud. dmx_gpu_padding_strip=False routes everything to the basic
+        # producer.
         self.adaptor = VLLMAdaptor(
             engine, resolved_model_id, self.vllm_config,
             gpu_padding_strip=bool(gpu_padding_strip))

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -63,6 +63,7 @@ from monitoring.step_context import StepContext
 from integration.model_shape import _make_model_shape_from_hf_config
 from monitoring.clickhouse_reader import CHClickhouseDriverReadOnly
 from monitoring.internal_mapper import make_lazy_internal
+from integration import vllm_node_toggle
 
 
 # ---------------------------------------------------------------------------
@@ -467,142 +468,8 @@ def _row_bytes_for_spec(spec, model_cfg) -> int:
 # ---------------------------------------------------------------------------
 # DMXGPUWorker
 # ---------------------------------------------------------------------------
-# Node-toggle helpers
-# ---------------------------------------------------------------------------
-
-# Armed (True) whenever a node-toggle gate is active (eager OR lazy). The
-# keep_graph CUDAGraph.replay() override then runs the replay-time graph guard:
-#   - validate the graph is registered+bound (else a runtime-captured graph
-#     would replay with default-ON producers while the meta gate filters ->
-#     desync); FATAL if not.
-#   - lazy mode only: apply the deferred toggle (ensure_graph_current) and check
-#     its result; eager mode: validation only (apply happened at config
-#     time -- read-only, per the eager/lazy separation).
-_DMX_TOGGLE_REPLAY_GUARD = False
-_CUDAGRAPH_KEEP_PATCHED = False
-
-
-def _parse_enabled_hooks(s: Any):
-    """Parse the dmx_enabled_hooks config into an enabled (ht, layer) list.
-
-    Three distinct meanings (no overloading of the empty string, no
-    nonexistent-hook hack):
-      - not provided / "" -> None  : toggle gate INACTIVE (all hooks fire)
-      - "none"            -> []    : explicit EMPTY set -> toggle-0 (all off)
-      - "0:1,0:2"         -> [(0,1),(0,2)] : that specific set
-
-    layer omitted ("14") -> layer_no -1 (global hook).
-    """
-    if s is None:
-        return None
-    s = str(s).strip()
-    if s == "":
-        return None                 # unconfigured -> gate inactive
-    if s.lower() == "none":
-        return []                   # explicit all-off
-    out = []
-    for tok in s.split(","):
-        tok = tok.strip()
-        if not tok:
-            continue
-        ht, _, ln = tok.partition(":")
-        out.append((int(ht), int(ln if ln != "" else -1)))
-    return out or None
-
-
-def _patch_cudagraph_keep_graph() -> None:
-    """Monkeypatch torch.cuda.CUDAGraph to default keep_graph=True.
-
-    vLLM's CUDAGraphWrapper creates ``torch.cuda.CUDAGraph()`` (keep_graph=False),
-    which frees the captured template graph after instantiate -> the node handles
-    DMI records via cudaStreamGetCaptureInfo would dangle. keep_graph=True keeps
-    the template alive (host memory only; no device/latency cost). Idempotent,
-    process-global; only applied when node-toggle is enabled.
-    """
-    global _CUDAGRAPH_KEEP_PATCHED
-    if _CUDAGRAPH_KEEP_PATCHED:
-        return
-    Orig = torch.cuda.CUDAGraph
-    if getattr(Orig, "_dmx_keep_graph", False):
-        _CUDAGRAPH_KEEP_PATCHED = True
-        return
-
-    class _KeepGraphCUDAGraph(Orig):
-        # Force keep_graph=True in BOTH __new__ and __init__: vLLM calls
-        # ``CUDAGraph()`` with no args, so __init__ (builtin) would otherwise
-        # reset keep_graph to its False default after __new__ set it. Subclass
-        # (not a factory) so isinstance(x, torch.cuda.CUDAGraph) still holds.
-        _dmx_keep_graph = True
-        _dmx_lazy_logged = False
-
-        def __new__(cls, *args, **kwargs):
-            kwargs["keep_graph"] = True
-            return Orig.__new__(cls, **kwargs)
-
-        def __init__(self, *args, **kwargs):
-            kwargs["keep_graph"] = True
-            super().__init__(**kwargs)
-
-        def replay(self):
-            # Replay-time node-toggle guard (eager + lazy). Armed by
-            # _DMX_TOGGLE_REPLAY_GUARD when a gate is active; otherwise stock
-            # replay (the common case, incl. all non-toggle runs).
-            if _DMX_TOGGLE_REPLAY_GUARD:
-                t = ring_transport.get_active()
-                if t is not None and getattr(t, "_toggle_gate_active", False):
-                    raw = self.raw_cuda_graph()
-                    # The graph about to replay MUST be a registered+bound
-                    # toggle graph. A graph vLLM captured at RUNTIME (new
-                    # batch_descriptor, after the warmup capture window closed)
-                    # has no recorded producer nodes and no bound exec -> its
-                    # producers run default-ON while the meta gate pushes only the
-                    # enabled subset -> desync. before_forward already pushed this
-                    # step's metas, so this is FATAL and unrecoverable: raise and
-                    # let the worker die. Read-only validation (eager + lazy).
-                    if not t.is_graph_ready(raw):
-                        raise RuntimeError(
-                            f"[DMX] node-toggle FATAL: graph {raw:#x} is about to replay "
-                            f"but is NOT registered+bound in the toggle registry -- it was "
-                            f"almost certainly captured by vLLM at RUNTIME after DMI closed "
-                            f"its capture window at warmup. Its producers run all-ON while "
-                            f"the meta gate filters to the enabled subset, which desyncs the "
-                            f"ring. The worker MUST terminate; do NOT catch and continue. "
-                            f"(Fix: ensure all decode batch_descriptors are captured during "
-                            f"warmup, or add runtime graph registration.)")
-                    if getattr(t, "_lazy_active", False):
-                        # Lazy: apply the deferred toggle now; a nonzero
-                        # result is FATAL (metas already pushed for the new set).
-                        err = t.ensure_graph_current(raw)
-                        if err != 0:
-                            raise RuntimeError(
-                                f"[DMX] node-toggle FATAL: lazy apply (ensure_graph_current) "
-                                f"failed with CUDA error {err} for graph {raw:#x}. The meta "
-                                f"gate already advanced this step, so replaying would desync "
-                                f"the ring irrecoverably. The worker MUST terminate; do NOT "
-                                f"catch and continue serving.")
-                        super().replay()
-                        # Record the replay event; if recording fails the
-                        # next ensure could mutate an executing exec (UB) -> FATAL.
-                        rerr = t.record_replay_event(raw)
-                        if rerr != 0:
-                            raise RuntimeError(
-                                f"[DMX] node-toggle FATAL: record_replay_event failed with "
-                                f"CUDA error {rerr} for graph {raw:#x}. Without a valid replay "
-                                f"event the next lazy reconfigure could mutate a still-executing "
-                                f"graph exec (UB). The worker MUST terminate.")
-                    else:
-                        # eager: device apply happened at config time; here we
-                        # only validated the graph is bound (read-only).
-                        super().replay()
-                    if not _KeepGraphCUDAGraph._dmx_lazy_logged:
-                        _KeepGraphCUDAGraph._dmx_lazy_logged = True
-                        _mode = "lazy" if getattr(t, "_lazy_active", False) else "eager"
-                        print(f"[DMX] node-toggle: replay guard active (mode={_mode})", flush=True)
-                    return
-            super().replay()
-
-    torch.cuda.CUDAGraph = _KeepGraphCUDAGraph
-    _CUDAGRAPH_KEEP_PATCHED = True
+# Node-toggle wiring (keep_graph patch, replay guard, config parser,
+# bind walker, post-warmup activation) lives in vllm_node_toggle.
 
 
 # ---------------------------------------------------------------------------
@@ -664,7 +531,7 @@ class DMXGPUWorker(Worker):
         lazy_toggle = _cfg(ac, "dmx_lazy_toggle", "DMX_LAZY_TOGGLE", False)
         self._dmx_node_toggle = bool(node_toggle)
         self._dmx_lazy_toggle = bool(lazy_toggle)
-        self._dmx_enabled_hooks = _parse_enabled_hooks(enabled_hooks_s)
+        self._dmx_enabled_hooks = vllm_node_toggle._parse_enabled_hooks(enabled_hooks_s)
 
         resolved_model_id = model_id or str(self.vllm_config.model_config.model)
 
@@ -804,10 +671,8 @@ class DMXGPUWorker(Worker):
                   and self.adaptor.ring_engine is not None)
         if toggle:
             # Scope node recording + keep_graph to the REAL capture that
-            # super() performs. Clear any stale registry first.
-            self.adaptor.ring_engine.clear_toggle_registry()
-            self.adaptor.ring_engine.enable_toggle_capture(True)
-            _patch_cudagraph_keep_graph()
+            # super() performs.
+            vllm_node_toggle.begin_capture_window(self.adaptor.ring_engine)
 
         # Warmup runs with null_mode=True (set in init_device).
         # Producer kernels fire but are no-ops -- ring stays clean.
@@ -827,95 +692,15 @@ class DMXGPUWorker(Worker):
         # and (optionally) apply the static enabled set. Done here -- after
         # warmup, before serving -- so no replay is in flight.
         if toggle:
-            eng = self.adaptor.ring_engine
-            n_bound = self._dmx_bind_captured_graphs()
-            eng.enable_toggle_capture(False)   # close the window
-            print(f"[DMX] node-toggle: bound {n_bound} captured graph(s), "
-                  f"{eng.toggle_node_count()} nodes registered")
-            if self._dmx_enabled_hooks is not None:
-                if n_bound == 0:
-                    # Requested a subset but nothing bound (e.g. cudagraph_mode not
-                    # FULL) -> refuse to serve silently with all hooks on.
-                    raise RuntimeError(
-                        "dmx_node_toggle + dmx_enabled_hooks were set but no CUDA graph "
-                        "was bound. Node-toggle requires cudagraph_mode=FULL for decode "
-                        "(one full-model graph per batch size). PIECEWISE graphs hold only "
-                        "a model SUBSET, so different graphs capture different hook subsets "
-                        "and would fail the uniform-hook-set requirement -- use FULL. "
-                        "Refusing to serve with node-toggle silently inert.")
-                transport = self.adaptor.transport
-                # Arm the replay-time guard for BOTH modes: eager needs the
-                # runtime-graph validation too, not just lazy.
-                global _DMX_TOGGLE_REPLAY_GUARD
-                _DMX_TOGGLE_REPLAY_GUARD = True
-                if self._dmx_lazy_toggle:
-                    # Lazy: defer device apply to each graph's first replay.
-                    transport.set_active_hooks_lazy(self._dmx_enabled_hooks)
-                    print(f"[DMX] node-toggle: LAZY active hooks set to "
-                          f"{self._dmx_enabled_hooks}")
-                else:
-                    transport.set_active_hooks(self._dmx_enabled_hooks)
-                    print(f"[DMX] node-toggle: active hooks set to {self._dmx_enabled_hooks}")
-            elif n_bound == 0:
-                print("[DMX] node-toggle: WARNING no graph bound; toggle is inert "
-                      "(no dmx_enabled_hooks requested, so serving continues all-on).")
+            vllm_node_toggle.activate_after_warmup(
+                getattr(self.model_runner, "model", None),
+                self.adaptor.ring_engine,
+                self.adaptor.transport,
+                self._dmx_enabled_hooks,
+                lazy=self._dmx_lazy_toggle,
+            )
 
         return result
-
-    def _dmx_bind_captured_graphs(self) -> int:
-        """Find vLLM's captured CUDA graphs and bind each exec to the toggle
-        registry. Returns the number bound. FULL-cudagraph path only (decode);
-        the model is wrapped as CUDAGraphWrapper whose concrete_cudagraph_entries
-        hold one torch.cuda.CUDAGraph per batch size."""
-        try:
-            from vllm.compilation.cuda_graph import CUDAGraphWrapper
-        except Exception:
-            return 0
-        eng = self.adaptor.ring_engine
-        model = getattr(self.model_runner, "model", None)
-        n = 0
-        # Unwrap nested wrappers (UBatchWrapper etc.) to find CUDAGraphWrapper(s).
-        seen = set()
-        stack = [model]
-        while stack:
-            obj = stack.pop()
-            if id(obj) in seen or obj is None:
-                continue
-            seen.add(id(obj))
-            if isinstance(obj, CUDAGraphWrapper):
-                for entry in obj.concrete_cudagraph_entries.values():
-                    g = getattr(entry, "cudagraph", None)
-                    if g is None:
-                        continue
-                    # A graph not created by the keep_graph patch means vLLM
-                    # resolved torch.cuda.CUDAGraph before (or without) the
-                    # patch -- its template is freed on instantiate, so the
-                    # capture-recorded node handles dangle and SetEnabled on
-                    # them is UB. Refuse before any handle is touched.
-                    if not getattr(type(g), "_dmx_keep_graph", False):
-                        raise RuntimeError(
-                            "[DMX] node-toggle FATAL: a captured CUDA graph was "
-                            "created from the UNPATCHED torch.cuda.CUDAGraph "
-                            "(keep_graph=False), so its template graph is already "
-                            "freed and the recorded producer-node handles dangle. "
-                            "vLLM likely binds the CUDAGraph class at import time "
-                            "in this version, bypassing _patch_cudagraph_keep_graph. "
-                            "Refusing to bind; fix the patch injection point before "
-                            "serving with node-toggle.")
-                    # Don't re-instantiate if an exec already exists (that would
-                    # destroy it). raw_cuda_graph_exec() raises until the graph
-                    # is instantiated -> instantiate exactly once in that case.
-                    try:
-                        exec_ptr = g.raw_cuda_graph_exec()
-                    except RuntimeError:
-                        g.instantiate()
-                        exec_ptr = g.raw_cuda_graph_exec()
-                    eng.bind_graph_exec(g.raw_cuda_graph(), exec_ptr)
-                    n += 1
-            inner = getattr(obj, "runnable", None)
-            if inner is not None:
-                stack.append(inner)
-        return n
 
     @torch.inference_mode()
     def execute_model(self, scheduler_output: Any) -> Any:

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -483,11 +483,25 @@ _CUDAGRAPH_KEEP_PATCHED = False
 
 
 def _parse_enabled_hooks(s: Any):
-    """Parse 'hook_type:layer,hook_type:layer,...' -> [(ht, ln), ...]; '' -> None."""
-    if not s:
+    """Parse the dmx_enabled_hooks config into an enabled (ht, layer) list.
+
+    Three distinct meanings (#5 -- no overloading of the empty string, no
+    nonexistent-hook hack):
+      - not provided / "" -> None  : toggle gate INACTIVE (all hooks fire)
+      - "none"            -> []    : explicit EMPTY set -> toggle-0 (all off)
+      - "0:1,0:2"         -> [(0,1),(0,2)] : that specific set
+
+    layer omitted ("14") -> layer_no -1 (global hook).
+    """
+    if s is None:
         return None
+    s = str(s).strip()
+    if s == "":
+        return None                 # unconfigured -> gate inactive
+    if s.lower() == "none":
+        return []                   # explicit all-off
     out = []
-    for tok in str(s).split(","):
+    for tok in s.split(","):
         tok = tok.strip()
         if not tok:
             continue

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -534,7 +534,20 @@ def _patch_cudagraph_keep_graph() -> None:
                 t = ring_transport.get_active()
                 if t is not None and getattr(t, "_toggle_gate_active", False):
                     raw = self.raw_cuda_graph()
-                    t.ensure_graph_current(raw)   # apply deferred toggle if stale
+                    # (#1) The deferred device apply MUST succeed before replay:
+                    # before_forward already pushed this step's metas for the new
+                    # enabled set, so replaying with a stale/partial node state
+                    # would put payloads and metas out of lockstep -> desync. A
+                    # nonzero result is a FATAL, unrecoverable error (the FIFO is
+                    # already dirty for this step) -> raise and let the worker die.
+                    err = t.ensure_graph_current(raw)
+                    if err != 0:
+                        raise RuntimeError(
+                            f"[DMX] node-toggle FATAL: lazy apply (ensure_graph_current) "
+                            f"failed with CUDA error {err} for graph {raw:#x}. The meta "
+                            f"gate already advanced to the new enabled set this step, so "
+                            f"replaying now would desync the ring irrecoverably. The "
+                            f"worker MUST terminate; do NOT catch this and continue serving.")
                     super().replay()
                     t.record_replay_event(raw)    # event guard for the next ensure
                     if not _KeepGraphCUDAGraph._dmx_lazy_logged:

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -581,7 +581,15 @@ def _patch_cudagraph_keep_graph() -> None:
                                 f"the ring irrecoverably. The worker MUST terminate; do NOT "
                                 f"catch and continue serving.")
                         super().replay()
-                        t.record_replay_event(raw)   # event guard for the next ensure
+                        # (#1) Record the replay event; if recording fails the
+                        # next ensure could mutate an executing exec (UB) -> FATAL.
+                        rerr = t.record_replay_event(raw)
+                        if rerr != 0:
+                            raise RuntimeError(
+                                f"[DMX] node-toggle FATAL: record_replay_event failed with "
+                                f"CUDA error {rerr} for graph {raw:#x}. Without a valid replay "
+                                f"event the next lazy reconfigure could mutate a still-executing "
+                                f"graph exec (UB). The worker MUST terminate.")
                     else:
                         # eager: device apply happened at config time; here we
                         # only validated the graph is bound (read-only).
@@ -822,7 +830,10 @@ class DMXGPUWorker(Worker):
                     # FULL) -> refuse to serve silently with all hooks on (#2).
                     raise RuntimeError(
                         "dmx_node_toggle + dmx_enabled_hooks were set but no CUDA graph "
-                        "was bound (is cudagraph_mode FULL/FULL_AND_PIECEWISE for decode?). "
+                        "was bound. Node-toggle requires cudagraph_mode=FULL for decode "
+                        "(one full-model graph per batch size). PIECEWISE graphs hold only "
+                        "a model SUBSET, so different graphs capture different hook subsets "
+                        "and would fail the uniform-hook-set requirement -- use FULL. "
                         "Refusing to serve with node-toggle silently inert.")
                 transport = self.adaptor.transport
                 # Arm the replay-time guard for BOTH modes (#3): eager needs the

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -470,10 +470,15 @@ def _row_bytes_for_spec(spec, model_cfg) -> int:
 # Node-toggle (Phase 3b) helpers
 # ---------------------------------------------------------------------------
 
-# Phase 4 lazy per-graph toggle: when True, the keep_graph CUDAGraph.replay()
-# override applies the deferred toggle to the graph about to replay (and records
-# an event after). Set only when dmx_lazy_toggle is requested.
-_DMX_LAZY_REPLAY_HOOK = False
+# Armed (True) whenever a node-toggle gate is active (eager OR lazy). The
+# keep_graph CUDAGraph.replay() override then runs the replay-time graph guard:
+#   - validate the graph is registered+bound (else a runtime-captured graph
+#     would replay with default-ON producers while the meta gate filters ->
+#     desync); FATAL if not (#3).
+#   - lazy mode only: apply the deferred toggle (ensure_graph_current) and check
+#     its result (#1); eager mode: validation only (apply happened at config
+#     time -- read-only, per the eager/lazy separation).
+_DMX_TOGGLE_REPLAY_GUARD = False
 _CUDAGRAPH_KEEP_PATCHED = False
 
 
@@ -525,34 +530,52 @@ def _patch_cudagraph_keep_graph() -> None:
             super().__init__(**kwargs)
 
         def replay(self):
-            # Phase 4 lazy: apply the deferred toggle to THIS graph just before
-            # it replays (and record an event after, so the next ensure waits for
-            # this replay before mutating the exec). Gated by _DMX_LAZY_REPLAY_HOOK
-            # and an active toggle gate; otherwise stock replay (the common case,
-            # incl. all eager-toggle and non-toggle runs).
-            if _DMX_LAZY_REPLAY_HOOK:
+            # Replay-time node-toggle guard (eager + lazy). Armed by
+            # _DMX_TOGGLE_REPLAY_GUARD when a gate is active; otherwise stock
+            # replay (the common case, incl. all non-toggle runs).
+            if _DMX_TOGGLE_REPLAY_GUARD:
                 t = ring_transport.get_active()
                 if t is not None and getattr(t, "_toggle_gate_active", False):
                     raw = self.raw_cuda_graph()
-                    # (#1) The deferred device apply MUST succeed before replay:
-                    # before_forward already pushed this step's metas for the new
-                    # enabled set, so replaying with a stale/partial node state
-                    # would put payloads and metas out of lockstep -> desync. A
-                    # nonzero result is a FATAL, unrecoverable error (the FIFO is
-                    # already dirty for this step) -> raise and let the worker die.
-                    err = t.ensure_graph_current(raw)
-                    if err != 0:
+                    # (#3) The graph about to replay MUST be a registered+bound
+                    # toggle graph. A graph vLLM captured at RUNTIME (new
+                    # batch_descriptor, after the warmup capture window closed)
+                    # has no recorded producer nodes and no bound exec -> its
+                    # producers run default-ON while the meta gate pushes only the
+                    # enabled subset -> desync. before_forward already pushed this
+                    # step's metas, so this is FATAL and unrecoverable: raise and
+                    # let the worker die. Read-only validation (eager + lazy).
+                    if not t.is_graph_ready(raw):
                         raise RuntimeError(
-                            f"[DMX] node-toggle FATAL: lazy apply (ensure_graph_current) "
-                            f"failed with CUDA error {err} for graph {raw:#x}. The meta "
-                            f"gate already advanced to the new enabled set this step, so "
-                            f"replaying now would desync the ring irrecoverably. The "
-                            f"worker MUST terminate; do NOT catch this and continue serving.")
-                    super().replay()
-                    t.record_replay_event(raw)    # event guard for the next ensure
+                            f"[DMX] node-toggle FATAL: graph {raw:#x} is about to replay "
+                            f"but is NOT registered+bound in the toggle registry -- it was "
+                            f"almost certainly captured by vLLM at RUNTIME after DMI closed "
+                            f"its capture window at warmup. Its producers run all-ON while "
+                            f"the meta gate filters to the enabled subset, which desyncs the "
+                            f"ring. The worker MUST terminate; do NOT catch and continue. "
+                            f"(Fix: ensure all decode batch_descriptors are captured during "
+                            f"warmup, or add runtime graph registration.)")
+                    if getattr(t, "_lazy_active", False):
+                        # (#1) lazy: apply the deferred toggle now; a nonzero
+                        # result is FATAL (metas already pushed for the new set).
+                        err = t.ensure_graph_current(raw)
+                        if err != 0:
+                            raise RuntimeError(
+                                f"[DMX] node-toggle FATAL: lazy apply (ensure_graph_current) "
+                                f"failed with CUDA error {err} for graph {raw:#x}. The meta "
+                                f"gate already advanced this step, so replaying would desync "
+                                f"the ring irrecoverably. The worker MUST terminate; do NOT "
+                                f"catch and continue serving.")
+                        super().replay()
+                        t.record_replay_event(raw)   # event guard for the next ensure
+                    else:
+                        # eager: device apply happened at config time; here we
+                        # only validated the graph is bound (read-only).
+                        super().replay()
                     if not _KeepGraphCUDAGraph._dmx_lazy_logged:
                         _KeepGraphCUDAGraph._dmx_lazy_logged = True
-                        print("[DMX] node-toggle: lazy replay hook active", flush=True)
+                        _mode = "lazy" if getattr(t, "_lazy_active", False) else "eager"
+                        print(f"[DMX] node-toggle: replay guard active (mode={_mode})", flush=True)
                     return
             super().replay()
 
@@ -788,11 +811,12 @@ class DMXGPUWorker(Worker):
                         "was bound (is cudagraph_mode FULL/FULL_AND_PIECEWISE for decode?). "
                         "Refusing to serve with node-toggle silently inert.")
                 transport = self.adaptor.transport
+                # Arm the replay-time guard for BOTH modes (#3): eager needs the
+                # runtime-graph validation too, not just lazy.
+                global _DMX_TOGGLE_REPLAY_GUARD
+                _DMX_TOGGLE_REPLAY_GUARD = True
                 if self._dmx_lazy_toggle:
-                    # Phase 4: arm the replay() hook; defer device apply to each
-                    # graph's first replay (lazy per-graph).
-                    global _DMX_LAZY_REPLAY_HOOK
-                    _DMX_LAZY_REPLAY_HOOK = True
+                    # Phase 4: defer device apply to each graph's first replay.
                     transport.set_active_hooks_lazy(self._dmx_enabled_hooks)
                     print(f"[DMX] node-toggle: LAZY active hooks set to "
                           f"{self._dmx_enabled_hooks}")

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -701,9 +701,15 @@ class DMXGPUWorker(Worker):
         # waits on byte/entry thresholds that sparse steps never hit, so data
         # sits in the ring until the buffer fills or a final flush-on-close. A
         # nonzero timeout forces the drain to flush pending entries after that
-        # idle window. 0 (default) = threshold-only (legacy behaviour).
+        # idle window.
+        # Default: 50 ms when node-toggle is ON (sparse by design -- matches the
+        # original toggle branch's default so partial-toggle users get prompt
+        # export without manual tuning); 0 (threshold-only, legacy) otherwise, to
+        # preserve main's non-toggle behaviour. Override via dmx_drain_flush_timeout_us.
+        _default_flush_us = 50000 if node_toggle else 0
         ring_cfg.drain_flush_timeout_us = int(_cfg(
-            ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US", 0))
+            ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US",
+            _default_flush_us))
         ring_cfg.insert_queue_max_bytes = int(_cfg(
             ac, "dmx_insert_queue_max_bytes", "DMX_INSERT_QUEUE_MAX_BYTES",
             4096 * 1024 * 1024))

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -21,8 +21,8 @@ Key pieces:
     ``VLLMAdaptor`` and delegates per-step work to it.  Architecture
     remap (GPT2LMHeadModel -> GPT2PLMHeadModel etc.) stays here.
   * Module-level ``register_preset("vllm-full", ...)`` -- relocated
-    from ``monitoring/selection.py``'s default ``_HOOK_SELECTIONS``
-    (deferred from Phase 1.5 per the unified-adaptor plan).  Lands as
+    from ``monitoring/selection.py``'s default ``_HOOK_SELECTIONS``.
+    Lands as
     a side-effect of importing this module.
 
 """
@@ -66,7 +66,7 @@ from monitoring.internal_mapper import make_lazy_internal
 
 
 # ---------------------------------------------------------------------------
-# vLLM-full preset registration (deferred from Phase 1.5).
+# vLLM-full preset registration.
 #
 # Moved out of monitoring/selection.py's default _HOOK_SELECTIONS so the
 # core selection module is framework-neutral.  Registers when this
@@ -162,8 +162,8 @@ class VLLMAdaptor(BackendAdaptor):
         self._step_counter: int = 0
         # gpu_padding_strip mode: when True, the producer copies only
         # actual_q_len * row_bytes per eligible hook (instead of the
-        # full padded captured tensor).  Default False = today's
-        # behavior verbatim.  When True, attach_model allocates the
+        # full padded captured tensor).  Default False = no strip.
+        # When True, attach_model allocates the
         # shared row_count tensor pair and wires each eligible
         # HookPoint's _strip_tensor + _strip_row_bytes; build_step_context
         # populates ctx.actual_q_len; before_forward does the per-step
@@ -467,16 +467,16 @@ def _row_bytes_for_spec(spec, model_cfg) -> int:
 # ---------------------------------------------------------------------------
 # DMXGPUWorker
 # ---------------------------------------------------------------------------
-# Node-toggle (Phase 3b) helpers
+# Node-toggle helpers
 # ---------------------------------------------------------------------------
 
 # Armed (True) whenever a node-toggle gate is active (eager OR lazy). The
 # keep_graph CUDAGraph.replay() override then runs the replay-time graph guard:
 #   - validate the graph is registered+bound (else a runtime-captured graph
 #     would replay with default-ON producers while the meta gate filters ->
-#     desync); FATAL if not (#3).
+#     desync); FATAL if not.
 #   - lazy mode only: apply the deferred toggle (ensure_graph_current) and check
-#     its result (#1); eager mode: validation only (apply happened at config
+#     its result; eager mode: validation only (apply happened at config
 #     time -- read-only, per the eager/lazy separation).
 _DMX_TOGGLE_REPLAY_GUARD = False
 _CUDAGRAPH_KEEP_PATCHED = False
@@ -485,7 +485,7 @@ _CUDAGRAPH_KEEP_PATCHED = False
 def _parse_enabled_hooks(s: Any):
     """Parse the dmx_enabled_hooks config into an enabled (ht, layer) list.
 
-    Three distinct meanings (#5 -- no overloading of the empty string, no
+    Three distinct meanings (no overloading of the empty string, no
     nonexistent-hook hack):
       - not provided / "" -> None  : toggle gate INACTIVE (all hooks fire)
       - "none"            -> []    : explicit EMPTY set -> toggle-0 (all off)
@@ -551,7 +551,7 @@ def _patch_cudagraph_keep_graph() -> None:
                 t = ring_transport.get_active()
                 if t is not None and getattr(t, "_toggle_gate_active", False):
                     raw = self.raw_cuda_graph()
-                    # (#3) The graph about to replay MUST be a registered+bound
+                    # The graph about to replay MUST be a registered+bound
                     # toggle graph. A graph vLLM captured at RUNTIME (new
                     # batch_descriptor, after the warmup capture window closed)
                     # has no recorded producer nodes and no bound exec -> its
@@ -570,7 +570,7 @@ def _patch_cudagraph_keep_graph() -> None:
                             f"(Fix: ensure all decode batch_descriptors are captured during "
                             f"warmup, or add runtime graph registration.)")
                     if getattr(t, "_lazy_active", False):
-                        # (#1) lazy: apply the deferred toggle now; a nonzero
+                        # Lazy: apply the deferred toggle now; a nonzero
                         # result is FATAL (metas already pushed for the new set).
                         err = t.ensure_graph_current(raw)
                         if err != 0:
@@ -581,7 +581,7 @@ def _patch_cudagraph_keep_graph() -> None:
                                 f"the ring irrecoverably. The worker MUST terminate; do NOT "
                                 f"catch and continue serving.")
                         super().replay()
-                        # (#1) Record the replay event; if recording fails the
+                        # Record the replay event; if recording fails the
                         # next ensure could mutate an executing exec (UB) -> FATAL.
                         rerr = t.record_replay_event(raw)
                         if rerr != 0:
@@ -655,12 +655,12 @@ class DMXGPUWorker(Worker):
         ch_parallelism = int(
             _cfg(ac, "dmx_ch_parallelism", "DMX_CH_PARALLELISM", 10)
         )
-        # Runtime node-toggle (Phase 3b). Default off -> behaviour unchanged.
+        # Runtime node-toggle. Default off -> behaviour unchanged.
         # dmx_enabled_hooks: optional static enabled set "hook_type:layer,..."
         # applied once after warmup; empty -> toggle armed but gate inactive.
         node_toggle = _cfg(ac, "dmx_node_toggle", "DMX_NODE_TOGGLE", False)
         enabled_hooks_s = _cfg(ac, "dmx_enabled_hooks", "DMX_ENABLED_HOOKS", "")
-        # Phase 4 lazy per-graph toggle (defer device apply to per-graph replay).
+        # Lazy per-graph toggle (defer device apply to per-graph replay).
         lazy_toggle = _cfg(ac, "dmx_lazy_toggle", "DMX_LAZY_TOGGLE", False)
         self._dmx_node_toggle = bool(node_toggle)
         self._dmx_lazy_toggle = bool(lazy_toggle)
@@ -702,10 +702,9 @@ class DMXGPUWorker(Worker):
         # sits in the ring until the buffer fills or a final flush-on-close. A
         # nonzero timeout forces the drain to flush pending entries after that
         # idle window.
-        # Default: 50 ms when node-toggle is ON (sparse by design -- matches the
-        # original toggle branch's default so partial-toggle users get prompt
-        # export without manual tuning); 0 (threshold-only, legacy) otherwise, to
-        # preserve main's non-toggle behaviour. Override via dmx_drain_flush_timeout_us.
+        # Default: 50 ms when node-toggle is ON (sparse by design, so partial
+        # toggle exports promptly without manual tuning); 0 (threshold-only)
+        # otherwise. Override via dmx_drain_flush_timeout_us.
         _default_flush_us = 50000 if node_toggle else 0
         ring_cfg.drain_flush_timeout_us = int(_cfg(
             ac, "dmx_drain_flush_timeout_us", "DMX_DRAIN_FLUSH_TIMEOUT_US",
@@ -835,13 +834,13 @@ class DMXGPUWorker(Worker):
         if toggle:
             eng = self.adaptor.ring_engine
             n_bound = self._dmx_bind_captured_graphs()
-            eng.enable_toggle_capture(False)   # close the window (#1)
+            eng.enable_toggle_capture(False)   # close the window
             print(f"[DMX] node-toggle: bound {n_bound} captured graph(s), "
                   f"{eng.toggle_node_count()} nodes registered")
             if self._dmx_enabled_hooks is not None:
                 if n_bound == 0:
                     # Requested a subset but nothing bound (e.g. cudagraph_mode not
-                    # FULL) -> refuse to serve silently with all hooks on (#2).
+                    # FULL) -> refuse to serve silently with all hooks on.
                     raise RuntimeError(
                         "dmx_node_toggle + dmx_enabled_hooks were set but no CUDA graph "
                         "was bound. Node-toggle requires cudagraph_mode=FULL for decode "
@@ -850,12 +849,12 @@ class DMXGPUWorker(Worker):
                         "and would fail the uniform-hook-set requirement -- use FULL. "
                         "Refusing to serve with node-toggle silently inert.")
                 transport = self.adaptor.transport
-                # Arm the replay-time guard for BOTH modes (#3): eager needs the
+                # Arm the replay-time guard for BOTH modes: eager needs the
                 # runtime-graph validation too, not just lazy.
                 global _DMX_TOGGLE_REPLAY_GUARD
                 _DMX_TOGGLE_REPLAY_GUARD = True
                 if self._dmx_lazy_toggle:
-                    # Phase 4: defer device apply to each graph's first replay.
+                    # Lazy: defer device apply to each graph's first replay.
                     transport.set_active_hooks_lazy(self._dmx_enabled_hooks)
                     print(f"[DMX] node-toggle: LAZY active hooks set to "
                           f"{self._dmx_enabled_hooks}")
@@ -894,7 +893,7 @@ class DMXGPUWorker(Worker):
                     if g is None:
                         continue
                     # Don't re-instantiate if an exec already exists (that would
-                    # destroy it, #3). raw_cuda_graph_exec() raises until the graph
+                    # destroy it). raw_cuda_graph_exec() raises until the graph
                     # is instantiated -> instantiate exactly once in that case.
                     try:
                         exec_ptr = g.raw_cuda_graph_exec()

--- a/integration/vllm_node_toggle.py
+++ b/integration/vllm_node_toggle.py
@@ -1,0 +1,253 @@
+"""vLLM-side wiring for runtime node-toggle (low-overhead hook configurability).
+
+Everything node-toggle needs from the vLLM integration lives here, so
+``vllm_adapter`` keeps only config reads and two call sites behind the
+``dmx_node_toggle`` flag:
+
+  - the ``keep_graph`` CUDAGraph patch + the replay-time graph guard,
+  - the ``dmx_enabled_hooks`` config parser,
+  - the captured-graph bind walker,
+  - the post-warmup static activation.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from monitoring import ring_transport
+
+# Armed (True) whenever a node-toggle gate is active (eager OR lazy). The
+# keep_graph CUDAGraph.replay() override then runs the replay-time graph guard:
+#   - validate the graph is registered+bound (else a runtime-captured graph
+#     would replay with default-ON producers while the meta gate filters ->
+#     desync); FATAL if not.
+#   - lazy mode only: apply the deferred toggle (ensure_graph_current) and check
+#     its result; eager mode: validation only (apply happened at config
+#     time -- read-only, per the eager/lazy separation).
+_DMX_TOGGLE_REPLAY_GUARD = False
+_CUDAGRAPH_KEEP_PATCHED = False
+
+
+def set_replay_guard(on: bool) -> None:
+    global _DMX_TOGGLE_REPLAY_GUARD
+    _DMX_TOGGLE_REPLAY_GUARD = bool(on)
+
+
+def _parse_enabled_hooks(s: Any):
+    """Parse the dmx_enabled_hooks config into an enabled (ht, layer) list.
+
+    Three distinct meanings (no overloading of the empty string, no
+    nonexistent-hook hack):
+      - not provided / "" -> None  : toggle gate INACTIVE (all hooks fire)
+      - "none"            -> []    : explicit EMPTY set -> toggle-0 (all off)
+      - "0:1,0:2"         -> [(0,1),(0,2)] : that specific set
+
+    layer omitted ("14") -> layer_no -1 (global hook).
+    """
+    if s is None:
+        return None
+    s = str(s).strip()
+    if s == "":
+        return None                 # unconfigured -> gate inactive
+    if s.lower() == "none":
+        return []                   # explicit all-off
+    out = []
+    for tok in s.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        ht, _, ln = tok.partition(":")
+        out.append((int(ht), int(ln if ln != "" else -1)))
+    return out or None
+
+
+def _patch_cudagraph_keep_graph() -> None:
+    """Monkeypatch torch.cuda.CUDAGraph to default keep_graph=True.
+
+    vLLM's CUDAGraphWrapper creates ``torch.cuda.CUDAGraph()`` (keep_graph=False),
+    which frees the captured template graph after instantiate -> the node handles
+    DMI records via cudaStreamGetCaptureInfo would dangle. keep_graph=True keeps
+    the template alive (host memory only; no device/latency cost). Idempotent,
+    process-global; only applied when node-toggle is enabled.
+    """
+    global _CUDAGRAPH_KEEP_PATCHED
+    if _CUDAGRAPH_KEEP_PATCHED:
+        return
+    Orig = torch.cuda.CUDAGraph
+    if getattr(Orig, "_dmx_keep_graph", False):
+        _CUDAGRAPH_KEEP_PATCHED = True
+        return
+
+    class _KeepGraphCUDAGraph(Orig):
+        # Force keep_graph=True in BOTH __new__ and __init__: vLLM calls
+        # ``CUDAGraph()`` with no args, so __init__ (builtin) would otherwise
+        # reset keep_graph to its False default after __new__ set it. Subclass
+        # (not a factory) so isinstance(x, torch.cuda.CUDAGraph) still holds.
+        _dmx_keep_graph = True
+        _dmx_lazy_logged = False
+
+        def __new__(cls, *args, **kwargs):
+            kwargs["keep_graph"] = True
+            return Orig.__new__(cls, **kwargs)
+
+        def __init__(self, *args, **kwargs):
+            kwargs["keep_graph"] = True
+            super().__init__(**kwargs)
+
+        def replay(self):
+            # Replay-time node-toggle guard (eager + lazy). Armed by
+            # _DMX_TOGGLE_REPLAY_GUARD when a gate is active; otherwise stock
+            # replay (the common case, incl. all non-toggle runs).
+            if _DMX_TOGGLE_REPLAY_GUARD:
+                t = ring_transport.get_active()
+                if t is not None and t.toggle_gate_active:
+                    raw = self.raw_cuda_graph()
+                    # The graph about to replay MUST be a registered+bound
+                    # toggle graph. A graph vLLM captured at RUNTIME (new
+                    # batch_descriptor, after the warmup capture window closed)
+                    # has no recorded producer nodes and no bound exec -> its
+                    # producers run default-ON while the meta gate pushes only the
+                    # enabled subset -> desync. before_forward already pushed this
+                    # step's metas, so this is FATAL and unrecoverable: raise and
+                    # let the worker die. Read-only validation (eager + lazy).
+                    if not t.is_graph_ready(raw):
+                        raise RuntimeError(
+                            f"[DMX] node-toggle FATAL: graph {raw:#x} is about to replay "
+                            f"but is NOT registered+bound in the toggle registry -- it was "
+                            f"almost certainly captured by vLLM at RUNTIME after DMI closed "
+                            f"its capture window at warmup. Its producers run all-ON while "
+                            f"the meta gate filters to the enabled subset, which desyncs the "
+                            f"ring. The worker MUST terminate; do NOT catch and continue. "
+                            f"(Fix: ensure all decode batch_descriptors are captured during "
+                            f"warmup, or add runtime graph registration.)")
+                    if t.toggle_lazy_active:
+                        # Lazy: apply the deferred toggle now; a nonzero
+                        # result is FATAL (metas already pushed for the new set).
+                        err = t.ensure_graph_current(raw)
+                        if err != 0:
+                            raise RuntimeError(
+                                f"[DMX] node-toggle FATAL: lazy apply (ensure_graph_current) "
+                                f"failed with CUDA error {err} for graph {raw:#x}. The meta "
+                                f"gate already advanced this step, so replaying would desync "
+                                f"the ring irrecoverably. The worker MUST terminate; do NOT "
+                                f"catch and continue serving.")
+                        super().replay()
+                        # Record the replay event; if recording fails the
+                        # next ensure could mutate an executing exec (UB) -> FATAL.
+                        rerr = t.record_replay_event(raw)
+                        if rerr != 0:
+                            raise RuntimeError(
+                                f"[DMX] node-toggle FATAL: record_replay_event failed with "
+                                f"CUDA error {rerr} for graph {raw:#x}. Without a valid replay "
+                                f"event the next lazy reconfigure could mutate a still-executing "
+                                f"graph exec (UB). The worker MUST terminate.")
+                    else:
+                        # eager: device apply happened at config time; here we
+                        # only validated the graph is bound (read-only).
+                        super().replay()
+                    if not _KeepGraphCUDAGraph._dmx_lazy_logged:
+                        _KeepGraphCUDAGraph._dmx_lazy_logged = True
+                        _mode = "lazy" if t.toggle_lazy_active else "eager"
+                        print(f"[DMX] node-toggle: replay guard active (mode={_mode})", flush=True)
+                    return
+            super().replay()
+
+    torch.cuda.CUDAGraph = _KeepGraphCUDAGraph
+    _CUDAGRAPH_KEEP_PATCHED = True
+
+
+def begin_capture_window(engine) -> None:
+    """Scope node recording + keep_graph to the warmup capture that follows.
+    Clears any stale registry first."""
+    engine.clear_toggle_registry()
+    engine.enable_toggle_capture(True)
+    _patch_cudagraph_keep_graph()
+
+
+def bind_captured_graphs(model, engine) -> int:
+    """Find vLLM's captured CUDA graphs and bind each exec to the toggle
+    registry. Returns the number bound. FULL-cudagraph path only (decode);
+    the model is wrapped as CUDAGraphWrapper whose concrete_cudagraph_entries
+    hold one torch.cuda.CUDAGraph per batch size."""
+    try:
+        from vllm.compilation.cuda_graph import CUDAGraphWrapper
+    except Exception:
+        return 0
+    n = 0
+    # Unwrap nested wrappers (UBatchWrapper etc.) to find CUDAGraphWrapper(s).
+    seen = set()
+    stack = [model]
+    while stack:
+        obj = stack.pop()
+        if id(obj) in seen or obj is None:
+            continue
+        seen.add(id(obj))
+        if isinstance(obj, CUDAGraphWrapper):
+            for entry in obj.concrete_cudagraph_entries.values():
+                g = getattr(entry, "cudagraph", None)
+                if g is None:
+                    continue
+                # A graph not created by the keep_graph patch means vLLM
+                # resolved torch.cuda.CUDAGraph before (or without) the
+                # patch -- its template is freed on instantiate, so the
+                # capture-recorded node handles dangle and SetEnabled on
+                # them is UB. Refuse before any handle is touched.
+                if not getattr(type(g), "_dmx_keep_graph", False):
+                    raise RuntimeError(
+                        "[DMX] node-toggle FATAL: a captured CUDA graph was "
+                        "created from the UNPATCHED torch.cuda.CUDAGraph "
+                        "(keep_graph=False), so its template graph is already "
+                        "freed and the recorded producer-node handles dangle. "
+                        "vLLM likely binds the CUDAGraph class at import time "
+                        "in this version, bypassing _patch_cudagraph_keep_graph. "
+                        "Refusing to bind; fix the patch injection point before "
+                        "serving with node-toggle.")
+                # Don't re-instantiate if an exec already exists (that would
+                # destroy it). raw_cuda_graph_exec() raises until the graph
+                # is instantiated -> instantiate exactly once in that case.
+                try:
+                    exec_ptr = g.raw_cuda_graph_exec()
+                except RuntimeError:
+                    g.instantiate()
+                    exec_ptr = g.raw_cuda_graph_exec()
+                engine.bind_graph_exec(g.raw_cuda_graph(), exec_ptr)
+                n += 1
+        inner = getattr(obj, "runnable", None)
+        if inner is not None:
+            stack.append(inner)
+    return n
+
+
+def activate_after_warmup(model, engine, transport, enabled_hooks, lazy: bool) -> None:
+    """Bind each captured graph's exec, close the capture window, and
+    (optionally) apply the static enabled set. Call after warmup, before
+    serving, so no replay is in flight."""
+    n_bound = bind_captured_graphs(model, engine)
+    engine.enable_toggle_capture(False)   # close the window
+    print(f"[DMX] node-toggle: bound {n_bound} captured graph(s), "
+          f"{engine.toggle_node_count()} nodes registered")
+    if enabled_hooks is not None:
+        if n_bound == 0:
+            # Requested a subset but nothing bound (e.g. cudagraph_mode not
+            # FULL) -> refuse to serve silently with all hooks on.
+            raise RuntimeError(
+                "dmx_node_toggle + dmx_enabled_hooks were set but no CUDA graph "
+                "was bound. Node-toggle requires cudagraph_mode=FULL for decode "
+                "(one full-model graph per batch size). PIECEWISE graphs hold only "
+                "a model SUBSET, so different graphs capture different hook subsets "
+                "and would fail the uniform-hook-set requirement -- use FULL. "
+                "Refusing to serve with node-toggle silently inert.")
+        # Arm the replay-time guard for BOTH modes: eager needs the
+        # runtime-graph validation too, not just lazy.
+        set_replay_guard(True)
+        if lazy:
+            # Lazy: defer device apply to each graph's first replay.
+            transport.set_active_hooks_lazy(enabled_hooks)
+            print(f"[DMX] node-toggle: LAZY active hooks set to {enabled_hooks}")
+        else:
+            transport.set_active_hooks(enabled_hooks)
+            print(f"[DMX] node-toggle: active hooks set to {enabled_hooks}")
+    elif n_bound == 0:
+        print("[DMX] node-toggle: WARNING no graph bound; toggle is inert "
+              "(no dmx_enabled_hooks requested, so serving continues all-on).")

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -111,7 +111,8 @@ NVCCFLAGS := \
 
 RING_SRCS := csrc/ring/producer.cu \
              csrc/ring/ring_engine.cu \
-             csrc/ring/ring_engine_py.cu
+             csrc/ring/ring_engine_py.cu \
+             csrc/ring/toggle_registry.cu
 RING_OBJS := $(patsubst csrc/%.cu,$(BUILD_DIR)/%.o,$(RING_SRCS))
 
 OBJS += $(RING_OBJS)

--- a/monitoring/adaptor_base.py
+++ b/monitoring/adaptor_base.py
@@ -202,13 +202,12 @@ class BackendAdaptor(abc.ABC):
           ``before_forward`` together with ``prepare_step``'s overflow
           result.
 
-        ``effective_specs`` == ``active_specs`` when node-toggle is inactive
-        (no behaviour change), and the enabled-AND-captured subset when it is
-        active -- so capacity-reserve here stays in LOCKSTEP with the meta-push
-        in ``pre_push_all_metas`` (both read the same set). Reserving for the
-        full ``active_specs`` while only the enabled subset fires would
-        over-count vs actual producer writes -> ring head/tail drift (the
-        reserve-invariant bug).
+        Reads ``transport.specs_for_step()`` -- the per-step lockstep set that
+        ``pre_push_all_metas`` also reads. On a decode-graph step that is the
+        node-toggle subset; on a prefill / eager step it is the full active set
+        (producers run ungated there). When node-toggle is inactive both are
+        ``active_specs``. Reserving for a different set than what fires would
+        drift the ring head/tail (the reserve-invariant bug).
         """
         if self.model_cfg is None or not self.active_specs:
             return 0, 0, False
@@ -216,7 +215,7 @@ class BackendAdaptor(abc.ABC):
         total = 0
         n = 0
         needs_eager = False
-        for spec in self.transport.effective_specs:
+        for spec in self.transport.specs_for_step():
             # When the adapter has populated actual_q_len AND the spec is
             # prefix-strip-eligible, size the byte budget for the unpadded
             # data the producer will actually write.  Other specs and the

--- a/monitoring/adaptor_base.py
+++ b/monitoring/adaptor_base.py
@@ -191,7 +191,8 @@ class BackendAdaptor(abc.ABC):
     def _compute_step_plan(self, ctx: StepContext) -> "tuple[int, int, bool]":
         """Return ``(aligned total bytes, n_hooks, needs_eager)`` for one step.
 
-        Single walk over ``active_specs``:
+        Single walk over ``transport.effective_specs`` (the node-toggle single
+        source of truth):
         - ``total`` and ``n_hooks`` feed ``prepare_step``.  ``n_hooks``
           counts only specs whose ``_compute_hook_shape`` returns a
           non-empty list -- matches the count of metas
@@ -200,6 +201,14 @@ class BackendAdaptor(abc.ABC):
           firing specs.  Drives the dispatch + safety-net decision in
           ``before_forward`` together with ``prepare_step``'s overflow
           result.
+
+        ``effective_specs`` == ``active_specs`` when node-toggle is inactive
+        (no behaviour change), and the enabled-AND-captured subset when it is
+        active -- so capacity-reserve here stays in LOCKSTEP with the meta-push
+        in ``pre_push_all_metas`` (both read the same set). Reserving for the
+        full ``active_specs`` while only the enabled subset fires would
+        over-count vs actual producer writes -> ring head/tail drift (the
+        reserve-invariant bug).
         """
         if self.model_cfg is None or not self.active_specs:
             return 0, 0, False
@@ -207,7 +216,7 @@ class BackendAdaptor(abc.ABC):
         total = 0
         n = 0
         needs_eager = False
-        for spec in self.active_specs:
+        for spec in self.transport.effective_specs:
             # When the adapter has populated actual_q_len AND the spec is
             # prefix-strip-eligible, size the byte budget for the unpadded
             # data the producer will actually write.  Other specs and the

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -388,7 +388,41 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("notify_drain",
            &ring_py::RingEnginePy::notify_drain,
-           py::call_guard<py::gil_scoped_release>());
+           py::call_guard<py::gil_scoped_release>())
+      // --- Runtime node-toggle (Phase B) ---
+      .def("enable_toggle_capture",
+           &ring_py::RingEnginePy::enable_toggle_capture,
+           py::arg("enabled"))
+      .def("toggle_capture_enabled",
+           &ring_py::RingEnginePy::toggle_capture_enabled)
+      .def("bind_graph_exec",
+           &ring_py::RingEnginePy::bind_graph_exec,
+           py::arg("graph"), py::arg("exec"))
+      .def("set_enabled_hooks",
+           &ring_py::RingEnginePy::set_enabled_hooks,
+           py::arg("enabled"))
+      .def("apply_toggle",
+           &ring_py::RingEnginePy::apply_toggle,
+           py::call_guard<py::gil_scoped_release>())
+      .def("is_hook_enabled",
+           &ring_py::RingEnginePy::is_hook_enabled,
+           py::arg("hook_type"), py::arg("layer_no"))
+      .def("effective_enabled_mask",
+           &ring_py::RingEnginePy::effective_enabled_mask,
+           py::arg("query"))
+      .def("ensure_graph_current",
+           &ring_py::RingEnginePy::ensure_graph_current,
+           py::arg("graph"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("record_replay_event",
+           &ring_py::RingEnginePy::record_replay_event,
+           py::arg("graph"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("toggle_node_count", &ring_py::RingEnginePy::toggle_node_count)
+      .def("bound_graph_count", &ring_py::RingEnginePy::bound_graph_count)
+      .def("last_apply_count",  &ring_py::RingEnginePy::last_apply_count)
+      .def("toggle_registry_uniform", &ring_py::RingEnginePy::toggle_registry_uniform)
+      .def("clear_toggle_registry", &ring_py::RingEnginePy::clear_toggle_registry);
 
   // Register the active ring engine pointer so C++ ring_producer_impl can
   // call it during CUDA graph capture.  The raw pointer is valid as long as

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -262,6 +262,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def(py::init([](ring_py::RingConfig cfg, py::object host_engine_obj) {
              ring_py::SubmitFn submit_fn;
              if (!host_engine_obj.is_none()) {
+                 // A DMXHostEngine -> ClickHouse sink, or a plain Python callable
+                 // sink (mainly for tests / custom consumers, e.g. node-toggle
+                 // reconfigure guardrails that observe delivered slices).
+                 if (py::isinstance<dmx_host::DMXHostEngine>(host_engine_obj)) {
                  auto host = host_engine_obj.cast<std::shared_ptr<dmx_host::DMXHostEngine>>();
                  submit_fn = [host](const std::string& model_id, int32_t shard_rank,
                                     const std::string& req_id, const std::string& act_name,
@@ -279,6 +283,26 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                      row.emplace_back(std::move(slice));
                      host->submit_direct(std::move(row), nbytes);
                  };
+                 } else {
+                     // Python callable sink. The p2p thread calls submit_fn with
+                     // the GIL released, so re-acquire before calling into Python.
+                     auto pyfn = std::make_shared<py::function>(
+                         host_engine_obj.cast<py::function>());
+                     submit_fn = [pyfn](const std::string& model_id, int32_t shard_rank,
+                                        const std::string& req_id, const std::string& act_name,
+                                        int32_t layer_no, int32_t start_token, int32_t end_token,
+                                        at::Tensor slice) {
+                         py::gil_scoped_acquire gil;
+                         try {
+                             (*pyfn)(model_id, shard_rank, req_id, act_name, layer_no,
+                                     start_token, end_token, std::move(slice));
+                         } catch (const py::error_already_set& ex) {
+                             // Don't let a sink error kill the p2p thread, but make
+                             // it visible (tests rely on this path).
+                             fprintf(stderr, "[ring p2p] Python SubmitFn raised: %s\n", ex.what());
+                         }
+                     };
+                 }
              }
              return std::make_shared<ring_py::RingEnginePy>(
                  std::move(cfg), std::move(submit_fn));

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -456,6 +456,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("toggle_registry_uniform", &ring_py::RingEnginePy::toggle_registry_uniform)
       .def("is_graph_ready", &ring_py::RingEnginePy::is_graph_ready, py::arg("graph"))
       .def("toggle_registry_complete", &ring_py::RingEnginePy::toggle_registry_complete)
+      .def("capture_anomaly_count", &ring_py::RingEnginePy::capture_anomaly_count)
+      .def("note_capture_anomaly", &ring_py::RingEnginePy::note_capture_anomaly)
       .def("_test_force_apply_error", &ring_py::RingEnginePy::_test_force_apply_error, py::arg("code"))
       .def("_test_applied_current", &ring_py::RingEnginePy::_test_applied_current, py::arg("graph"))
       .def("clear_toggle_registry", &ring_py::RingEnginePy::clear_toggle_registry);

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -456,6 +456,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("is_graph_ready", &ring_py::RingEnginePy::is_graph_ready, py::arg("graph"))
       .def("toggle_registry_complete", &ring_py::RingEnginePy::toggle_registry_complete)
       .def("capture_anomaly_count", &ring_py::RingEnginePy::capture_anomaly_count)
+      .def("toggle_registry_version", &ring_py::RingEnginePy::toggle_registry_version)
       .def("note_capture_anomaly", &ring_py::RingEnginePy::note_capture_anomaly)
       .def("_test_force_apply_error", &ring_py::RingEnginePy::_test_force_apply_error, py::arg("code"))
       .def("_test_applied_current", &ring_py::RingEnginePy::_test_applied_current, py::arg("graph"))

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -268,9 +268,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def(py::init([](ring_py::RingConfig cfg, py::object host_engine_obj) {
              ring_py::SubmitFn submit_fn;
              if (!host_engine_obj.is_none()) {
-                 // A DMXHostEngine -> ClickHouse sink, or a plain Python callable
-                 // sink (mainly for tests / custom consumers, e.g. node-toggle
-                 // reconfigure guardrails that observe delivered slices).
+                 // A DMXHostEngine -> ClickHouse sink, or a plain Python
+                 // callable sink (tests / custom consumers).
                  if (py::isinstance<dmx_host::DMXHostEngine>(host_engine_obj)) {
                  auto host = host_engine_obj.cast<std::shared_ptr<dmx_host::DMXHostEngine>>();
                  submit_fn = [host](const std::string& model_id, int32_t shard_rank,
@@ -303,8 +302,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                              (*pyfn)(model_id, shard_rank, req_id, act_name, layer_no,
                                      start_token, end_token, std::move(slice));
                          } catch (const py::error_already_set& ex) {
-                             // Don't let a sink error kill the p2p thread, but make
-                             // it visible (tests rely on this path).
+                             // Don't let a sink error kill the p2p thread, but
+                             // make it visible.
                              fprintf(stderr, "[ring p2p] Python SubmitFn raised: %s\n", ex.what());
                          }
                      };

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -454,6 +454,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("bound_graph_count", &ring_py::RingEnginePy::bound_graph_count)
       .def("last_apply_count",  &ring_py::RingEnginePy::last_apply_count)
       .def("toggle_registry_uniform", &ring_py::RingEnginePy::toggle_registry_uniform)
+      .def("is_graph_ready", &ring_py::RingEnginePy::is_graph_ready, py::arg("graph"))
+      .def("toggle_registry_complete", &ring_py::RingEnginePy::toggle_registry_complete)
       .def("clear_toggle_registry", &ring_py::RingEnginePy::clear_toggle_registry);
 
   // Register the active ring engine pointer so C++ ring_producer_impl can

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -456,6 +456,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("toggle_registry_uniform", &ring_py::RingEnginePy::toggle_registry_uniform)
       .def("is_graph_ready", &ring_py::RingEnginePy::is_graph_ready, py::arg("graph"))
       .def("toggle_registry_complete", &ring_py::RingEnginePy::toggle_registry_complete)
+      .def("_test_force_apply_error", &ring_py::RingEnginePy::_test_force_apply_error, py::arg("code"))
+      .def("_test_applied_current", &ring_py::RingEnginePy::_test_applied_current, py::arg("graph"))
       .def("clear_toggle_registry", &ring_py::RingEnginePy::clear_toggle_registry);
 
   // Register the active ring engine pointer so C++ ring_producer_impl can

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -421,7 +421,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("get_stats", &ring_py::RingEnginePy::get_stats,
            py::call_guard<py::gil_scoped_release>())
-      // --- Runtime node-toggle (Phase B) ---
+      // --- Runtime node-toggle ---
       .def("enable_toggle_capture",
            &ring_py::RingEnginePy::enable_toggle_capture,
            py::arg("enabled"))

--- a/monitoring/csrc/bindings.cpp
+++ b/monitoring/csrc/bindings.cpp
@@ -258,6 +258,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_readwrite("insert_queue_max_bytes",    &ring_py::RingConfig::insert_queue_max_bytes)
       .def_readwrite("insert_queue_max_items",    &ring_py::RingConfig::insert_queue_max_items);
 
+  py::class_<ring_py::RingFlushStats>(m, "RingFlushStats")
+      .def_readonly("cpu_payload_head", &ring_py::RingFlushStats::cpu_payload_head)
+      .def_readonly("cpu_payload_tail_committed", &ring_py::RingFlushStats::cpu_payload_tail_committed)
+      .def_readonly("cpu_task_head", &ring_py::RingFlushStats::cpu_task_head)
+      .def_readonly("cpu_task_tail_committed", &ring_py::RingFlushStats::cpu_task_tail_committed);
+
   py::class_<ring_py::RingEnginePy, std::shared_ptr<ring_py::RingEnginePy>>(m, "RingEngine")
       .def(py::init([](ring_py::RingConfig cfg, py::object host_engine_obj) {
              ring_py::SubmitFn submit_fn;
@@ -412,6 +418,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("notify_drain",
            &ring_py::RingEnginePy::notify_drain,
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_stats", &ring_py::RingEnginePy::get_stats,
            py::call_guard<py::gil_scoped_release>())
       // --- Runtime node-toggle (Phase B) ---
       .def("enable_toggle_capture",

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -10,6 +10,7 @@
 #include "ring/ring_torch_op.h"
 #include "ring/producer.cuh"
 #include "ring/ring_debug.h"
+#include "ring/toggle_registry.h"
 #include <ATen/cuda/CUDAContext.h>  // at::cuda::getCurrentCUDAStream
 #include <cuda_runtime.h>
 #include <set>
@@ -44,39 +45,9 @@ struct RingEnginePy::Impl {
     // Tensor(a!) mutation alias passed to every producer op call.
     at::Tensor       payload_view;
 
-    // --- node-toggle registry ---
-    struct RegEntry { int hook_type; int layer_no; cudaGraphNode_t node;
-                      bool last_enabled{true}; };  // device default after instantiate
-    std::unordered_map<cudaGraph_t, std::vector<RegEntry>> reg_nodes;  // per captured graph
-    std::unordered_map<cudaGraph_t, cudaGraphExec_t>       reg_exec;   // graph -> exec
-    std::set<std::pair<int,int>>                           registered_hooks;  // (ht,layer) captured
-    std::set<std::pair<int,int>>                           enabled_hooks;     // single source
-    bool                                                   toggle_active{false};
-    bool                                                   toggle_capture{false};
-    uint64_t                                               last_apply_count{0};
-    // --- lazy per-graph apply ---
-    // target_version bumps on every enabled-set change; each graph tracks the
-    // version it was last applied to. ensure_graph_current() applies the current
-    // enabled set to ONE graph only when stale (just before that graph replays),
-    // so a reconfigure costs O(changed x graphs-actually-used). replay_event[g]
-    // is recorded after each replay so ensure can wait for the prior replay to
-    // finish before mutating the exec (SetEnabled on an executing exec is UB).
-    uint64_t                                               target_version{0};
-    std::unordered_map<cudaGraph_t, uint64_t>              applied_version;
-    std::unordered_map<cudaGraph_t, cudaEvent_t>           replay_event;
-    mutable std::mutex                                     toggle_mu;
-    // Test-only fault injection: when nonzero, ensure_graph_current returns this
-    // code as if a device apply failed (no SetEnabled, no version bump). Lets
-    // the failure-path gates exercise error propagation deterministically.
-    int                                                    force_apply_error{0};
-    // Count of capture-time recordings whose tail-dependency node was NOT a
-    // kernel node (so it could not be the producer kernel). Nonzero => the
-    // registry may be misaligned; set_active_hooks fails loud (fail-closed).
-    uint64_t                                               capture_anomaly{0};
-    // Bumped by EVERY registry mutation (capture flag, node recording, anomaly,
-    // bind, clear). The host caches its registry-guard verdict keyed on this
-    // version, so a stale "valid" verdict can never outlive a mutation.
-    uint64_t                                               registry_version{0};
+    // Runtime node-toggle: all state + CUDA-graph operations live in the
+    // registry (toggle_registry.h); the engine methods only delegate.
+    ToggleRegistry toggle;
 
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
@@ -88,9 +59,6 @@ struct RingEnginePy::Impl {
             state.payload_buf,
             {static_cast<int64_t>(state.payload_cap)},
             at::TensorOptions().dtype(at::kByte).device(at::kCUDA, dev_idx));
-    }
-    ~Impl() {
-        for (auto& kv : replay_event) if (kv.second) cudaEventDestroy(kv.second);
     }
 };
 
@@ -165,280 +133,99 @@ RingFlushStats RingEnginePy::get_stats() const {
 }
 
 // --- Runtime node-toggle -----------------------------------------
+// Thin delegates: all toggle state + CUDA-graph operations live in
+// ToggleRegistry (toggle_registry.{h,cu}). The engine only glues in the
+// process-global capture flag (ring_set_toggle_capture, read by the producer
+// op) and the ATen current stream for the replay event.
 void RingEnginePy::enable_toggle_capture(bool enabled) {
-    {
-        std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-        impl_->toggle_capture = enabled;
-        ++impl_->registry_version;
-    }
+    impl_->toggle.set_capture(enabled);
     ring_set_toggle_capture(enabled);   // tell the producer op to record nodes
 }
 
 bool RingEnginePy::toggle_capture_enabled() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    return impl_->toggle_capture;
+    return impl_->toggle.capture_enabled();
 }
 
 void RingEnginePy::register_capture_node(uint64_t graph, int hook_type, int layer_no, uint64_t node) {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    impl_->reg_nodes[reinterpret_cast<cudaGraph_t>(graph)].push_back(
-        Impl::RegEntry{hook_type, layer_no, reinterpret_cast<cudaGraphNode_t>(node)});
-    impl_->registered_hooks.insert({hook_type, layer_no});
-    ++impl_->registry_version;
+    impl_->toggle.register_node(graph, hook_type, layer_no, node);
 }
 
 void RingEnginePy::note_capture_anomaly() {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    ++impl_->capture_anomaly;
-    ++impl_->registry_version;
+    impl_->toggle.note_anomaly();
 }
 
 uint64_t RingEnginePy::capture_anomaly_count() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    return impl_->capture_anomaly;
+    return impl_->toggle.anomaly_count();
 }
 
 void RingEnginePy::bind_graph_exec(uint64_t graph, uint64_t exec) {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    impl_->reg_exec[reinterpret_cast<cudaGraph_t>(graph)] =
-        reinterpret_cast<cudaGraphExec_t>(exec);
-    ++impl_->registry_version;
+    impl_->toggle.bind_exec(graph, exec);
 }
 
 uint64_t RingEnginePy::toggle_registry_version() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    return impl_->registry_version;
+    return impl_->toggle.version();
 }
 
 void RingEnginePy::set_enabled_hooks(const std::vector<std::pair<int,int>>& enabled) {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    impl_->enabled_hooks.clear();
-    for (const auto& p : enabled) impl_->enabled_hooks.insert(p);
-    impl_->toggle_active = true;
-    ++impl_->target_version;   // mark all graphs stale for lazy ensure (no-op for eager)
+    impl_->toggle.set_enabled(enabled);
 }
 
 int RingEnginePy::apply_toggle() {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    cudaError_t first = cudaSuccess;
-    uint64_t applied = 0;
-    for (auto& kv : impl_->reg_exec) {
-        cudaGraphExec_t exec = kv.second;
-        auto it = impl_->reg_nodes.find(kv.first);
-        if (it == impl_->reg_nodes.end()) continue;
-        for (auto& e : it->second) {
-            const bool on = impl_->enabled_hooks.count({e.hook_type, e.layer_no}) > 0;
-            // Diff: only touch nodes whose desired state changed since the last
-            // apply (last_enabled tracks the exec's actual state -- DMI is the
-            // only toggler of its nodes). Adaptive flips of a few hooks then cost
-            // O(#changed) SetEnabled calls instead of O(#nodes).
-            if (on == e.last_enabled) continue;
-            cudaError_t err = cudaGraphNodeSetEnabled(exec, e.node, on ? 1u : 0u);
-            if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
-            e.last_enabled = on;   // update only on success
-            ++applied;
-        }
-    }
-    impl_->last_apply_count = applied;
-    return static_cast<int>(first);
+    return impl_->toggle.apply_all();
 }
 
 uint64_t RingEnginePy::bound_graph_count() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    return impl_->reg_exec.size();
+    return impl_->toggle.bound_count();
 }
 
 uint64_t RingEnginePy::last_apply_count() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    return impl_->last_apply_count;
+    return impl_->toggle.last_apply_count();
 }
 
 bool RingEnginePy::toggle_registry_uniform() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    // True iff every captured graph registered the same set of (hook_type,layer).
-    // The meta gate keys on (ht,layer) globally; if graphs differ, a hook present
-    // in one graph but absent from the one replayed this step would push a meta
-    // with no payload -> desync.
-    const std::set<std::pair<int,int>>* ref = nullptr;
-    std::set<std::pair<int,int>> ref_set;
-    for (const auto& kv : impl_->reg_nodes) {
-        std::set<std::pair<int,int>> s;
-        for (const auto& e : kv.second) s.insert({e.hook_type, e.layer_no});
-        if (!ref) { ref_set = std::move(s); ref = &ref_set; }
-        else if (s != ref_set) return false;
-    }
-    return true;
+    return impl_->toggle.uniform();
 }
 
 bool RingEnginePy::is_hook_enabled(int hook_type, int layer_no) const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    if (!impl_->toggle_active) return true;   // toggle inactive -> all hooks on
-    // Desync guard: the meta gate returns true only if the hook is BOTH
-    // enabled AND actually registered (has a captured producer node). Otherwise
-    // an enabled-but-uncaptured hook would push a meta with no matching payload
-    // -> p2p desync. With this, "meta pushed" <=> "a producer fires" in all cases.
-    const std::pair<int,int> k{hook_type, layer_no};
-    return impl_->enabled_hooks.count(k) > 0 && impl_->registered_hooks.count(k) > 0;
+    return impl_->toggle.is_enabled(hook_type, layer_no);
 }
 
 std::vector<int> RingEnginePy::effective_enabled_mask(
     const std::vector<std::pair<int,int>>& query) const {
-    // Batched is_hook_enabled (same semantics, one lock, one pybind crossing):
-    // toggle inactive -> all on; else enabled AND registered.
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    const bool inactive = !impl_->toggle_active;
-    std::vector<int> mask;
-    mask.reserve(query.size());
-    for (const auto& k : query) {
-        mask.push_back((inactive ||
-                        (impl_->enabled_hooks.count(k) > 0 &&
-                         impl_->registered_hooks.count(k) > 0)) ? 1 : 0);
-    }
-    return mask;
+    return impl_->toggle.effective_mask(query);
 }
 
 int RingEnginePy::ensure_graph_current(uint64_t graph) {
-    // Lazy: apply the current enabled set to ONE graph, only if it is
-    // stale (applied_version != target_version). Called just before that graph
-    // replays. Same per-node diff as apply_toggle, but scoped to one graph.
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
-    auto av = impl_->applied_version.find(g);
-    const uint64_t cur = (av == impl_->applied_version.end()) ? 0 : av->second;
-    if (cur == impl_->target_version) return 0;   // current -> fast no-op (common path)
-
-    auto ex = impl_->reg_exec.find(g);
-    if (ex == impl_->reg_exec.end()) return 0;     // unregistered/unbound graph -> skip
-    auto it = impl_->reg_nodes.find(g);
-    if (it == impl_->reg_nodes.end()) return 0;
-
-    // Test fault injection: fail before any mutation / version bump.
-    if (impl_->force_apply_error != 0) return impl_->force_apply_error;
-
-    // Event guard: the prior replay of THIS exec must be complete before we
-    // mutate it (host can run ahead of the GPU). Wait on its last-replay event.
-    // If the wait itself fails we CANNOT confirm the prior replay finished,
-    // so do NOT touch the exec -- return the error; the caller treats it as a
-    // FATAL desync risk. No nodes mutated, version left stale.
-    auto ev = impl_->replay_event.find(g);
-    if (ev != impl_->replay_event.end() && ev->second) {
-        cudaError_t se = cudaEventSynchronize(ev->second);
-        if (se != cudaSuccess) return static_cast<int>(se);
-    }
-
-    cudaError_t first = cudaSuccess;
-    for (auto& e : it->second) {
-        const bool on = impl_->enabled_hooks.count({e.hook_type, e.layer_no}) > 0;
-        if (on == e.last_enabled) continue;
-        cudaError_t err = cudaGraphNodeSetEnabled(ex->second, e.node, on ? 1u : 0u);
-        if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
-        e.last_enabled = on;
-    }
-    // Mark this graph current ONLY on full success. If any SetEnabled
-    // failed, leave applied_version stale so a later ensure retries the
-    // still-unapplied nodes (last_enabled already tracks per-node success, so
-    // the retry is a no-op for the ones that did flip). The caller (replay
-    // hook) treats a nonzero return as a FATAL desync and terminates, but the
-    // stale version is the correct state regardless.
-    if (first == cudaSuccess)
-        impl_->applied_version[g] = impl_->target_version;
-    return static_cast<int>(first);
+    return impl_->toggle.ensure_current(graph);
 }
 
 int RingEnginePy::record_replay_event(uint64_t graph) {
-    // Record a (timing-disabled) event on the current stream right after a
-    // graph's replay, so a later ensure_graph_current() can wait for it before
-    // mutating that exec. Returns the CUDA error: if event create OR record
-    // fails, the stored event would be stale/missing and a later ensure could
-    // wrongly believe a prior replay finished -> mutate an executing exec (UB).
-    // The caller treats nonzero as FATAL so we never reach that state.
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
-    if (impl_->reg_exec.find(g) == impl_->reg_exec.end()) return 0;  // not bound -> nothing to track
-    cudaEvent_t& ev = impl_->replay_event[g];
-    if (ev == nullptr) {
-        cudaError_t ce = cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
-        if (ce != cudaSuccess) { ev = nullptr; return static_cast<int>(ce); }
-    }
-    cudaError_t re = cudaEventRecord(ev, at::cuda::getCurrentCUDAStream().stream());
-    return static_cast<int>(re);
+    return impl_->toggle.record_replay_event(
+        graph, at::cuda::getCurrentCUDAStream().stream());
 }
 
-// --- test-only fault injection / introspection (see Impl::force_apply_error) -
 void RingEnginePy::_test_force_apply_error(int code) {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    impl_->force_apply_error = code;
+    impl_->toggle.force_apply_error(code);
 }
 
 bool RingEnginePy::_test_applied_current(uint64_t graph) const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
-    auto av = impl_->applied_version.find(g);
-    const uint64_t cur = (av == impl_->applied_version.end()) ? 0 : av->second;
-    return cur == impl_->target_version;
+    return impl_->toggle.applied_current(graph);
 }
 
 uint64_t RingEnginePy::toggle_node_count() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    uint64_t n = 0;
-    for (const auto& kv : impl_->reg_nodes) n += kv.second.size();
-    return n;
+    return impl_->toggle.node_count();
 }
 
 bool RingEnginePy::is_graph_ready(uint64_t graph) const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
-    return impl_->reg_nodes.count(g) > 0 && impl_->reg_exec.count(g) > 0;
+    return impl_->toggle.is_ready(graph);
 }
 
 bool RingEnginePy::toggle_registry_complete() const {
-    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-    // Exact key-set match: every captured graph bound AND every bound graph
-    // captured. Equal sizes + every reg_nodes key present in reg_exec ⟹
-    // bijection (both keyed by unique cudaGraph_t).
-    if (impl_->reg_nodes.size() != impl_->reg_exec.size()) return false;
-    for (const auto& kv : impl_->reg_nodes)
-        if (impl_->reg_exec.count(kv.first) == 0) return false;
-    return true;
+    return impl_->toggle.complete();
 }
 
 void RingEnginePy::clear_toggle_registry() {
-    {
-        std::lock_guard<std::mutex> lk(impl_->toggle_mu);
-        // Restore device state BEFORE dropping the registry: re-enable any node
-        // we disabled, so a graph that keeps replaying after a clear does not run
-        // with producers OFF while the (now-inactive) host gate pushes all metas
-        // -> desync. Best-effort, only for bound execs; safe at the quiescent
-        // call sites (warmup-start / teardown, no replay in flight). To revert to
-        // all-on DURING serving, prefer set_active_hooks(full_set) (event-guarded)
-        // over clear_toggle.
-        for (auto& kv : impl_->reg_nodes) {
-            auto ex = impl_->reg_exec.find(kv.first);
-            if (ex == impl_->reg_exec.end()) continue;
-            for (auto& e : kv.second) {
-                if (e.last_enabled) continue;
-                if (cudaGraphNodeSetEnabled(ex->second, e.node, 1u) == cudaSuccess)
-                    e.last_enabled = true;
-            }
-        }
-        impl_->reg_nodes.clear();
-        impl_->reg_exec.clear();
-        impl_->registered_hooks.clear();
-        // Full reset: also drop the enabled set + deactivate, so a stale gate
-        // (is_hook_enabled) can't skip every meta after a clear. Disable
-        // capture too so a later capture doesn't record into a cleared engine.
-        impl_->enabled_hooks.clear();
-        impl_->toggle_active = false;
-        impl_->toggle_capture = false;
-        impl_->last_apply_count = 0;
-        impl_->capture_anomaly = 0;
-        // Lazy state: reset versions + destroy per-graph replay events.
-        impl_->target_version = 0;
-        impl_->applied_version.clear();
-        for (auto& kv : impl_->replay_event) if (kv.second) cudaEventDestroy(kv.second);
-        impl_->replay_event.clear();
-        ++impl_->registry_version;
-    }
+    impl_->toggle.clear();
     ring_set_toggle_capture(false);
 }
 

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -65,6 +65,10 @@ struct RingEnginePy::Impl {
     std::unordered_map<cudaGraph_t, uint64_t>              applied_version;
     std::unordered_map<cudaGraph_t, cudaEvent_t>           replay_event;
     mutable std::mutex                                     toggle_mu;
+    // Test-only fault injection: when nonzero, ensure_graph_current returns this
+    // code as if a device apply failed (no SetEnabled, no version bump). Lets
+    // the failure-path gates exercise #1/#2 error propagation deterministically.
+    int                                                    force_apply_error{0};
 
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
@@ -278,10 +282,19 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
     auto it = impl_->reg_nodes.find(g);
     if (it == impl_->reg_nodes.end()) return 0;
 
+    // Test fault injection (#2 gate): fail before any mutation / version bump.
+    if (impl_->force_apply_error != 0) return impl_->force_apply_error;
+
     // Event guard: the prior replay of THIS exec must be complete before we
     // mutate it (host can run ahead of the GPU). Wait on its last-replay event.
+    // (#1) If the wait itself fails we CANNOT confirm the prior replay finished,
+    // so do NOT touch the exec -- return the error; the caller treats it as a
+    // FATAL desync risk. No nodes mutated, version left stale.
     auto ev = impl_->replay_event.find(g);
-    if (ev != impl_->replay_event.end() && ev->second) cudaEventSynchronize(ev->second);
+    if (ev != impl_->replay_event.end() && ev->second) {
+        cudaError_t se = cudaEventSynchronize(ev->second);
+        if (se != cudaSuccess) return static_cast<int>(se);
+    }
 
     cudaError_t first = cudaSuccess;
     for (auto& e : it->second) {
@@ -302,18 +315,37 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
     return static_cast<int>(first);
 }
 
-void RingEnginePy::record_replay_event(uint64_t graph) {
+int RingEnginePy::record_replay_event(uint64_t graph) {
     // Record a (timing-disabled) event on the current stream right after a
     // graph's replay, so a later ensure_graph_current() can wait for it before
-    // mutating that exec.
+    // mutating that exec. (#1) Returns the CUDA error: if event create OR record
+    // fails, the stored event would be stale/missing and a later ensure could
+    // wrongly believe a prior replay finished -> mutate an executing exec (UB).
+    // The caller treats nonzero as FATAL so we never reach that state.
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
     cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
-    if (impl_->reg_exec.find(g) == impl_->reg_exec.end()) return;  // only track bound graphs
+    if (impl_->reg_exec.find(g) == impl_->reg_exec.end()) return 0;  // not bound -> nothing to track
     cudaEvent_t& ev = impl_->replay_event[g];
     if (ev == nullptr) {
-        if (cudaEventCreateWithFlags(&ev, cudaEventDisableTiming) != cudaSuccess) return;
+        cudaError_t ce = cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
+        if (ce != cudaSuccess) { ev = nullptr; return static_cast<int>(ce); }
     }
-    cudaEventRecord(ev, at::cuda::getCurrentCUDAStream().stream());
+    cudaError_t re = cudaEventRecord(ev, at::cuda::getCurrentCUDAStream().stream());
+    return static_cast<int>(re);
+}
+
+// --- test-only fault injection / introspection (see Impl::force_apply_error) -
+void RingEnginePy::_test_force_apply_error(int code) {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    impl_->force_apply_error = code;
+}
+
+bool RingEnginePy::_test_applied_current(uint64_t graph) const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    auto av = impl_->applied_version.find(g);
+    const uint64_t cur = (av == impl_->applied_version.end()) ? 0 : av->second;
+    return cur == impl_->target_version;
 }
 
 uint64_t RingEnginePy::toggle_node_count() const {

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -69,6 +69,10 @@ struct RingEnginePy::Impl {
     // code as if a device apply failed (no SetEnabled, no version bump). Lets
     // the failure-path gates exercise #1/#2 error propagation deterministically.
     int                                                    force_apply_error{0};
+    // Count of capture-time recordings whose tail-dependency node was NOT a
+    // kernel node (so it could not be the producer kernel). Nonzero => the
+    // registry may be misaligned; set_active_hooks fails loud (fail-closed).
+    uint64_t                                               capture_anomaly{0};
 
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
@@ -172,6 +176,16 @@ void RingEnginePy::register_capture_node(uint64_t graph, int hook_type, int laye
     impl_->reg_nodes[reinterpret_cast<cudaGraph_t>(graph)].push_back(
         Impl::RegEntry{hook_type, layer_no, reinterpret_cast<cudaGraphNode_t>(node)});
     impl_->registered_hooks.insert({hook_type, layer_no});
+}
+
+void RingEnginePy::note_capture_anomaly() {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    ++impl_->capture_anomaly;
+}
+
+uint64_t RingEnginePy::capture_anomaly_count() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    return impl_->capture_anomaly;
 }
 
 void RingEnginePy::bind_graph_exec(uint64_t graph, uint64_t exec) {
@@ -375,6 +389,22 @@ bool RingEnginePy::toggle_registry_complete() const {
 void RingEnginePy::clear_toggle_registry() {
     {
         std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+        // Restore device state BEFORE dropping the registry: re-enable any node
+        // we disabled, so a graph that keeps replaying after a clear does not run
+        // with producers OFF while the (now-inactive) host gate pushes all metas
+        // -> desync. Best-effort, only for bound execs; safe at the quiescent
+        // call sites (warmup-start / teardown, no replay in flight). To revert to
+        // all-on DURING serving, prefer set_active_hooks(full_set) (event-guarded)
+        // over clear_toggle.
+        for (auto& kv : impl_->reg_nodes) {
+            auto ex = impl_->reg_exec.find(kv.first);
+            if (ex == impl_->reg_exec.end()) continue;
+            for (auto& e : kv.second) {
+                if (e.last_enabled) continue;
+                if (cudaGraphNodeSetEnabled(ex->second, e.node, 1u) == cudaSuccess)
+                    e.last_enabled = true;
+            }
+        }
         impl_->reg_nodes.clear();
         impl_->reg_exec.clear();
         impl_->registered_hooks.clear();
@@ -385,6 +415,7 @@ void RingEnginePy::clear_toggle_registry() {
         impl_->toggle_active = false;
         impl_->toggle_capture = false;
         impl_->last_apply_count = 0;
+        impl_->capture_anomaly = 0;
         // Phase 4 lazy state: reset versions + destroy per-graph replay events.
         impl_->target_version = 0;
         impl_->applied_version.clear();

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -73,6 +73,10 @@ struct RingEnginePy::Impl {
     // kernel node (so it could not be the producer kernel). Nonzero => the
     // registry may be misaligned; set_active_hooks fails loud (fail-closed).
     uint64_t                                               capture_anomaly{0};
+    // Bumped by EVERY registry mutation (capture flag, node recording, anomaly,
+    // bind, clear). The host caches its registry-guard verdict keyed on this
+    // version, so a stale "valid" verdict can never outlive a mutation.
+    uint64_t                                               registry_version{0};
 
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
@@ -162,7 +166,11 @@ RingFlushStats RingEnginePy::get_stats() const {
 
 // --- Runtime node-toggle -----------------------------------------
 void RingEnginePy::enable_toggle_capture(bool enabled) {
-    { std::lock_guard<std::mutex> lk(impl_->toggle_mu); impl_->toggle_capture = enabled; }
+    {
+        std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+        impl_->toggle_capture = enabled;
+        ++impl_->registry_version;
+    }
     ring_set_toggle_capture(enabled);   // tell the producer op to record nodes
 }
 
@@ -176,11 +184,13 @@ void RingEnginePy::register_capture_node(uint64_t graph, int hook_type, int laye
     impl_->reg_nodes[reinterpret_cast<cudaGraph_t>(graph)].push_back(
         Impl::RegEntry{hook_type, layer_no, reinterpret_cast<cudaGraphNode_t>(node)});
     impl_->registered_hooks.insert({hook_type, layer_no});
+    ++impl_->registry_version;
 }
 
 void RingEnginePy::note_capture_anomaly() {
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
     ++impl_->capture_anomaly;
+    ++impl_->registry_version;
 }
 
 uint64_t RingEnginePy::capture_anomaly_count() const {
@@ -192,6 +202,12 @@ void RingEnginePy::bind_graph_exec(uint64_t graph, uint64_t exec) {
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
     impl_->reg_exec[reinterpret_cast<cudaGraph_t>(graph)] =
         reinterpret_cast<cudaGraphExec_t>(exec);
+    ++impl_->registry_version;
+}
+
+uint64_t RingEnginePy::toggle_registry_version() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    return impl_->registry_version;
 }
 
 void RingEnginePy::set_enabled_hooks(const std::vector<std::pair<int,int>>& enabled) {
@@ -421,6 +437,7 @@ void RingEnginePy::clear_toggle_registry() {
         impl_->applied_version.clear();
         for (auto& kv : impl_->replay_event) if (kv.second) cudaEventDestroy(kv.second);
         impl_->replay_event.clear();
+        ++impl_->registry_version;
     }
     ring_set_toggle_capture(false);
 }

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -11,6 +11,12 @@
 #include "ring/producer.cuh"
 #include "ring/ring_debug.h"
 #include <ATen/cuda/CUDAContext.h>  // at::cuda::getCurrentCUDAStream
+#include <cuda_runtime.h>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <mutex>
 
 // Forward-declare symbols from producer.cu
 namespace ring {
@@ -38,6 +44,28 @@ struct RingEnginePy::Impl {
     // Tensor(a!) mutation alias passed to every producer op call.
     at::Tensor       payload_view;
 
+    // --- node-toggle registry (Phase B) ---
+    struct RegEntry { int hook_type; int layer_no; cudaGraphNode_t node;
+                      bool last_enabled{true}; };  // device default after instantiate
+    std::unordered_map<cudaGraph_t, std::vector<RegEntry>> reg_nodes;  // per captured graph
+    std::unordered_map<cudaGraph_t, cudaGraphExec_t>       reg_exec;   // graph -> exec
+    std::set<std::pair<int,int>>                           registered_hooks;  // (ht,layer) captured
+    std::set<std::pair<int,int>>                           enabled_hooks;     // single source
+    bool                                                   toggle_active{false};
+    bool                                                   toggle_capture{false};
+    uint64_t                                               last_apply_count{0};
+    // --- Phase 4: lazy per-graph apply ---
+    // target_version bumps on every enabled-set change; each graph tracks the
+    // version it was last applied to. ensure_graph_current() applies the current
+    // enabled set to ONE graph only when stale (just before that graph replays),
+    // so a reconfigure costs O(changed x graphs-actually-used). replay_event[g]
+    // is recorded after each replay so ensure can wait for the prior replay to
+    // finish before mutating the exec (SetEnabled on an executing exec is UB).
+    uint64_t                                               target_version{0};
+    std::unordered_map<cudaGraph_t, uint64_t>              applied_version;
+    std::unordered_map<cudaGraph_t, cudaEvent_t>           replay_event;
+    mutable std::mutex                                     toggle_mu;
+
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
     {
@@ -48,6 +76,9 @@ struct RingEnginePy::Impl {
             state.payload_buf,
             {static_cast<int64_t>(state.payload_cap)},
             at::TensorOptions().dtype(at::kByte).device(at::kCUDA, dev_idx));
+    }
+    ~Impl() {
+        for (auto& kv : replay_event) if (kv.second) cudaEventDestroy(kv.second);
     }
 };
 
@@ -106,6 +137,192 @@ void RingEnginePy::set_null_mode(bool enabled) {
 
 void RingEnginePy::push_step(StepContext* ctx, std::vector<TensorMeta>& metas) {
     impl_->fifo.push_step(ctx, metas);
+}
+
+// --- Runtime node-toggle (Phase B) -----------------------------------------
+void RingEnginePy::enable_toggle_capture(bool enabled) {
+    { std::lock_guard<std::mutex> lk(impl_->toggle_mu); impl_->toggle_capture = enabled; }
+    ring_set_toggle_capture(enabled);   // tell the producer op to record nodes
+}
+
+bool RingEnginePy::toggle_capture_enabled() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    return impl_->toggle_capture;
+}
+
+void RingEnginePy::register_capture_node(uint64_t graph, int hook_type, int layer_no, uint64_t node) {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    impl_->reg_nodes[reinterpret_cast<cudaGraph_t>(graph)].push_back(
+        Impl::RegEntry{hook_type, layer_no, reinterpret_cast<cudaGraphNode_t>(node)});
+    impl_->registered_hooks.insert({hook_type, layer_no});
+}
+
+void RingEnginePy::bind_graph_exec(uint64_t graph, uint64_t exec) {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    impl_->reg_exec[reinterpret_cast<cudaGraph_t>(graph)] =
+        reinterpret_cast<cudaGraphExec_t>(exec);
+}
+
+void RingEnginePy::set_enabled_hooks(const std::vector<std::pair<int,int>>& enabled) {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    impl_->enabled_hooks.clear();
+    for (const auto& p : enabled) impl_->enabled_hooks.insert(p);
+    impl_->toggle_active = true;
+    ++impl_->target_version;   // mark all graphs stale for lazy ensure (no-op for eager)
+}
+
+int RingEnginePy::apply_toggle() {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    cudaError_t first = cudaSuccess;
+    uint64_t applied = 0;
+    for (auto& kv : impl_->reg_exec) {
+        cudaGraphExec_t exec = kv.second;
+        auto it = impl_->reg_nodes.find(kv.first);
+        if (it == impl_->reg_nodes.end()) continue;
+        for (auto& e : it->second) {
+            const bool on = impl_->enabled_hooks.count({e.hook_type, e.layer_no}) > 0;
+            // Diff: only touch nodes whose desired state changed since the last
+            // apply (last_enabled tracks the exec's actual state -- DMI is the
+            // only toggler of its nodes). Adaptive flips of a few hooks then cost
+            // O(#changed) SetEnabled calls instead of O(#nodes).
+            if (on == e.last_enabled) continue;
+            cudaError_t err = cudaGraphNodeSetEnabled(exec, e.node, on ? 1u : 0u);
+            if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
+            e.last_enabled = on;   // update only on success
+            ++applied;
+        }
+    }
+    impl_->last_apply_count = applied;
+    return static_cast<int>(first);
+}
+
+uint64_t RingEnginePy::bound_graph_count() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    return impl_->reg_exec.size();
+}
+
+uint64_t RingEnginePy::last_apply_count() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    return impl_->last_apply_count;
+}
+
+bool RingEnginePy::toggle_registry_uniform() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    // True iff every captured graph registered the same set of (hook_type,layer).
+    // The meta gate keys on (ht,layer) globally; if graphs differ, a hook present
+    // in one graph but absent from the one replayed this step would push a meta
+    // with no payload -> desync. vLLM captures all hooks in every graph (uniform).
+    const std::set<std::pair<int,int>>* ref = nullptr;
+    std::set<std::pair<int,int>> ref_set;
+    for (const auto& kv : impl_->reg_nodes) {
+        std::set<std::pair<int,int>> s;
+        for (const auto& e : kv.second) s.insert({e.hook_type, e.layer_no});
+        if (!ref) { ref_set = std::move(s); ref = &ref_set; }
+        else if (s != ref_set) return false;
+    }
+    return true;
+}
+
+bool RingEnginePy::is_hook_enabled(int hook_type, int layer_no) const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    if (!impl_->toggle_active) return true;   // toggle inactive -> all hooks on
+    // Desync guard (#14): the meta gate returns true only if the hook is BOTH
+    // enabled AND actually registered (has a captured producer node). Otherwise
+    // an enabled-but-uncaptured hook would push a meta with no matching payload
+    // -> p2p desync. With this, "meta pushed" <=> "a producer fires" in all cases.
+    const std::pair<int,int> k{hook_type, layer_no};
+    return impl_->enabled_hooks.count(k) > 0 && impl_->registered_hooks.count(k) > 0;
+}
+
+std::vector<int> RingEnginePy::effective_enabled_mask(
+    const std::vector<std::pair<int,int>>& query) const {
+    // Batched is_hook_enabled (same semantics, one lock, one pybind crossing):
+    // toggle inactive -> all on; else enabled AND registered (#14 guard).
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    const bool inactive = !impl_->toggle_active;
+    std::vector<int> mask;
+    mask.reserve(query.size());
+    for (const auto& k : query) {
+        mask.push_back((inactive ||
+                        (impl_->enabled_hooks.count(k) > 0 &&
+                         impl_->registered_hooks.count(k) > 0)) ? 1 : 0);
+    }
+    return mask;
+}
+
+int RingEnginePy::ensure_graph_current(uint64_t graph) {
+    // Phase 4 lazy: apply the current enabled set to ONE graph, only if it is
+    // stale (applied_version != target_version). Called just before that graph
+    // replays. Same per-node diff as apply_toggle, but scoped to one graph.
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    auto av = impl_->applied_version.find(g);
+    const uint64_t cur = (av == impl_->applied_version.end()) ? 0 : av->second;
+    if (cur == impl_->target_version) return 0;   // current -> fast no-op (common path)
+
+    auto ex = impl_->reg_exec.find(g);
+    if (ex == impl_->reg_exec.end()) return 0;     // unregistered/unbound graph -> skip
+    auto it = impl_->reg_nodes.find(g);
+    if (it == impl_->reg_nodes.end()) return 0;
+
+    // Event guard: the prior replay of THIS exec must be complete before we
+    // mutate it (host can run ahead of the GPU). Wait on its last-replay event.
+    auto ev = impl_->replay_event.find(g);
+    if (ev != impl_->replay_event.end() && ev->second) cudaEventSynchronize(ev->second);
+
+    cudaError_t first = cudaSuccess;
+    for (auto& e : it->second) {
+        const bool on = impl_->enabled_hooks.count({e.hook_type, e.layer_no}) > 0;
+        if (on == e.last_enabled) continue;
+        cudaError_t err = cudaGraphNodeSetEnabled(ex->second, e.node, on ? 1u : 0u);
+        if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
+        e.last_enabled = on;
+    }
+    impl_->applied_version[g] = impl_->target_version;
+    return static_cast<int>(first);
+}
+
+void RingEnginePy::record_replay_event(uint64_t graph) {
+    // Record a (timing-disabled) event on the current stream right after a
+    // graph's replay, so a later ensure_graph_current() can wait for it before
+    // mutating that exec.
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    if (impl_->reg_exec.find(g) == impl_->reg_exec.end()) return;  // only track bound graphs
+    cudaEvent_t& ev = impl_->replay_event[g];
+    if (ev == nullptr) {
+        if (cudaEventCreateWithFlags(&ev, cudaEventDisableTiming) != cudaSuccess) return;
+    }
+    cudaEventRecord(ev, at::cuda::getCurrentCUDAStream().stream());
+}
+
+uint64_t RingEnginePy::toggle_node_count() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    uint64_t n = 0;
+    for (const auto& kv : impl_->reg_nodes) n += kv.second.size();
+    return n;
+}
+
+void RingEnginePy::clear_toggle_registry() {
+    {
+        std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+        impl_->reg_nodes.clear();
+        impl_->reg_exec.clear();
+        impl_->registered_hooks.clear();
+        // Full reset: also drop the enabled set + deactivate, so a stale gate
+        // (is_hook_enabled) can't skip every meta after a clear (#2). Disable
+        // capture too so a later capture doesn't record into a cleared engine (#3).
+        impl_->enabled_hooks.clear();
+        impl_->toggle_active = false;
+        impl_->toggle_capture = false;
+        impl_->last_apply_count = 0;
+        // Phase 4 lazy state: reset versions + destroy per-graph replay events.
+        impl_->target_version = 0;
+        impl_->applied_version.clear();
+        for (auto& kv : impl_->replay_event) if (kv.second) cudaEventDestroy(kv.second);
+        impl_->replay_event.clear();
+    }
+    ring_set_toggle_capture(false);
 }
 
 // ---------------------------------------------------------------------------
@@ -230,10 +447,23 @@ int RingEnginePy::prepare_step(uint64_t step_total_bytes,
     }
 
     // Case A: step fits.  Check available space for BOTH payload AND tasks.
-    const uint64_t payload_avail = pcap -
-        (drain.cpu_payload_head() - drain.cpu_payload_tail_committed());
-    const uint64_t task_avail = tcap -
-        (drain.cpu_task_head() - drain.cpu_task_tail_committed());
+    // Clamp `used` to [0, cap] on BOTH ends (node-toggle reserve-invariant):
+    //   - head < tail: a small constant skew exists because producers that fire
+    //     during CUDA-graph capture get drained (advancing the tail) with no
+    //     matching reserve() (which only runs per real step) -> the ring is in
+    //     fact drained, so used = 0 (avail = cap). Computing head-tail here would
+    //     underflow uint64 to a huge value -> avail = 0 -> a spurious ring-full
+    //     flush (main-stream sync) every step.
+    //   - head-tail > cap: over-reserve drift; fail safe with avail = 0 rather
+    //     than underflowing to a huge "available" that disables the check.
+    const uint64_t ph = drain.cpu_payload_head();
+    const uint64_t pt = drain.cpu_payload_tail_committed();
+    const uint64_t payload_used = (ph > pt) ? (ph - pt) : 0;
+    const uint64_t payload_avail = (payload_used >= pcap) ? 0 : pcap - payload_used;
+    const uint64_t th = drain.cpu_task_head();
+    const uint64_t tt = drain.cpu_task_tail_committed();
+    const uint64_t task_used = (th > tt) ? (th - tt) : 0;
+    const uint64_t task_avail = (task_used >= tcap) ? 0 : tcap - task_used;
 
     if (step_total_bytes <= payload_avail && num_hooks <= task_avail) {
         drain.reserve(step_total_bytes, num_hooks);

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -139,6 +139,19 @@ void RingEnginePy::push_step(StepContext* ctx, std::vector<TensorMeta>& metas) {
     impl_->fifo.push_step(ctx, metas);
 }
 
+RingFlushStats RingEnginePy::get_stats() const {
+    // Reserve-invariant probe: expose the live drain-thread head/tail counters
+    // so a test can confirm the ring fully drains (head == tail_committed) after
+    // a flush -> reserve() matched actual producer writes.
+    RingFlushStats stats{};
+    auto& drain = impl_->engine.drain_thread();
+    stats.cpu_payload_head           = drain.cpu_payload_head();
+    stats.cpu_payload_tail_committed = drain.cpu_payload_tail_committed();
+    stats.cpu_task_head              = drain.cpu_task_head();
+    stats.cpu_task_tail_committed    = drain.cpu_task_tail_committed();
+    return stats;
+}
+
 // --- Runtime node-toggle (Phase B) -----------------------------------------
 void RingEnginePy::enable_toggle_capture(bool enabled) {
     { std::lock_guard<std::mutex> lk(impl_->toggle_mu); impl_->toggle_capture = enabled; }

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -242,7 +242,7 @@ bool RingEnginePy::toggle_registry_uniform() const {
     // True iff every captured graph registered the same set of (hook_type,layer).
     // The meta gate keys on (ht,layer) globally; if graphs differ, a hook present
     // in one graph but absent from the one replayed this step would push a meta
-    // with no payload -> desync. vLLM captures all hooks in every graph (uniform).
+    // with no payload -> desync.
     const std::set<std::pair<int,int>>* ref = nullptr;
     std::set<std::pair<int,int>> ref_set;
     for (const auto& kv : impl_->reg_nodes) {

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -44,7 +44,7 @@ struct RingEnginePy::Impl {
     // Tensor(a!) mutation alias passed to every producer op call.
     at::Tensor       payload_view;
 
-    // --- node-toggle registry (Phase B) ---
+    // --- node-toggle registry ---
     struct RegEntry { int hook_type; int layer_no; cudaGraphNode_t node;
                       bool last_enabled{true}; };  // device default after instantiate
     std::unordered_map<cudaGraph_t, std::vector<RegEntry>> reg_nodes;  // per captured graph
@@ -54,7 +54,7 @@ struct RingEnginePy::Impl {
     bool                                                   toggle_active{false};
     bool                                                   toggle_capture{false};
     uint64_t                                               last_apply_count{0};
-    // --- Phase 4: lazy per-graph apply ---
+    // --- lazy per-graph apply ---
     // target_version bumps on every enabled-set change; each graph tracks the
     // version it was last applied to. ensure_graph_current() applies the current
     // enabled set to ONE graph only when stale (just before that graph replays),
@@ -67,7 +67,7 @@ struct RingEnginePy::Impl {
     mutable std::mutex                                     toggle_mu;
     // Test-only fault injection: when nonzero, ensure_graph_current returns this
     // code as if a device apply failed (no SetEnabled, no version bump). Lets
-    // the failure-path gates exercise #1/#2 error propagation deterministically.
+    // the failure-path gates exercise error propagation deterministically.
     int                                                    force_apply_error{0};
     // Count of capture-time recordings whose tail-dependency node was NOT a
     // kernel node (so it could not be the producer kernel). Nonzero => the
@@ -160,7 +160,7 @@ RingFlushStats RingEnginePy::get_stats() const {
     return stats;
 }
 
-// --- Runtime node-toggle (Phase B) -----------------------------------------
+// --- Runtime node-toggle -----------------------------------------
 void RingEnginePy::enable_toggle_capture(bool enabled) {
     { std::lock_guard<std::mutex> lk(impl_->toggle_mu); impl_->toggle_capture = enabled; }
     ring_set_toggle_capture(enabled);   // tell the producer op to record nodes
@@ -257,7 +257,7 @@ bool RingEnginePy::toggle_registry_uniform() const {
 bool RingEnginePy::is_hook_enabled(int hook_type, int layer_no) const {
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
     if (!impl_->toggle_active) return true;   // toggle inactive -> all hooks on
-    // Desync guard (#14): the meta gate returns true only if the hook is BOTH
+    // Desync guard: the meta gate returns true only if the hook is BOTH
     // enabled AND actually registered (has a captured producer node). Otherwise
     // an enabled-but-uncaptured hook would push a meta with no matching payload
     // -> p2p desync. With this, "meta pushed" <=> "a producer fires" in all cases.
@@ -268,7 +268,7 @@ bool RingEnginePy::is_hook_enabled(int hook_type, int layer_no) const {
 std::vector<int> RingEnginePy::effective_enabled_mask(
     const std::vector<std::pair<int,int>>& query) const {
     // Batched is_hook_enabled (same semantics, one lock, one pybind crossing):
-    // toggle inactive -> all on; else enabled AND registered (#14 guard).
+    // toggle inactive -> all on; else enabled AND registered.
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
     const bool inactive = !impl_->toggle_active;
     std::vector<int> mask;
@@ -282,7 +282,7 @@ std::vector<int> RingEnginePy::effective_enabled_mask(
 }
 
 int RingEnginePy::ensure_graph_current(uint64_t graph) {
-    // Phase 4 lazy: apply the current enabled set to ONE graph, only if it is
+    // Lazy: apply the current enabled set to ONE graph, only if it is
     // stale (applied_version != target_version). Called just before that graph
     // replays. Same per-node diff as apply_toggle, but scoped to one graph.
     std::lock_guard<std::mutex> lk(impl_->toggle_mu);
@@ -296,12 +296,12 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
     auto it = impl_->reg_nodes.find(g);
     if (it == impl_->reg_nodes.end()) return 0;
 
-    // Test fault injection (#2 gate): fail before any mutation / version bump.
+    // Test fault injection: fail before any mutation / version bump.
     if (impl_->force_apply_error != 0) return impl_->force_apply_error;
 
     // Event guard: the prior replay of THIS exec must be complete before we
     // mutate it (host can run ahead of the GPU). Wait on its last-replay event.
-    // (#1) If the wait itself fails we CANNOT confirm the prior replay finished,
+    // If the wait itself fails we CANNOT confirm the prior replay finished,
     // so do NOT touch the exec -- return the error; the caller treats it as a
     // FATAL desync risk. No nodes mutated, version left stale.
     auto ev = impl_->replay_event.find(g);
@@ -318,7 +318,7 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
         if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
         e.last_enabled = on;
     }
-    // (#2) Mark this graph current ONLY on full success. If any SetEnabled
+    // Mark this graph current ONLY on full success. If any SetEnabled
     // failed, leave applied_version stale so a later ensure retries the
     // still-unapplied nodes (last_enabled already tracks per-node success, so
     // the retry is a no-op for the ones that did flip). The caller (replay
@@ -332,7 +332,7 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
 int RingEnginePy::record_replay_event(uint64_t graph) {
     // Record a (timing-disabled) event on the current stream right after a
     // graph's replay, so a later ensure_graph_current() can wait for it before
-    // mutating that exec. (#1) Returns the CUDA error: if event create OR record
+    // mutating that exec. Returns the CUDA error: if event create OR record
     // fails, the stored event would be stale/missing and a later ensure could
     // wrongly believe a prior replay finished -> mutate an executing exec (UB).
     // The caller treats nonzero as FATAL so we never reach that state.
@@ -409,14 +409,14 @@ void RingEnginePy::clear_toggle_registry() {
         impl_->reg_exec.clear();
         impl_->registered_hooks.clear();
         // Full reset: also drop the enabled set + deactivate, so a stale gate
-        // (is_hook_enabled) can't skip every meta after a clear (#2). Disable
-        // capture too so a later capture doesn't record into a cleared engine (#3).
+        // (is_hook_enabled) can't skip every meta after a clear. Disable
+        // capture too so a later capture doesn't record into a cleared engine.
         impl_->enabled_hooks.clear();
         impl_->toggle_active = false;
         impl_->toggle_capture = false;
         impl_->last_apply_count = 0;
         impl_->capture_anomaly = 0;
-        // Phase 4 lazy state: reset versions + destroy per-graph replay events.
+        // Lazy state: reset versions + destroy per-graph replay events.
         impl_->target_version = 0;
         impl_->applied_version.clear();
         for (auto& kv : impl_->replay_event) if (kv.second) cudaEventDestroy(kv.second);

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -291,7 +291,14 @@ int RingEnginePy::ensure_graph_current(uint64_t graph) {
         if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
         e.last_enabled = on;
     }
-    impl_->applied_version[g] = impl_->target_version;
+    // (#2) Mark this graph current ONLY on full success. If any SetEnabled
+    // failed, leave applied_version stale so a later ensure retries the
+    // still-unapplied nodes (last_enabled already tracks per-node success, so
+    // the retry is a no-op for the ones that did flip). The caller (replay
+    // hook) treats a nonzero return as a FATAL desync and terminates, but the
+    // stale version is the correct state regardless.
+    if (first == cudaSuccess)
+        impl_->applied_version[g] = impl_->target_version;
     return static_cast<int>(first);
 }
 

--- a/monitoring/csrc/ring/ring_engine_py.cu
+++ b/monitoring/csrc/ring/ring_engine_py.cu
@@ -323,6 +323,23 @@ uint64_t RingEnginePy::toggle_node_count() const {
     return n;
 }
 
+bool RingEnginePy::is_graph_ready(uint64_t graph) const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    return impl_->reg_nodes.count(g) > 0 && impl_->reg_exec.count(g) > 0;
+}
+
+bool RingEnginePy::toggle_registry_complete() const {
+    std::lock_guard<std::mutex> lk(impl_->toggle_mu);
+    // Exact key-set match: every captured graph bound AND every bound graph
+    // captured. Equal sizes + every reg_nodes key present in reg_exec ⟹
+    // bijection (both keyed by unique cudaGraph_t).
+    if (impl_->reg_nodes.size() != impl_->reg_exec.size()) return false;
+    for (const auto& kv : impl_->reg_nodes)
+        if (impl_->reg_exec.count(kv.first) == 0) return false;
+    return true;
+}
+
 void RingEnginePy::clear_toggle_registry() {
     {
         std::lock_guard<std::mutex> lk(impl_->toggle_mu);

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>   // std::pair (node-toggle hook keys)
 #include <vector>
 
 #include "ring/tensor_meta.h"   // TensorMeta, TensorMetaFifo
@@ -164,6 +165,48 @@ public:
     // GIL.  Used by safety-net branches that need to free ring space or
     // ensure FIFO ordering before consuming the next meta out-of-band.
     void flush_and_wait();
+
+    // ---- Runtime node-toggle (Phase B) -----------------------------------
+    // cudaGraph_t / cudaGraphNode_t / cudaGraphExec_t are passed as opaque
+    // uint64_t so this header stays CUDA-free (it is included by the
+    // g++-compiled bindings.cpp). The enabled (hook_type, layer_no) set is the
+    // SINGLE SOURCE OF TRUTH: apply_toggle()/ensure_graph_current() (device)
+    // and is_hook_enabled()/effective_enabled_mask() (host meta gate) read it.
+
+    // enable_toggle_capture(true) makes the producer op record its kernel node
+    // (via cudaStreamGetCaptureInfo) during graph capture; default off.
+    void enable_toggle_capture(bool enabled);
+    bool toggle_capture_enabled() const;
+    // Called from the producer op during capture (C++ only, not bound).
+    void register_capture_node(uint64_t graph, int hook_type, int layer_no, uint64_t node);
+    // Bind a captured graph to its instantiated exec (post-warmup).
+    void bind_graph_exec(uint64_t graph, uint64_t exec);
+    // Set the enabled (hook_type, layer_no) set (the single source).
+    void set_enabled_hooks(const std::vector<std::pair<int,int>>& enabled);
+    // Apply the enabled set to every bound exec via cudaGraphNodeSetEnabled.
+    // Returns the first CUDA error code (0 = success). Diff-based.
+    int  apply_toggle();
+    // Host meta-gate query: true if the hook is enabled AND registered (or
+    // toggle inactive -> all on).
+    bool is_hook_enabled(int hook_type, int layer_no) const;
+    // Batched is_hook_enabled: one entry per query, same semantics. Lets the
+    // per-reconfigure effective-set recompute be ONE pybind crossing instead of
+    // N round-trips; C++ remains the single source of truth.
+    std::vector<int> effective_enabled_mask(
+        const std::vector<std::pair<int,int>>& query) const;
+    // Phase 4 lazy per-graph apply. ensure_graph_current(): apply the current
+    // enabled set to ONE graph if it is stale (call just before that graph
+    // replays). record_replay_event(): record a stream event after that graph's
+    // replay so a later ensure can wait for it before mutating the exec.
+    int  ensure_graph_current(uint64_t graph);
+    void record_replay_event(uint64_t graph);
+    uint64_t toggle_node_count() const;
+    uint64_t bound_graph_count() const;          // #bound execs (0 => apply is a no-op)
+    uint64_t last_apply_count() const;           // #SetEnabled calls in last apply_toggle
+    bool     toggle_registry_uniform() const;    // all graphs share the same hook set
+    // Full reset: registry, exec map, enabled set, toggle_active, capture flag,
+    // and Phase-4 lazy state (versions + per-graph replay events).
+    void clear_toggle_registry();
 
 private:
     struct Impl;

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -88,7 +88,7 @@ public:
     // Space must be guaranteed by pre-forward capacity check.
     // Three variants matching the three torch ops.
 
-    // Static: copies all `nbytes`; today's behavior.
+    // Static: copies all `nbytes`.
     void hook_no_notify(uint64_t d_ptr, uint64_t nbytes,
                         uint32_t hook_type,
                         uint64_t stream_handle);
@@ -183,7 +183,7 @@ public:
     // Snapshot the live ring head/tail counters (reserve-invariant probe).
     RingFlushStats get_stats() const;
 
-    // ---- Runtime node-toggle (Phase B) -----------------------------------
+    // ---- Runtime node-toggle -----------------------------------
     // cudaGraph_t / cudaGraphNode_t / cudaGraphExec_t are passed as opaque
     // uint64_t so this header stays CUDA-free (it is included by the
     // g++-compiled bindings.cpp). The enabled (hook_type, layer_no) set is the
@@ -215,7 +215,7 @@ public:
     // N round-trips; C++ remains the single source of truth.
     std::vector<int> effective_enabled_mask(
         const std::vector<std::pair<int,int>>& query) const;
-    // Phase 4 lazy per-graph apply. ensure_graph_current(): apply the current
+    // Lazy per-graph apply. ensure_graph_current(): apply the current
     // enabled set to ONE graph if it is stale (call just before that graph
     // replays). record_replay_event(): record a stream event after that graph's
     // replay so a later ensure can wait for it before mutating the exec.
@@ -244,7 +244,7 @@ public:
     // activation so a partial/mismatched bind fails loud instead of desyncing.
     bool     toggle_registry_complete() const;
     // Full reset: registry, exec map, enabled set, toggle_active, capture flag,
-    // and Phase-4 lazy state (versions + per-graph replay events).
+    // and lazy state (versions + per-graph replay events).
     void clear_toggle_registry();
 
 private:

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -216,7 +216,14 @@ public:
     // replays). record_replay_event(): record a stream event after that graph's
     // replay so a later ensure can wait for it before mutating the exec.
     int  ensure_graph_current(uint64_t graph);
-    void record_replay_event(uint64_t graph);
+    // Returns the CUDA error from event create/record (0 = ok). Nonzero must be
+    // treated as FATAL by the caller (a missing/stale replay event would let a
+    // later ensure mutate an executing exec -> UB).
+    int  record_replay_event(uint64_t graph);
+    // Test-only: force ensure_graph_current to fail with `code` (0 disables);
+    // and query whether a graph's applied_version == target_version.
+    void _test_force_apply_error(int code);
+    bool _test_applied_current(uint64_t graph) const;
     uint64_t toggle_node_count() const;
     uint64_t bound_graph_count() const;          // #bound execs (0 => apply is a no-op)
     uint64_t last_apply_count() const;           // #SetEnabled calls in last apply_toggle

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -196,6 +196,10 @@ public:
     bool toggle_capture_enabled() const;
     // Called from the producer op during capture (C++ only, not bound).
     void register_capture_node(uint64_t graph, int hook_type, int layer_no, uint64_t node);
+    // Called from the producer op during capture when the recorded tail node is
+    // NOT a kernel node (could not be the producer) -> fail-closed signal.
+    void note_capture_anomaly();
+    uint64_t capture_anomaly_count() const;     // >0 => registry suspect, refuse to activate
     // Bind a captured graph to its instantiated exec (post-warmup).
     void bind_graph_exec(uint64_t graph, uint64_t exec);
     // Set the enabled (hook_type, layer_no) set (the single source).

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -202,6 +202,10 @@ public:
     uint64_t capture_anomaly_count() const;     // >0 => registry suspect, refuse to activate
     // Bind a captured graph to its instantiated exec (post-warmup).
     void bind_graph_exec(uint64_t graph, uint64_t exec);
+    // Bumped by every registry mutation (capture flag, node recording, anomaly,
+    // bind, clear). The host caches its registry-guard verdict keyed on this,
+    // so a cached "valid" can never survive a mutation.
+    uint64_t toggle_registry_version() const;
     // Set the enabled (hook_type, layer_no) set (the single source).
     void set_enabled_hooks(const std::vector<std::pair<int,int>>& enabled);
     // Apply the enabled set to every bound exec via cudaGraphNodeSetEnabled.

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -39,6 +39,20 @@ struct RingConfig {
     uint64_t insert_queue_max_items     = 65536;
 };
 
+// Live ring flow-control counters (debug / reserve-invariant probe).
+// payload/task *_head advance on reserve() (prepare_step); *_tail_committed
+// advance as the drain thread consumes ACTUAL producer task entries. A
+// monotonically growing (head - tail_committed) gap means reserve() over-counts
+// vs what producers actually write (e.g. node-toggle reserving for disabled
+// hooks) -- the reserve invariant is held iff the ring fully drains to
+// head == tail_committed after a flush.
+struct RingFlushStats {
+    uint64_t cpu_payload_head{0};
+    uint64_t cpu_payload_tail_committed{0};
+    uint64_t cpu_task_head{0};
+    uint64_t cpu_task_tail_committed{0};
+};
+
 // Called by the p2p thread for each per-request tensor slice.
 using SubmitFn = std::function<void(
     const std::string& model_id,
@@ -165,6 +179,9 @@ public:
     // GIL.  Used by safety-net branches that need to free ring space or
     // ensure FIFO ordering before consuming the next meta out-of-band.
     void flush_and_wait();
+
+    // Snapshot the live ring head/tail counters (reserve-invariant probe).
+    RingFlushStats get_stats() const;
 
     // ---- Runtime node-toggle (Phase B) -----------------------------------
     // cudaGraph_t / cudaGraphNode_t / cudaGraphExec_t are passed as opaque

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -221,6 +221,17 @@ public:
     uint64_t bound_graph_count() const;          // #bound execs (0 => apply is a no-op)
     uint64_t last_apply_count() const;           // #SetEnabled calls in last apply_toggle
     bool     toggle_registry_uniform() const;    // all graphs share the same hook set
+    // Read-only replay-time guard (eager + lazy): a graph is "ready" iff it has
+    // recorded producer nodes AND a bound exec. A graph vLLM captured at RUNTIME
+    // (new batch_descriptor, after the warmup capture window closed) is neither,
+    // so its producers run default-ON while the meta gate filters -> desync. The
+    // replay hook calls this and fails loud. NO version bump / event wait / node
+    // mutation -- pure validation (distinct from ensure_graph_current).
+    bool     is_graph_ready(uint64_t graph) const;
+    // True iff the node-registry and exec-binding key sets match EXACTLY (every
+    // captured graph is bound, every bound graph has nodes). Checked at
+    // activation so a partial/mismatched bind fails loud instead of desyncing.
+    bool     toggle_registry_complete() const;
     // Full reset: registry, exec map, enabled set, toggle_active, capture flag,
     // and Phase-4 lazy state (versions + per-graph replay events).
     void clear_toggle_registry();

--- a/monitoring/csrc/ring/ring_engine_py.h
+++ b/monitoring/csrc/ring/ring_engine_py.h
@@ -88,7 +88,7 @@ public:
     // Space must be guaranteed by pre-forward capacity check.
     // Three variants matching the three torch ops.
 
-    // Static: copies all `nbytes`.
+    // Static: copies all `nbytes`; today's behavior.
     void hook_no_notify(uint64_t d_ptr, uint64_t nbytes,
                         uint32_t hook_type,
                         uint64_t stream_handle);

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -113,10 +113,22 @@ void ring_producer_impl(
             if (cudaStreamGetCaptureInfo(stream.stream(), &cap_st, &cap_id, &cap_graph,
                                          &cap_deps, &cap_edges, &cap_nd) == cudaSuccess
                 && cap_st == cudaStreamCaptureStatusActive && cap_nd >= 1) {
-                g_active_engine->register_capture_node(
-                    reinterpret_cast<uint64_t>(cap_graph),
-                    static_cast<int>(hook_type), static_cast<int>(hook_id),
-                    reinterpret_cast<uint64_t>(cap_deps[cap_nd - 1]));
+                // The producer is a single kernel launch, so the capture tail
+                // dependency should be a kernel node. Validate it (fail-closed):
+                // if the tail node is NOT a kernel (multi-op producer, capture
+                // event-join, or unexpected topology), do NOT register a wrong
+                // node -- flag an anomaly so set_active_hooks refuses to activate.
+                cudaGraphNode_t node = cap_deps[cap_nd - 1];
+                cudaGraphNodeType ntype;
+                if (cudaGraphNodeGetType(node, &ntype) == cudaSuccess
+                    && ntype == cudaGraphNodeTypeKernel) {
+                    g_active_engine->register_capture_node(
+                        reinterpret_cast<uint64_t>(cap_graph),
+                        static_cast<int>(hook_type), static_cast<int>(hook_id),
+                        reinterpret_cast<uint64_t>(node));
+                } else {
+                    g_active_engine->note_capture_anomaly();
+                }
             }
         }
     }

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -42,6 +42,48 @@ void ring_set_active_engine(ring_py::RingEnginePy* e) {
     if (e == nullptr) ring_set_toggle_capture(false);
 }
 
+// Node-toggle capture: record THIS producer's kernel node (the current capture
+// tail dependency) so it can be enabled/disabled post-capture via
+// cudaGraphNodeSetEnabled. No-op outside the capture window.
+//   supported=true  (basic + prefix producers): each is a single kernel launch,
+//     so the tail dependency is its kernel node. Validate it (fail-closed): a
+//     non-kernel tail (multi-op producer / capture event-join) must NOT be
+//     registered as a wrong node.
+//   supported=false (chunked/MoE producer): node-toggle does not manage this
+//     producer in the current prefix-path implementation. Flag an anomaly so
+//     set_active_hooks fails loud instead of leaving a fired-but-unregistered
+//     producer (which would desync). Use gpu_padding_strip=False (all-basic)
+//     to run toggle on MoE.
+static void dmx_record_capture_node(cudaStream_t stream, int hook_type,
+                                    int hook_id, bool supported) {
+    if (!g_toggle_capture || !g_active_engine) return;
+    cudaStreamCaptureStatus  cap_st    = cudaStreamCaptureStatusNone;
+    unsigned long long       cap_id    = 0;
+    cudaGraph_t              cap_graph = nullptr;
+    const cudaGraphNode_t*   cap_deps  = nullptr;
+    const cudaGraphEdgeData* cap_edges = nullptr;  // CUDA 13 signature
+    size_t                   cap_nd    = 0;
+    if (cudaStreamGetCaptureInfo(stream, &cap_st, &cap_id, &cap_graph,
+                                 &cap_deps, &cap_edges, &cap_nd) != cudaSuccess
+        || cap_st != cudaStreamCaptureStatusActive || cap_nd < 1) {
+        return;
+    }
+    if (!supported) {
+        g_active_engine->note_capture_anomaly();
+        return;
+    }
+    cudaGraphNode_t node = cap_deps[cap_nd - 1];
+    cudaGraphNodeType ntype;
+    if (cudaGraphNodeGetType(node, &ntype) == cudaSuccess
+        && ntype == cudaGraphNodeTypeKernel) {
+        g_active_engine->register_capture_node(
+            reinterpret_cast<uint64_t>(cap_graph), hook_type, hook_id,
+            reinterpret_cast<uint64_t>(node));
+    } else {
+        g_active_engine->note_capture_anomaly();
+    }
+}
+
 // Three side-effect ops, one per use case:
 //
 //   ring::producer(x, hook_type, hook_id)
@@ -98,39 +140,9 @@ void ring_producer_impl(
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
 
-        // Node-toggle (option B: basic producer only -- toggle requires
-        // gpu_padding_strip=False so every hook dispatches here, not to
-        // producer_prefix/producer_chunked). If capturing, record THIS
-        // producer's kernel node (the current tail dependency) so it can be
-        // enabled/disabled post-capture via cudaGraphNodeSetEnabled.
-        if (g_toggle_capture) {
-            cudaStreamCaptureStatus  cap_st    = cudaStreamCaptureStatusNone;
-            unsigned long long       cap_id    = 0;
-            cudaGraph_t              cap_graph = nullptr;
-            const cudaGraphNode_t*   cap_deps  = nullptr;
-            const cudaGraphEdgeData* cap_edges = nullptr;  // CUDA 13 signature
-            size_t                   cap_nd    = 0;
-            if (cudaStreamGetCaptureInfo(stream.stream(), &cap_st, &cap_id, &cap_graph,
-                                         &cap_deps, &cap_edges, &cap_nd) == cudaSuccess
-                && cap_st == cudaStreamCaptureStatusActive && cap_nd >= 1) {
-                // The producer is a single kernel launch, so the capture tail
-                // dependency should be a kernel node. Validate it (fail-closed):
-                // if the tail node is NOT a kernel (multi-op producer, capture
-                // event-join, or unexpected topology), do NOT register a wrong
-                // node -- flag an anomaly so set_active_hooks refuses to activate.
-                cudaGraphNode_t node = cap_deps[cap_nd - 1];
-                cudaGraphNodeType ntype;
-                if (cudaGraphNodeGetType(node, &ntype) == cudaSuccess
-                    && ntype == cudaGraphNodeTypeKernel) {
-                    g_active_engine->register_capture_node(
-                        reinterpret_cast<uint64_t>(cap_graph),
-                        static_cast<int>(hook_type), static_cast<int>(hook_id),
-                        reinterpret_cast<uint64_t>(node));
-                } else {
-                    g_active_engine->note_capture_anomaly();
-                }
-            }
-        }
+        // Node-toggle: record this basic producer's kernel node (if capturing).
+        dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
+                                static_cast<int>(hook_id), /*supported=*/true);
     }
 }
 
@@ -155,6 +167,11 @@ void ring_producer_prefix_impl(
             static_cast<uint64_t>(row_bytes),
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
+
+        // Node-toggle (Option A, prefix path): record the prefix producer's
+        // kernel node so toggle works with gpu_padding_strip on (dense hooks).
+        dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
+                                static_cast<int>(hook_id), /*supported=*/true);
     }
 }
 
@@ -180,6 +197,12 @@ void ring_producer_chunked_impl(
             K,
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
+
+        // Node-toggle does not manage chunked/MoE producers in the prefix-path
+        // implementation -> flag (fail-closed): set_active_hooks will refuse to
+        // activate. Run toggle on MoE with gpu_padding_strip=False (all-basic).
+        dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
+                                static_cast<int>(hook_id), /*supported=*/false);
     }
 }
 

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -28,8 +28,18 @@ void ring_diag_print_host_counters() {
     fprintf(stderr, "  total=%lu\n", total);
 }
 
+// Node-toggle capture flag (process-global, like g_active_engine). Set true
+// only during the warmup CUDA-graph capture window via ring_set_toggle_capture.
+static bool g_toggle_capture = false;
+void ring_set_toggle_capture(bool enabled) {
+    g_toggle_capture = enabled;
+}
+
 void ring_set_active_engine(ring_py::RingEnginePy* e) {
     g_active_engine = e;
+    // Deactivation must also disable capture: g_toggle_capture is process-global,
+    // so a stale "true" after the engine is cleared would record into nothing (#3).
+    if (e == nullptr) ring_set_toggle_capture(false);
 }
 
 // Three side-effect ops, one per use case:
@@ -87,6 +97,28 @@ void ring_producer_impl(
             static_cast<uint64_t>(tensor.nbytes()),
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
+
+        // Node-toggle (option B: basic producer only -- toggle requires
+        // gpu_padding_strip=False so every hook dispatches here, not to
+        // producer_prefix/producer_chunked). If capturing, record THIS
+        // producer's kernel node (the current tail dependency) so it can be
+        // enabled/disabled post-capture via cudaGraphNodeSetEnabled.
+        if (g_toggle_capture) {
+            cudaStreamCaptureStatus  cap_st    = cudaStreamCaptureStatusNone;
+            unsigned long long       cap_id    = 0;
+            cudaGraph_t              cap_graph = nullptr;
+            const cudaGraphNode_t*   cap_deps  = nullptr;
+            const cudaGraphEdgeData* cap_edges = nullptr;  // CUDA 13 signature
+            size_t                   cap_nd    = 0;
+            if (cudaStreamGetCaptureInfo(stream.stream(), &cap_st, &cap_id, &cap_graph,
+                                         &cap_deps, &cap_edges, &cap_nd) == cudaSuccess
+                && cap_st == cudaStreamCaptureStatusActive && cap_nd >= 1) {
+                g_active_engine->register_capture_node(
+                    reinterpret_cast<uint64_t>(cap_graph),
+                    static_cast<int>(hook_type), static_cast<int>(hook_id),
+                    reinterpret_cast<uint64_t>(cap_deps[cap_nd - 1]));
+            }
+        }
     }
 }
 

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -99,7 +99,7 @@ static void dmx_record_capture_node(cudaStream_t stream, int hook_type,
 // Three side-effect ops, one per use case:
 //
 //   ring::producer(x, hook_type, hook_id)
-//     Static path; copies all of x.nbytes().
+//     Static path; copies all of x.nbytes(); today's behavior.
 //
 //   ring::producer_prefix(x, row_count, row_bytes, hook_type, hook_id)
 //     Reads row_count[0] from device at kernel start; copies

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -38,14 +38,14 @@ void ring_set_toggle_capture(bool enabled) {
 void ring_set_active_engine(ring_py::RingEnginePy* e) {
     g_active_engine = e;
     // Deactivation must also disable capture: g_toggle_capture is process-global,
-    // so a stale "true" after the engine is cleared would record into nothing (#3).
+    // so a stale "true" after the engine is cleared would record into nothing.
     if (e == nullptr) ring_set_toggle_capture(false);
 }
 
 // Three side-effect ops, one per use case:
 //
 //   ring::producer(x, hook_type, hook_id)
-//     Static path; copies all of x.nbytes(); today's behavior.
+//     Static path; copies all of x.nbytes().
 //
 //   ring::producer_prefix(x, row_count, row_bytes, hook_type, hook_id)
 //     Reads row_count[0] from device at kernel start; copies

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -50,10 +50,8 @@ void ring_set_active_engine(ring_py::RingEnginePy* e) {
 //     non-kernel tail (multi-op producer / capture event-join) must NOT be
 //     registered as a wrong node.
 //   supported=false (chunked producer): node-toggle does not manage this
-//     producer in the current prefix-path implementation. Flag an anomaly so
-//     set_active_hooks fails loud instead of leaving a fired-but-unregistered
-//     producer (which would desync). (The vLLM adapter never dispatches chunked
-//     today -- it is dormant infra; this is a fail-closed guard for it.)
+//     producer. Flag an anomaly so set_active_hooks fails loud instead of
+//     leaving a fired-but-unregistered producer (which would desync).
 //
 // Fail-closed: any state where the producer fired under capture but we could
 // NOT record its node flags an anomaly (capture-info read failed, or capturing
@@ -182,8 +180,8 @@ void ring_producer_prefix_impl(
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
 
-        // Node-toggle (Option A, prefix path): record the prefix producer's
-        // kernel node so toggle works with gpu_padding_strip on (dense hooks).
+        // Node-toggle: record the prefix producer's kernel node so the
+        // toggle composes with gpu_padding_strip.
         dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
                                 static_cast<int>(hook_id), /*supported=*/true);
     }
@@ -212,11 +210,9 @@ void ring_producer_chunked_impl(
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
 
-        // Node-toggle does not manage the chunked producer in the prefix-path
-        // implementation -> flag (fail-closed): set_active_hooks will refuse to
-        // activate. (The vLLM adapter never dispatches chunked today; this guards
-        // any future/manual use. dmx_gpu_padding_strip=False routes everything to
-        // the basic producer.)
+        // Node-toggle does not manage the chunked producer -> flag
+        // (fail-closed): set_active_hooks will refuse to activate.
+        // dmx_gpu_padding_strip=False routes every hook to the basic producer.
         dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
                                 static_cast<int>(hook_id), /*supported=*/false);
     }

--- a/monitoring/csrc/ring/ring_torch_op.cpp
+++ b/monitoring/csrc/ring/ring_torch_op.cpp
@@ -49,11 +49,16 @@ void ring_set_active_engine(ring_py::RingEnginePy* e) {
 //     so the tail dependency is its kernel node. Validate it (fail-closed): a
 //     non-kernel tail (multi-op producer / capture event-join) must NOT be
 //     registered as a wrong node.
-//   supported=false (chunked/MoE producer): node-toggle does not manage this
+//   supported=false (chunked producer): node-toggle does not manage this
 //     producer in the current prefix-path implementation. Flag an anomaly so
 //     set_active_hooks fails loud instead of leaving a fired-but-unregistered
-//     producer (which would desync). Use gpu_padding_strip=False (all-basic)
-//     to run toggle on MoE.
+//     producer (which would desync). (The vLLM adapter never dispatches chunked
+//     today -- it is dormant infra; this is a fail-closed guard for it.)
+//
+// Fail-closed: any state where the producer fired under capture but we could
+// NOT record its node flags an anomaly (capture-info read failed, or capturing
+// with no tail dependency). The one silent case is "not actively capturing"
+// (status != Active) -- that's a legitimate eager warmup run, not a graph node.
 static void dmx_record_capture_node(cudaStream_t stream, int hook_type,
                                     int hook_id, bool supported) {
     if (!g_toggle_capture || !g_active_engine) return;
@@ -63,9 +68,18 @@ static void dmx_record_capture_node(cudaStream_t stream, int hook_type,
     const cudaGraphNode_t*   cap_deps  = nullptr;
     const cudaGraphEdgeData* cap_edges = nullptr;  // CUDA 13 signature
     size_t                   cap_nd    = 0;
-    if (cudaStreamGetCaptureInfo(stream, &cap_st, &cap_id, &cap_graph,
-                                 &cap_deps, &cap_edges, &cap_nd) != cudaSuccess
-        || cap_st != cudaStreamCaptureStatusActive || cap_nd < 1) {
+    cudaError_t ce = cudaStreamGetCaptureInfo(stream, &cap_st, &cap_id, &cap_graph,
+                                              &cap_deps, &cap_edges, &cap_nd);
+    if (ce != cudaSuccess) {
+        // In the capture window but can't read capture state -> can't confirm
+        // the node was recorded. Fail closed. (A healthy non-capturing stream
+        // returns success with status=None, so this is a genuine error.)
+        g_active_engine->note_capture_anomaly();
+        return;
+    }
+    if (cap_st != cudaStreamCaptureStatusActive) return;  // eager run, not a node
+    if (cap_nd < 1) {                                     // capturing, no tail dep -> abnormal
+        g_active_engine->note_capture_anomaly();
         return;
     }
     if (!supported) {
@@ -198,9 +212,11 @@ void ring_producer_chunked_impl(
             static_cast<uint32_t>(hook_type),
             reinterpret_cast<uint64_t>(stream.stream()));
 
-        // Node-toggle does not manage chunked/MoE producers in the prefix-path
+        // Node-toggle does not manage the chunked producer in the prefix-path
         // implementation -> flag (fail-closed): set_active_hooks will refuse to
-        // activate. Run toggle on MoE with gpu_padding_strip=False (all-basic).
+        // activate. (The vLLM adapter never dispatches chunked today; this guards
+        // any future/manual use. dmx_gpu_padding_strip=False routes everything to
+        // the basic producer.)
         dmx_record_capture_node(stream.stream(), static_cast<int>(hook_type),
                                 static_cast<int>(hook_id), /*supported=*/false);
     }

--- a/monitoring/csrc/ring/ring_torch_op.h
+++ b/monitoring/csrc/ring/ring_torch_op.h
@@ -8,3 +8,9 @@
 void ring_set_active_engine(ring_py::RingEnginePy* e);
 void ring_diag_reset_host_counters();
 void ring_diag_print_host_counters();
+
+// Node-toggle capture window. When enabled, each producer op records the
+// kernel node it just enqueued (via cudaStreamGetCaptureInfo) into the active
+// engine's toggle registry, so it can be enabled/disabled post-capture with
+// cudaGraphNodeSetEnabled. Default off -> producer path is unchanged.
+void ring_set_toggle_capture(bool enabled);

--- a/monitoring/csrc/ring/toggle_registry.cu
+++ b/monitoring/csrc/ring/toggle_registry.cu
@@ -1,0 +1,279 @@
+#include "toggle_registry.h"
+
+namespace ring_py {
+
+ToggleRegistry::~ToggleRegistry() {
+    for (auto& kv : replay_event_) if (kv.second) cudaEventDestroy(kv.second);
+}
+
+void ToggleRegistry::set_capture(bool enabled) {
+    std::lock_guard<std::mutex> lk(mu_);
+    toggle_capture_ = enabled;
+    ++version_;
+}
+
+bool ToggleRegistry::capture_enabled() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return toggle_capture_;
+}
+
+void ToggleRegistry::register_node(uint64_t graph, int hook_type, int layer_no, uint64_t node) {
+    std::lock_guard<std::mutex> lk(mu_);
+    reg_nodes_[reinterpret_cast<cudaGraph_t>(graph)].push_back(
+        RegEntry{hook_type, layer_no, reinterpret_cast<cudaGraphNode_t>(node)});
+    registered_hooks_.insert({hook_type, layer_no});
+    ++version_;
+}
+
+void ToggleRegistry::note_anomaly() {
+    std::lock_guard<std::mutex> lk(mu_);
+    ++anomaly_;
+    ++version_;
+}
+
+uint64_t ToggleRegistry::anomaly_count() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return anomaly_;
+}
+
+void ToggleRegistry::bind_exec(uint64_t graph, uint64_t exec) {
+    std::lock_guard<std::mutex> lk(mu_);
+    reg_exec_[reinterpret_cast<cudaGraph_t>(graph)] =
+        reinterpret_cast<cudaGraphExec_t>(exec);
+    ++version_;
+}
+
+uint64_t ToggleRegistry::version() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return version_;
+}
+
+void ToggleRegistry::set_enabled(const std::vector<std::pair<int,int>>& enabled) {
+    std::lock_guard<std::mutex> lk(mu_);
+    enabled_hooks_.clear();
+    for (const auto& p : enabled) enabled_hooks_.insert(p);
+    toggle_active_ = true;
+    ++target_version_;   // mark all graphs stale for lazy ensure (no-op for eager)
+}
+
+int ToggleRegistry::apply_all() {
+    std::lock_guard<std::mutex> lk(mu_);
+    cudaError_t first = cudaSuccess;
+    uint64_t applied = 0;
+    for (auto& kv : reg_exec_) {
+        cudaGraphExec_t exec = kv.second;
+        auto it = reg_nodes_.find(kv.first);
+        if (it == reg_nodes_.end()) continue;
+        for (auto& e : it->second) {
+            const bool on = enabled_hooks_.count({e.hook_type, e.layer_no}) > 0;
+            // Diff: only touch nodes whose desired state changed since the last
+            // apply (last_enabled tracks the exec's actual state -- DMI is the
+            // only toggler of its nodes). Adaptive flips of a few hooks then cost
+            // O(#changed) SetEnabled calls instead of O(#nodes).
+            if (on == e.last_enabled) continue;
+            cudaError_t err = cudaGraphNodeSetEnabled(exec, e.node, on ? 1u : 0u);
+            if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
+            e.last_enabled = on;   // update only on success
+            ++applied;
+        }
+    }
+    last_apply_count_ = applied;
+    return static_cast<int>(first);
+}
+
+uint64_t ToggleRegistry::bound_count() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return reg_exec_.size();
+}
+
+uint64_t ToggleRegistry::node_count() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    uint64_t n = 0;
+    for (const auto& kv : reg_nodes_) n += kv.second.size();
+    return n;
+}
+
+uint64_t ToggleRegistry::last_apply_count() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return last_apply_count_;
+}
+
+bool ToggleRegistry::uniform() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    // True iff every captured graph registered the same set of (hook_type,layer).
+    // The meta gate keys on (ht,layer) globally; if graphs differ, a hook present
+    // in one graph but absent from the one replayed this step would push a meta
+    // with no payload -> desync.
+    const std::set<std::pair<int,int>>* ref = nullptr;
+    std::set<std::pair<int,int>> ref_set;
+    for (const auto& kv : reg_nodes_) {
+        std::set<std::pair<int,int>> s;
+        for (const auto& e : kv.second) s.insert({e.hook_type, e.layer_no});
+        if (!ref) { ref_set = std::move(s); ref = &ref_set; }
+        else if (s != ref_set) return false;
+    }
+    return true;
+}
+
+bool ToggleRegistry::complete() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    // Exact key-set match: every captured graph bound AND every bound graph
+    // captured. Equal sizes + every reg_nodes key present in reg_exec ⟹
+    // bijection (both keyed by unique cudaGraph_t).
+    if (reg_nodes_.size() != reg_exec_.size()) return false;
+    for (const auto& kv : reg_nodes_)
+        if (reg_exec_.count(kv.first) == 0) return false;
+    return true;
+}
+
+bool ToggleRegistry::is_ready(uint64_t graph) const {
+    std::lock_guard<std::mutex> lk(mu_);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    return reg_nodes_.count(g) > 0 && reg_exec_.count(g) > 0;
+}
+
+bool ToggleRegistry::is_enabled(int hook_type, int layer_no) const {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (!toggle_active_) return true;   // toggle inactive -> all hooks on
+    // Desync guard: the meta gate returns true only if the hook is BOTH
+    // enabled AND actually registered (has a captured producer node). Otherwise
+    // an enabled-but-uncaptured hook would push a meta with no matching payload
+    // -> p2p desync. With this, "meta pushed" <=> "a producer fires" in all cases.
+    const std::pair<int,int> k{hook_type, layer_no};
+    return enabled_hooks_.count(k) > 0 && registered_hooks_.count(k) > 0;
+}
+
+std::vector<int> ToggleRegistry::effective_mask(
+    const std::vector<std::pair<int,int>>& query) const {
+    // Batched is_enabled (same semantics, one lock, one pybind crossing):
+    // toggle inactive -> all on; else enabled AND registered.
+    std::lock_guard<std::mutex> lk(mu_);
+    const bool inactive = !toggle_active_;
+    std::vector<int> mask;
+    mask.reserve(query.size());
+    for (const auto& k : query) {
+        mask.push_back((inactive ||
+                        (enabled_hooks_.count(k) > 0 &&
+                         registered_hooks_.count(k) > 0)) ? 1 : 0);
+    }
+    return mask;
+}
+
+int ToggleRegistry::ensure_current(uint64_t graph) {
+    // Lazy: apply the current enabled set to ONE graph, only if it is
+    // stale (applied_version != target_version). Called just before that graph
+    // replays. Same per-node diff as apply_all, but scoped to one graph.
+    std::lock_guard<std::mutex> lk(mu_);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    auto av = applied_version_.find(g);
+    const uint64_t cur = (av == applied_version_.end()) ? 0 : av->second;
+    if (cur == target_version_) return 0;   // current -> fast no-op (common path)
+
+    auto ex = reg_exec_.find(g);
+    if (ex == reg_exec_.end()) return 0;     // unregistered/unbound graph -> skip
+    auto it = reg_nodes_.find(g);
+    if (it == reg_nodes_.end()) return 0;
+
+    // Test fault injection: fail before any mutation / version bump.
+    if (force_apply_error_ != 0) return force_apply_error_;
+
+    // Event guard: the prior replay of THIS exec must be complete before we
+    // mutate it (host can run ahead of the GPU). Wait on its last-replay event.
+    // If the wait itself fails we CANNOT confirm the prior replay finished,
+    // so do NOT touch the exec -- return the error; the caller treats it as a
+    // FATAL desync risk. No nodes mutated, version left stale.
+    auto ev = replay_event_.find(g);
+    if (ev != replay_event_.end() && ev->second) {
+        cudaError_t se = cudaEventSynchronize(ev->second);
+        if (se != cudaSuccess) return static_cast<int>(se);
+    }
+
+    cudaError_t first = cudaSuccess;
+    for (auto& e : it->second) {
+        const bool on = enabled_hooks_.count({e.hook_type, e.layer_no}) > 0;
+        if (on == e.last_enabled) continue;
+        cudaError_t err = cudaGraphNodeSetEnabled(ex->second, e.node, on ? 1u : 0u);
+        if (err != cudaSuccess) { if (first == cudaSuccess) first = err; continue; }
+        e.last_enabled = on;
+    }
+    // Mark this graph current ONLY on full success. If any SetEnabled
+    // failed, leave applied_version stale so a later ensure retries the
+    // still-unapplied nodes (last_enabled already tracks per-node success, so
+    // the retry is a no-op for the ones that did flip). The caller (replay
+    // hook) treats a nonzero return as a FATAL desync and terminates, but the
+    // stale version is the correct state regardless.
+    if (first == cudaSuccess)
+        applied_version_[g] = target_version_;
+    return static_cast<int>(first);
+}
+
+int ToggleRegistry::record_replay_event(uint64_t graph, cudaStream_t stream) {
+    // Record a (timing-disabled) event on the given stream right after a
+    // graph's replay, so a later ensure_current() can wait for it before
+    // mutating that exec. Returns the CUDA error: if event create OR record
+    // fails, the stored event would be stale/missing and a later ensure could
+    // wrongly believe a prior replay finished -> mutate an executing exec (UB).
+    // The caller treats nonzero as FATAL so we never reach that state.
+    std::lock_guard<std::mutex> lk(mu_);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    if (reg_exec_.find(g) == reg_exec_.end()) return 0;  // not bound -> nothing to track
+    cudaEvent_t& ev = replay_event_[g];
+    if (ev == nullptr) {
+        cudaError_t ce = cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
+        if (ce != cudaSuccess) { ev = nullptr; return static_cast<int>(ce); }
+    }
+    cudaError_t re = cudaEventRecord(ev, stream);
+    return static_cast<int>(re);
+}
+
+void ToggleRegistry::clear() {
+    std::lock_guard<std::mutex> lk(mu_);
+    // Restore device state BEFORE dropping the registry: re-enable any node
+    // we disabled, so a graph that keeps replaying after a clear does not run
+    // with producers OFF while the (now-inactive) host gate pushes all metas
+    // -> desync. Best-effort, only for bound execs; safe at the quiescent
+    // call sites (warmup-start / teardown, no replay in flight). To revert to
+    // all-on DURING serving, prefer an all-on enabled set (event-guarded)
+    // over clear.
+    for (auto& kv : reg_nodes_) {
+        auto ex = reg_exec_.find(kv.first);
+        if (ex == reg_exec_.end()) continue;
+        for (auto& e : kv.second) {
+            if (e.last_enabled) continue;
+            if (cudaGraphNodeSetEnabled(ex->second, e.node, 1u) == cudaSuccess)
+                e.last_enabled = true;
+        }
+    }
+    reg_nodes_.clear();
+    reg_exec_.clear();
+    registered_hooks_.clear();
+    // Full reset: also drop the enabled set + deactivate, so a stale gate
+    // (is_enabled) can't skip every meta after a clear. Disable capture too
+    // so a later capture doesn't record into a cleared registry.
+    enabled_hooks_.clear();
+    toggle_active_ = false;
+    toggle_capture_ = false;
+    last_apply_count_ = 0;
+    anomaly_ = 0;
+    // Lazy state: reset versions + destroy per-graph replay events.
+    target_version_ = 0;
+    applied_version_.clear();
+    for (auto& kv : replay_event_) if (kv.second) cudaEventDestroy(kv.second);
+    replay_event_.clear();
+    ++version_;
+}
+
+void ToggleRegistry::force_apply_error(int code) {
+    std::lock_guard<std::mutex> lk(mu_);
+    force_apply_error_ = code;
+}
+
+bool ToggleRegistry::applied_current(uint64_t graph) const {
+    std::lock_guard<std::mutex> lk(mu_);
+    cudaGraph_t g = reinterpret_cast<cudaGraph_t>(graph);
+    auto av = applied_version_.find(g);
+    const uint64_t cur = (av == applied_version_.end()) ? 0 : av->second;
+    return cur == target_version_;
+}
+
+}  // namespace ring_py

--- a/monitoring/csrc/ring/toggle_registry.h
+++ b/monitoring/csrc/ring/toggle_registry.h
@@ -1,0 +1,100 @@
+// ToggleRegistry -- all state and CUDA-graph operations for runtime
+// node-toggle, extracted from the ring engine so the engine only delegates.
+//
+// Owns: the capture-time node registry (graph -> producer kernel nodes), the
+// graph->exec bindings, the enabled (hook_type, layer_no) set (SINGLE SOURCE
+// OF TRUTH for host meta gate + device node-enable), the lazy per-graph apply
+// state (target/applied versions + per-graph replay events), the capture
+// anomaly counter, and the registry version every mutation bumps (the host
+// caches guard verdicts keyed on it).
+//
+// Thread-safe: every public method takes the internal mutex. Depends only on
+// the CUDA runtime (the caller passes streams in) -- this header contains CUDA
+// types, so it is included by .cu/.cpp translation units only, never by the
+// CUDA-free ring_engine_py.h.
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <mutex>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace ring_py {
+
+class ToggleRegistry {
+public:
+    ~ToggleRegistry();
+
+    // -- capture window ----------------------------------------------------
+    void set_capture(bool enabled);
+    bool capture_enabled() const;
+    // Called from the producer op during capture (single kernel just enqueued).
+    void register_node(uint64_t graph, int hook_type, int layer_no, uint64_t node);
+    // Called when a capture-time recording could not be validated (non-kernel
+    // tail, unreadable capture state, unsupported producer) -> fail-closed.
+    void note_anomaly();
+    uint64_t anomaly_count() const;
+
+    // -- binding / introspection --------------------------------------------
+    void bind_exec(uint64_t graph, uint64_t exec);
+    uint64_t version() const;          // bumped by EVERY mutation
+    uint64_t bound_count() const;
+    uint64_t node_count() const;
+    uint64_t last_apply_count() const;
+    bool uniform() const;              // all graphs share the same hook set
+    bool complete() const;             // reg_nodes keys == reg_exec keys
+    bool is_ready(uint64_t graph) const;   // registered AND bound
+
+    // -- enabled set + device apply ------------------------------------------
+    void set_enabled(const std::vector<std::pair<int, int>>& enabled);
+    int  apply_all();                  // eager: every bound exec, diff-based
+    bool is_enabled(int hook_type, int layer_no) const;
+    std::vector<int> effective_mask(
+        const std::vector<std::pair<int, int>>& query) const;
+    int  ensure_current(uint64_t graph);                       // lazy, one graph
+    int  record_replay_event(uint64_t graph, cudaStream_t stream);
+    void clear();
+
+    // -- test-only fault injection / introspection ---------------------------
+    void force_apply_error(int code);
+    bool applied_current(uint64_t graph) const;
+
+private:
+    struct RegEntry { int hook_type; int layer_no; cudaGraphNode_t node;
+                      bool last_enabled{true}; };  // device default after instantiate
+    std::unordered_map<cudaGraph_t, std::vector<RegEntry>> reg_nodes_;  // per captured graph
+    std::unordered_map<cudaGraph_t, cudaGraphExec_t>       reg_exec_;   // graph -> exec
+    std::set<std::pair<int,int>>                           registered_hooks_;  // (ht,layer) captured
+    std::set<std::pair<int,int>>                           enabled_hooks_;     // single source
+    bool                                                   toggle_active_{false};
+    bool                                                   toggle_capture_{false};
+    uint64_t                                               last_apply_count_{0};
+    // Lazy per-graph apply: target_version_ bumps on every enabled-set change;
+    // each graph tracks the version it was last applied to. ensure_current()
+    // applies the current enabled set to ONE graph only when stale (just
+    // before that graph replays), so a reconfigure costs
+    // O(changed x graphs-actually-used). replay_event_[g] is recorded after
+    // each replay so ensure can wait for the prior replay to finish before
+    // mutating the exec (SetEnabled on an executing exec is UB).
+    uint64_t                                               target_version_{0};
+    std::unordered_map<cudaGraph_t, uint64_t>              applied_version_;
+    std::unordered_map<cudaGraph_t, cudaEvent_t>           replay_event_;
+    // Test-only fault injection: when nonzero, ensure_current returns this
+    // code as if a device apply failed (no SetEnabled, no version bump).
+    int                                                    force_apply_error_{0};
+    // Count of capture-time recordings whose tail-dependency node was NOT a
+    // kernel node (so it could not be the producer kernel). Nonzero => the
+    // registry may be misaligned; activation fails loud (fail-closed).
+    uint64_t                                               anomaly_{0};
+    // Bumped by EVERY registry mutation (capture flag, node recording,
+    // anomaly, bind, clear), so a host-cached "valid" guard verdict can never
+    // outlive a mutation.
+    uint64_t                                               version_{0};
+    mutable std::mutex                                     mu_;
+};
+
+}  // namespace ring_py

--- a/monitoring/hook_points.py
+++ b/monitoring/hook_points.py
@@ -307,6 +307,18 @@ class HookPoint(nn.Module):
         from . import ring_transport as _rt
         transport = _rt._active_transport
         if transport is not None and transport.force_eager:
+            # Node-toggle: the eager safety net fires producers WITHOUT a graph,
+            # so cudaGraphNodeSetEnabled cannot gate them. On a gated step (a
+            # decode step that overflowed -> force_eager) a disabled hook must
+            # skip here too, or it fires while meta/reserve counted only the
+            # enabled subset -> ring desync. Gate host-side (safe: this branch
+            # is never captured/compiled). The toggle_gate_active short-circuit
+            # keeps the non-toggle eager path (stock prefill) untouched.
+            if (transport.toggle_gate_active
+                    and getattr(transport, "_gated_step", True)
+                    and not transport._ring_engine.is_hook_enabled(
+                        self._ring_hook_type, self._ring_hook_id)):
+                return x_cont
             engine = transport._ring_engine
             if engine is not None:
                 nbytes = x_cont.nbytes

--- a/monitoring/node_toggle.py
+++ b/monitoring/node_toggle.py
@@ -1,0 +1,198 @@
+"""Host-side controller for runtime node-toggle (low-overhead hook configurability).
+
+Owns everything Python-side that the toggle needs beyond the engine bindings:
+the activation guards (with their registry-version cache), the effective-specs
+recompute (with its preset memo), and the eager/lazy reconfigure entry points.
+``RingTransport`` holds one ``NodeToggleController`` lazily and exposes
+one-line delegates, so the transport's diff against a toggle-less tree is just
+the ``effective_specs`` seam.
+
+The engine's enabled-set remains the single source of truth; this controller
+only derives host-side views from it (never the other way around). The lockstep
+invariant -- capacity-reserve == meta-push == device node-enable -- is carried
+by ``transport.effective_specs``, which reads this controller's precomputed
+subset while the gate is active.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid a runtime import cycle with ring_transport
+    from monitoring.ring_transport import HookSpec, RingTransport
+
+
+class NodeToggleController:
+    """One per transport. All state defaults to 'toggle inactive'."""
+
+    def __init__(self, engine, transport: "RingTransport") -> None:
+        self._eng = engine
+        self._transport = transport
+        # True once set_active_hooks[_lazy] ran; the transport's
+        # effective_specs property gates on this.
+        self.gate_active: bool = False
+        # True when the active gate uses the LAZY device-apply path. The
+        # serving-framework replay guard reads this to decide
+        # ensure_graph_current (lazy) vs validate-only (eager).
+        self.lazy_active: bool = False
+        # The precomputed enabled-AND-captured subset of the transport's
+        # active specs (None until first activation). Single source for the
+        # transport's effective_specs while the gate is active.
+        self.effective_enabled_specs: "Optional[List[HookSpec]]" = None
+        self.enabled_version: int = 0   # bumped whenever the enabled set changes
+        # Reconfigure caches, both keyed on the engine's registry version
+        # (bumped by every registry mutation) so neither can serve stale:
+        #   - _guard_valid_version: registry version whose guard validation
+        #     PASSED (failures are never cached).
+        #   - _cache: (registry_version, enabled frozenset) ->
+        #     (active_specs ref, effective list). The stored active_specs
+        #     reference is compared with `is` (the strong ref pins the id).
+        self._guard_valid_version: Optional[int] = None
+        self._cache: dict = {}
+
+    # -- reconfigure entry points ------------------------------------------
+
+    def set_active_hooks(self, enabled: "Iterable[Tuple[int, int]]") -> None:
+        """Eager runtime node-toggle: enable exactly `enabled` (hook_type,
+        layer_no) pairs and disable the rest, NOW.
+
+        Flips the captured producer nodes on every bound exec (apply_toggle)
+        and activates the host meta gate, both driven by the engine's
+        enabled-set (single source of truth) so reserve/meta/device stay in
+        lockstep.
+
+        CONTRACT: eager apply does not wait on replay events, so call only at
+        a quiescent point (no bound-exec replay in flight) -- e.g. once after
+        warmup. For dynamic / per-step reconfigure use set_active_hooks_lazy
+        (event-guarded). Requires producer nodes registered at capture + execs
+        bound.
+        """
+        self._validate_registry("set_active_hooks")
+        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
+        self._eng.set_enabled_hooks(pairs)
+        err = self._eng.apply_toggle()
+        if err != 0:
+            raise RuntimeError(f"apply_toggle failed with CUDA error {err}")
+        self.gate_active = True
+        self.lazy_active = False
+        self._recompute(pairs)
+
+    def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
+        """Lazy reconfigure: update the enabled set + host meta gate, but
+        DEFER the device apply to per-graph ensure_graph_current() (called
+        just before each graph replays). set_enabled_hooks bumps the engine's
+        target_version, marking every captured graph stale; the device flip
+        then happens lazily, only on graphs actually replayed. Same guards +
+        gate semantics as set_active_hooks, minus apply_toggle.
+        """
+        self._validate_registry("set_active_hooks_lazy")
+        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
+        self._eng.set_enabled_hooks(pairs)   # bumps target_version; apply deferred
+        self.gate_active = True
+        self.lazy_active = True
+        self._recompute(pairs)
+
+    def clear(self) -> None:
+        """Paired teardown: clear the engine's toggle registry AND deactivate
+        the host gate, so neither lane is left half-configured. Call before a
+        re-capture or when disabling monitoring."""
+        self._eng.clear_toggle_registry()
+        self.gate_active = False
+        self.lazy_active = False
+        self.effective_enabled_specs = None
+        self.enabled_version += 1
+        self._guard_valid_version = None
+        self._cache.clear()
+
+    # -- replay-time hooks (used by the serving-framework replay guard) -----
+
+    def is_graph_ready(self, raw_graph: int) -> bool:
+        """Read-only replay-time guard: True iff the graph has recorded
+        producer nodes AND a bound exec. False for a graph the serving
+        framework captured at runtime after the warmup window closed -> the
+        replay hook fails loud."""
+        return self._eng.is_graph_ready(raw_graph)
+
+    def ensure_graph_current(self, raw_graph: int) -> int:
+        """Lazy: apply the deferred toggle to the graph about to replay (no-op
+        if already current). Call right before the graph's replay; raw_graph
+        is the cudaGraph_t handle the graph was bound with."""
+        return self._eng.ensure_graph_current(raw_graph)
+
+    def record_replay_event(self, raw_graph: int) -> int:
+        """Lazy event guard: record a stream event after a graph's replay so a
+        later ensure_graph_current() waits for it before mutating that exec.
+        Returns the CUDA error (0 = ok); nonzero is FATAL (a missing event
+        would let a later ensure mutate an executing exec)."""
+        return self._eng.record_replay_event(raw_graph)
+
+    # -- internals -----------------------------------------------------------
+
+    def _validate_registry(self, who: str) -> None:
+        """Registry guards shared by set_active_hooks[_lazy], memoized on the
+        engine's registry version: the registry mutates only at capture / bind
+        / clear time, so re-running the O(graphs x hooks) checks on an
+        unchanged registry is wasted work on every reconfigure. Only a PASS is
+        cached; every registry mutation bumps the version and forces
+        re-validation."""
+        eng = self._eng
+        version = eng.toggle_registry_version()   # read BEFORE validating
+        if version == self._guard_valid_version:
+            return
+        # Guard: gate active but device toggle a no-op (nothing bound/captured)
+        # -> metas filtered while all producers still fire -> desync. Fail loud.
+        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
+            raise RuntimeError(
+                "%s: no producer nodes registered / no graph exec bound "
+                "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
+                "enable_toggle_capture(True) and call bind_graph_exec() first."
+                % (who, eng.toggle_node_count(), eng.bound_graph_count()))
+        # Guard: non-uniform hook sets across graphs -> a hook in one graph but
+        # not the replayed one pushes an orphan meta.
+        if not eng.toggle_registry_uniform():
+            raise RuntimeError(
+                "%s: captured graphs have non-uniform hook sets; the "
+                "global meta gate cannot stay aligned. Ensure every captured "
+                "graph registers the same hooks." % who)
+        # Guard: node-registry vs exec-binding key mismatch (partial bind) -> a
+        # graph replays default-ON while the meta gate filters -> desync.
+        if not eng.toggle_registry_complete():
+            raise RuntimeError(
+                "%s: toggle registry incomplete -- the set of graphs "
+                "with recorded producer nodes does not match the set of bound "
+                "execs. Every captured graph must be bound (bind_graph_exec) "
+                "and vice versa." % who)
+        if eng.capture_anomaly_count() > 0:
+            raise RuntimeError(
+                "%s: capture recorded %d producer node(s) node-toggle "
+                "cannot manage -- either a non-kernel tail dependency (multi-op "
+                "producer / capture event-join), or a chunked producer (not "
+                "supported under node-toggle; set dmx_gpu_padding_strip=False "
+                "to route every hook through the basic producer). Refusing to "
+                "activate (fail-closed)." % (who, eng.capture_anomaly_count()))
+        self._guard_valid_version = version
+
+    def _recompute(self, pairs) -> None:
+        """Recompute the effective-enabled set (active ∩ enabled ∩ registered)
+        via ONE batched pybind call. The enabled set changes only here; the
+        registered set is fixed after capture. Bumps enabled_version to
+        invalidate any capacity cache keyed on it.
+
+        The result is memoized per (registry version, enabled set,
+        active_specs identity), so repeated presets (graduated monitoring
+        levels, profiler sweep cycles) skip the recompute. The cached
+        active_specs reference is compared with `is`; holding it pins the id,
+        so identity cannot be reused."""
+        active = self._transport._active_specs
+        key = (self._eng.toggle_registry_version(), frozenset(pairs))
+        hit = self._cache.get(key)
+        if hit is not None and hit[0] is active:
+            self.effective_enabled_specs = hit[1]
+            self.enabled_version += 1
+            return
+        mask = self._eng.effective_enabled_mask(
+            [(s.hook_type, s.layer_no) for s in active])
+        self.effective_enabled_specs = [s for s, m in zip(active, mask) if m]
+        self.enabled_version += 1
+        if len(self._cache) >= 64:   # ad-hoc sets: bound it
+            self._cache.clear()
+        self._cache[key] = (active, self.effective_enabled_specs)

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -16,7 +16,7 @@ All transport now uses the CUDA-graph-compatible forward-hook path.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
 import torch.library
@@ -429,6 +429,23 @@ class RingTransport:
         self._active_specs: List[HookSpec] = []
         self._using_forward_hooks: bool = False
 
+        # Runtime node-toggle gate. When False (default), the meta path is
+        # unchanged -- every active spec pushes a meta. When True (set by
+        # set_active_hooks), pre_push_all_metas pushes metas only for the
+        # enabled-AND-captured subset, in LOCKSTEP with the device-side
+        # cudaGraphNodeSetEnabled. The engine's enabled-set (with the #14
+        # enabled-AND-captured guard) is the single source of truth.
+        self._toggle_gate_active: bool = False
+        # Single source of truth for "which specs actually fire this step".
+        # When the toggle gate is active, this is the subset of _active_specs
+        # whose nodes are enabled-AND-captured; recomputed once per
+        # set_active_hooks (NOT per step). None => toggle inactive => all
+        # _active_specs fire. capacity-reserve (adaptor_base._compute_step_plan),
+        # meta-push AND the device node-enable must all read this same set, else
+        # reserve() over-counts vs actual producer writes.
+        self._effective_enabled_specs: "Optional[List[HookSpec]]" = None
+        self._enabled_version: int = 0   # bumped whenever the enabled set changes
+
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").
         # Set by the active adapter before hook installation.
         self._hook_selection: Optional[str] = None
@@ -485,6 +502,16 @@ class RingTransport:
         """Set the model shape config for analytical shape computation."""
         self._model_cfg = cfg
 
+    @property
+    def effective_specs(self) -> "List[HookSpec]":
+        """The specs that actually fire this step -- the single set that must
+        drive capacity-reserve, meta-push and device node-enable in lockstep.
+        Toggle active -> the precomputed enabled-AND-captured subset; else all
+        active specs (legacy: every active hook fires every step)."""
+        if self._toggle_gate_active and self._effective_enabled_specs is not None:
+            return self._effective_enabled_specs
+        return self._active_specs
+
     def pre_push_all_metas(self, batch: int, q_len: int, kv_dim: int,
                            logits_to_keep: int = 0,
                            token_ids_dtype: Optional[torch.dtype] = None,
@@ -518,7 +545,11 @@ class RingTransport:
         shapes = []
         dtypes = []
         flags = []
-        for spec in self._active_specs:
+        # Iterate the single effective-enabled set (precomputed in
+        # set_active_hooks). This IS the lockstep node-toggle gate: host meta set
+        # == device enabled set == capacity-reserve set. Toggle-inactive ->
+        # effective_specs is _active_specs (legacy behaviour, unchanged).
+        for spec in self.effective_specs:
             spec_q_len = (actual_q_len if actual_q_len is not None
                           and spec.dim0_is_actual_tokens
                           else q_len)
@@ -554,6 +585,103 @@ class RingTransport:
                 list(self._current_dim0_offsets),
                 list(self._current_kv_offsets) if self._current_kv_offsets else [],
             )
+
+    def set_active_hooks(self, enabled: "Iterable[Tuple[int, int]]") -> None:
+        """Set which hooks fire this step, as (hook_type, layer_no) pairs.
+
+        THE single driver for runtime node-toggle (eager apply). Must be called
+        at a step boundary with the prior graph replay complete. It:
+          1. set_enabled_hooks + apply_toggle on the engine -> device side
+             (cudaGraphNodeSetEnabled on the captured producer nodes), and
+          2. activates the host meta gate so pre_push_all_metas pushes metas only
+             for the same enabled set.
+        Both lanes read the engine's enabled-set (single source of truth).
+
+        Requires the producer nodes to have been registered during capture
+        (enable_toggle_capture(True) before capture) and the exec(s) bound via
+        bind_graph_exec(). Hooks not captured are gated off (the engine's #14
+        guard), so they neither fire nor get a meta.
+        """
+        eng = self._ring_engine
+        # Guard (#1): activating the host gate while the device toggle is a no-op
+        # (no exec bound / nothing captured) would filter metas while every
+        # producer still fires at its default-enabled state -> desync. Fail loud.
+        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
+            raise RuntimeError(
+                "set_active_hooks: no producer nodes registered / no graph exec bound "
+                "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
+                "enable_toggle_capture(True) and call bind_graph_exec() first."
+                % (eng.toggle_node_count(), eng.bound_graph_count()))
+        # Guard (#4): the gate keys on (hook_type,layer) globally; if captured
+        # graphs have different hook sets, a hook in one graph but not the one
+        # replayed this step would push a meta with no payload.
+        if not eng.toggle_registry_uniform():
+            raise RuntimeError(
+                "set_active_hooks: captured graphs have non-uniform hook sets; the "
+                "global meta gate cannot stay aligned. Ensure every captured graph "
+                "registers the same hooks.")
+        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
+        eng.set_enabled_hooks(pairs)
+        err = eng.apply_toggle()
+        if err != 0:
+            raise RuntimeError(f"apply_toggle failed with CUDA error {err}")
+        self._toggle_gate_active = True
+        self._recompute_effective_specs()
+
+    def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
+        """Phase 4 lazy reconfigure: update the enabled set + host meta gate, but
+        DEFER the device apply to per-graph ensure_graph_current() (called just
+        before each graph replays). set_enabled_hooks bumps the engine's
+        target_version, marking every captured graph stale; the device flip then
+        happens lazily, only on graphs actually replayed. Same guards + gate
+        semantics as set_active_hooks, minus apply_toggle.
+        """
+        eng = self._ring_engine
+        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
+            raise RuntimeError(
+                "set_active_hooks_lazy: no producer nodes registered / no graph exec "
+                "bound (toggle_node_count=%d, bound_graph_count=%d)."
+                % (eng.toggle_node_count(), eng.bound_graph_count()))
+        if not eng.toggle_registry_uniform():
+            raise RuntimeError(
+                "set_active_hooks_lazy: captured graphs have non-uniform hook sets.")
+        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
+        eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred
+        self._toggle_gate_active = True
+        self._recompute_effective_specs()
+
+    def _recompute_effective_specs(self) -> None:
+        """Recompute the single effective-enabled set (active ∩ enabled ∩
+        registered) via ONE batched pybind call. Called by set_active_hooks[_lazy]
+        only (the enabled set changes there; registered set is fixed after
+        capture). capacity-reserve + meta-push both read this -> they can never
+        diverge from the device enabled set. Bumps version to invalidate the
+        worker's capacity cache."""
+        mask = self._ring_engine.effective_enabled_mask(
+            [(s.hook_type, s.layer_no) for s in self._active_specs])
+        self._effective_enabled_specs = [
+            s for s, m in zip(self._active_specs, mask) if m]
+        self._enabled_version += 1
+
+    def ensure_graph_current(self, raw_graph: int) -> int:
+        """Lazy: apply the deferred toggle to the graph about to replay (no-op if
+        already current). Call right before the graph's replay; raw_graph is the
+        cudaGraph_t handle the graph was bound with."""
+        return self._ring_engine.ensure_graph_current(raw_graph)
+
+    def record_replay_event(self, raw_graph: int) -> None:
+        """Lazy event guard: record a stream event after a graph's replay so a
+        later ensure_graph_current() waits for it before mutating that exec."""
+        self._ring_engine.record_replay_event(raw_graph)
+
+    def clear_toggle(self) -> None:
+        """Paired teardown: clear the engine's toggle registry AND deactivate the
+        host gate, so neither lane is left half-configured (#2). Call before a
+        re-capture or when disabling monitoring."""
+        self._ring_engine.clear_toggle_registry()
+        self._toggle_gate_active = False
+        self._effective_enabled_specs = None
+        self._enabled_version += 1
 
     def submit_cpu_direct(self, cpu_tensor: torch.Tensor,
                           hook_type: int, hook_id: int) -> None:

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -638,6 +638,12 @@ class RingTransport:
                 "set_active_hooks: toggle registry incomplete -- the set of graphs "
                 "with recorded producer nodes does not match the set of bound execs. "
                 "Every captured graph must be bound (bind_graph_exec) and vice versa.")
+        if eng.capture_anomaly_count() > 0:
+            raise RuntimeError(
+                "set_active_hooks: capture recorded %d non-kernel tail node(s) -- the "
+                "producer node registry may be misaligned (multi-op producer / capture "
+                "event-join / unexpected topology). Refusing to activate (fail-closed)."
+                % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)
         err = eng.apply_toggle()
@@ -669,6 +675,11 @@ class RingTransport:
                 "set_active_hooks_lazy: toggle registry incomplete -- node-registry and "
                 "exec-binding key sets differ (some captured graph unbound, or some "
                 "bound graph has no recorded nodes).")
+        if eng.capture_anomaly_count() > 0:
+            raise RuntimeError(
+                "set_active_hooks_lazy: capture recorded %d non-kernel tail node(s); "
+                "producer node registry may be misaligned. Refusing to activate."
+                % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred
         self._toggle_gate_active = True

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -449,6 +449,16 @@ class RingTransport:
         # (set_active_hooks_lazy). The replay guard reads this to decide whether
         # to ensure_graph_current (lazy) or only validate (eager).
         self._lazy_active: bool = False
+        # Reconfigure caches, both keyed on the engine's registry version (bumped
+        # by every registry mutation) so neither can serve a stale result:
+        #   - _guard_valid_version: the registry version whose guard validation
+        #     PASSED; same version => skip re-running the O(graphs x hooks)
+        #     registry guards on the next reconfigure. Failures are never cached.
+        #   - _effective_specs_cache: (registry_version, enabled frozenset) ->
+        #     (active_specs ref, effective list). The stored active_specs
+        #     reference is compared with `is` (the strong ref pins the id).
+        self._guard_valid_version: Optional[int] = None
+        self._effective_specs_cache: dict = {}
 
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").
         # Set by the active adapter before hook installation.
@@ -604,36 +614,7 @@ class RingTransport:
         Requires producer nodes registered at capture + execs bound.
         """
         eng = self._ring_engine
-        # Guard: gate active but device toggle a no-op (nothing bound/captured)
-        # -> metas filtered while all producers still fire -> desync. Fail loud.
-        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
-            raise RuntimeError(
-                "set_active_hooks: no producer nodes registered / no graph exec bound "
-                "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
-                "enable_toggle_capture(True) and call bind_graph_exec() first."
-                % (eng.toggle_node_count(), eng.bound_graph_count()))
-        # Guard: non-uniform hook sets across graphs -> a hook in one graph but
-        # not the replayed one pushes an orphan meta.
-        if not eng.toggle_registry_uniform():
-            raise RuntimeError(
-                "set_active_hooks: captured graphs have non-uniform hook sets; the "
-                "global meta gate cannot stay aligned. Ensure every captured graph "
-                "registers the same hooks.")
-        # Guard: node-registry vs exec-binding key mismatch (partial bind) -> a
-        # graph replays default-ON while the meta gate filters -> desync.
-        if not eng.toggle_registry_complete():
-            raise RuntimeError(
-                "set_active_hooks: toggle registry incomplete -- the set of graphs "
-                "with recorded producer nodes does not match the set of bound execs. "
-                "Every captured graph must be bound (bind_graph_exec) and vice versa.")
-        if eng.capture_anomaly_count() > 0:
-            raise RuntimeError(
-                "set_active_hooks: capture recorded %d producer node(s) node-toggle "
-                "cannot manage -- either a non-kernel tail dependency (multi-op "
-                "producer / capture event-join), or a chunked producer (not "
-                "supported under node-toggle; set dmx_gpu_padding_strip=False to route "
-                "every hook through the basic producer). Refusing to activate "
-                "(fail-closed)." % eng.capture_anomaly_count())
+        self._validate_toggle_registry("set_active_hooks")
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)
         err = eng.apply_toggle()
@@ -641,7 +622,7 @@ class RingTransport:
             raise RuntimeError(f"apply_toggle failed with CUDA error {err}")
         self._toggle_gate_active = True
         self._lazy_active = False
-        self._recompute_effective_specs()
+        self._recompute_effective_specs(pairs)
 
     def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
         """Lazy reconfigure: update the enabled set + host meta gate, but
@@ -652,43 +633,87 @@ class RingTransport:
         semantics as set_active_hooks, minus apply_toggle.
         """
         eng = self._ring_engine
-        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
-            raise RuntimeError(
-                "set_active_hooks_lazy: no producer nodes registered / no graph exec "
-                "bound (toggle_node_count=%d, bound_graph_count=%d)."
-                % (eng.toggle_node_count(), eng.bound_graph_count()))
-        if not eng.toggle_registry_uniform():
-            raise RuntimeError(
-                "set_active_hooks_lazy: captured graphs have non-uniform hook sets.")
-        if not eng.toggle_registry_complete():
-            raise RuntimeError(
-                "set_active_hooks_lazy: toggle registry incomplete -- node-registry and "
-                "exec-binding key sets differ (some captured graph unbound, or some "
-                "bound graph has no recorded nodes).")
-        if eng.capture_anomaly_count() > 0:
-            raise RuntimeError(
-                "set_active_hooks_lazy: capture recorded %d producer node(s) node-toggle "
-                "cannot manage (non-kernel tail, or chunked producer -- set "
-                "dmx_gpu_padding_strip=False). Refusing to activate."
-                % eng.capture_anomaly_count())
+        self._validate_toggle_registry("set_active_hooks_lazy")
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred
         self._toggle_gate_active = True
         self._lazy_active = True
-        self._recompute_effective_specs()
+        self._recompute_effective_specs(pairs)
 
-    def _recompute_effective_specs(self) -> None:
+    def _validate_toggle_registry(self, who: str) -> None:
+        """Registry guards shared by set_active_hooks[_lazy], memoized on the
+        engine's registry version: the registry mutates only at capture / bind /
+        clear time, so re-running the O(graphs x hooks) checks on an unchanged
+        registry is wasted work on every reconfigure. Only a PASS is cached;
+        every registry mutation bumps the version and forces re-validation."""
+        eng = self._ring_engine
+        version = eng.toggle_registry_version()   # read BEFORE validating
+        if version == self._guard_valid_version:
+            return
+        # Guard: gate active but device toggle a no-op (nothing bound/captured)
+        # -> metas filtered while all producers still fire -> desync. Fail loud.
+        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
+            raise RuntimeError(
+                "%s: no producer nodes registered / no graph exec bound "
+                "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
+                "enable_toggle_capture(True) and call bind_graph_exec() first."
+                % (who, eng.toggle_node_count(), eng.bound_graph_count()))
+        # Guard: non-uniform hook sets across graphs -> a hook in one graph but
+        # not the replayed one pushes an orphan meta.
+        if not eng.toggle_registry_uniform():
+            raise RuntimeError(
+                "%s: captured graphs have non-uniform hook sets; the "
+                "global meta gate cannot stay aligned. Ensure every captured graph "
+                "registers the same hooks." % who)
+        # Guard: node-registry vs exec-binding key mismatch (partial bind) -> a
+        # graph replays default-ON while the meta gate filters -> desync.
+        if not eng.toggle_registry_complete():
+            raise RuntimeError(
+                "%s: toggle registry incomplete -- the set of graphs "
+                "with recorded producer nodes does not match the set of bound execs. "
+                "Every captured graph must be bound (bind_graph_exec) and vice versa."
+                % who)
+        if eng.capture_anomaly_count() > 0:
+            raise RuntimeError(
+                "%s: capture recorded %d producer node(s) node-toggle "
+                "cannot manage -- either a non-kernel tail dependency (multi-op "
+                "producer / capture event-join), or a chunked producer (not "
+                "supported under node-toggle; set dmx_gpu_padding_strip=False to route "
+                "every hook through the basic producer). Refusing to activate "
+                "(fail-closed)." % (who, eng.capture_anomaly_count()))
+        self._guard_valid_version = version
+
+    def _recompute_effective_specs(self, pairs=None) -> None:
         """Recompute the single effective-enabled set (active ∩ enabled ∩
         registered) via ONE batched pybind call. Called by set_active_hooks[_lazy]
         only (the enabled set changes there; registered set is fixed after
         capture). capacity-reserve + meta-push both read this -> they can never
         diverge from the device enabled set. Bumps version to invalidate the
-        worker's capacity cache."""
+        worker's capacity cache.
+
+        With `pairs` (the enabled set just pushed to the engine), the result is
+        memoized per (registry version, enabled set, active_specs identity), so
+        repeated presets (graduated monitoring levels, profiler sweep cycles)
+        skip the recompute. The cached active_specs reference is compared with
+        `is`; holding it pins the id, so identity cannot be reused."""
+        key = None
+        if pairs is not None:
+            key = (self._ring_engine.toggle_registry_version(), frozenset(pairs))
+            hit = self._effective_specs_cache.get(key)
+            if hit is not None and hit[0] is self._active_specs:
+                self._effective_enabled_specs = hit[1]
+                self._enabled_version += 1
+                return
         mask = self._ring_engine.effective_enabled_mask(
             [(s.hook_type, s.layer_no) for s in self._active_specs])
         self._effective_enabled_specs = [
             s for s, m in zip(self._active_specs, mask) if m]
         self._enabled_version += 1
+        if key is not None:
+            if len(self._effective_specs_cache) >= 64:   # ad-hoc sets: bound it
+                self._effective_specs_cache.clear()
+            self._effective_specs_cache[key] = (
+                self._active_specs, self._effective_enabled_specs)
 
     def is_graph_ready(self, raw_graph: int) -> bool:
         """Read-only replay-time guard: True iff the graph has recorded producer
@@ -718,6 +743,8 @@ class RingTransport:
         self._lazy_active = False
         self._effective_enabled_specs = None
         self._enabled_version += 1
+        self._guard_valid_version = None
+        self._effective_specs_cache.clear()
 
     def submit_cpu_direct(self, cpu_tensor: torch.Tensor,
                           hook_type: int, hook_id: int) -> None:

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -593,8 +593,13 @@ class RingTransport:
     def set_active_hooks(self, enabled: "Iterable[Tuple[int, int]]") -> None:
         """Set which hooks fire this step, as (hook_type, layer_no) pairs.
 
-        THE single driver for runtime node-toggle (eager apply). Must be called
-        at a step boundary with the prior graph replay complete. It:
+        EAGER apply: flips every bound exec NOW via cudaGraphNodeSetEnabled.
+        CONTRACT: only safe at a QUIESCENT point (no replay of any bound exec in
+        flight) -- e.g. once after warmup for a static config. apply_toggle does
+        NOT wait on per-graph replay events, so mutating an exec that the GPU is
+        still executing is UB. For DYNAMIC / per-step reconfigure use
+        set_active_hooks_lazy (its replay-time ensure_graph_current waits on the
+        prior replay event before mutating). It:
           1. set_enabled_hooks + apply_toggle on the engine -> device side
              (cudaGraphNodeSetEnabled on the captured producer nodes), and
           2. activates the host meta gate so pre_push_all_metas pushes metas only

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -628,10 +628,12 @@ class RingTransport:
                 "Every captured graph must be bound (bind_graph_exec) and vice versa.")
         if eng.capture_anomaly_count() > 0:
             raise RuntimeError(
-                "set_active_hooks: capture recorded %d non-kernel tail node(s) -- the "
-                "producer node registry may be misaligned (multi-op producer / capture "
-                "event-join / unexpected topology). Refusing to activate (fail-closed)."
-                % eng.capture_anomaly_count())
+                "set_active_hooks: capture recorded %d producer node(s) node-toggle "
+                "cannot manage -- either a non-kernel tail dependency (multi-op "
+                "producer / capture event-join), or a chunked/MoE producer (not "
+                "supported with gpu_padding_strip; set dmx_gpu_padding_strip=False to "
+                "route every hook through the basic producer). Refusing to activate "
+                "(fail-closed)." % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)
         err = eng.apply_toggle()
@@ -665,8 +667,9 @@ class RingTransport:
                 "bound graph has no recorded nodes).")
         if eng.capture_anomaly_count() > 0:
             raise RuntimeError(
-                "set_active_hooks_lazy: capture recorded %d non-kernel tail node(s); "
-                "producer node registry may be misaligned. Refusing to activate."
+                "set_active_hooks_lazy: capture recorded %d producer node(s) node-toggle "
+                "cannot manage (non-kernel tail, or chunked/MoE producer -- set "
+                "dmx_gpu_padding_strip=False). Refusing to activate."
                 % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -429,36 +429,10 @@ class RingTransport:
         self._active_specs: List[HookSpec] = []
         self._using_forward_hooks: bool = False
 
-        # Runtime node-toggle gate. When False (default), the meta path is
-        # unchanged -- every active spec pushes a meta. When True (set by
-        # set_active_hooks), pre_push_all_metas pushes metas only for the
-        # enabled-AND-captured subset, in LOCKSTEP with the device-side
-        # cudaGraphNodeSetEnabled. The engine's enabled-set (with the
-        # enabled-AND-captured guard) is the single source of truth.
-        self._toggle_gate_active: bool = False
-        # Single source of truth for "which specs actually fire this step".
-        # When the toggle gate is active, this is the subset of _active_specs
-        # whose nodes are enabled-AND-captured; recomputed once per
-        # set_active_hooks (NOT per step). None => toggle inactive => all
-        # _active_specs fire. capacity-reserve (adaptor_base._compute_step_plan),
-        # meta-push AND the device node-enable must all read this same set, else
-        # reserve() over-counts vs actual producer writes.
-        self._effective_enabled_specs: "Optional[List[HookSpec]]" = None
-        self._enabled_version: int = 0   # bumped whenever the enabled set changes
-        # True when the active gate uses the LAZY device-apply path
-        # (set_active_hooks_lazy). The replay guard reads this to decide whether
-        # to ensure_graph_current (lazy) or only validate (eager).
-        self._lazy_active: bool = False
-        # Reconfigure caches, both keyed on the engine's registry version (bumped
-        # by every registry mutation) so neither can serve a stale result:
-        #   - _guard_valid_version: the registry version whose guard validation
-        #     PASSED; same version => skip re-running the O(graphs x hooks)
-        #     registry guards on the next reconfigure. Failures are never cached.
-        #   - _effective_specs_cache: (registry_version, enabled frozenset) ->
-        #     (active_specs ref, effective list). The stored active_specs
-        #     reference is compared with `is` (the strong ref pins the id).
-        self._guard_valid_version: Optional[int] = None
-        self._effective_specs_cache: dict = {}
+        # Runtime node-toggle controller (monitoring/node_toggle.py), created
+        # on first use. None (or absent on a minimally-constructed transport)
+        # => toggle inactive => every active spec fires every step.
+        self._toggle: "Optional[NodeToggleController]" = None
 
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").
         # Set by the active adapter before hook installation.
@@ -523,12 +497,29 @@ class RingTransport:
         Toggle active -> the precomputed enabled-AND-captured subset; else all
         active specs (toggle inactive: every active hook fires every step).
 
-        getattr defaults: a minimally-constructed transport (tests build one
-        via ``RingTransport.__new__``) has no toggle attributes -> inactive."""
-        if (getattr(self, "_toggle_gate_active", False)
-                and getattr(self, "_effective_enabled_specs", None) is not None):
-            return self._effective_enabled_specs
+        getattr default: a minimally-constructed transport (tests build one
+        via ``RingTransport.__new__``) has no controller -> inactive."""
+        t = getattr(self, "_toggle", None)
+        if (t is not None and t.gate_active
+                and t.effective_enabled_specs is not None):
+            return t.effective_enabled_specs
         return self._active_specs
+
+    def _toggle_ctrl(self) -> "NodeToggleController":
+        if self._toggle is None:
+            from monitoring.node_toggle import NodeToggleController
+            self._toggle = NodeToggleController(self._ring_engine, self)
+        return self._toggle
+
+    @property
+    def toggle_gate_active(self) -> bool:
+        t = getattr(self, "_toggle", None)
+        return t is not None and t.gate_active
+
+    @property
+    def toggle_lazy_active(self) -> bool:
+        t = getattr(self, "_toggle", None)
+        return t is not None and t.lazy_active
 
     def pre_push_all_metas(self, batch: int, q_len: int, kv_dim: int,
                            logits_to_keep: int = 0,
@@ -605,150 +596,34 @@ class RingTransport:
             )
 
     def set_active_hooks(self, enabled: "Iterable[Tuple[int, int]]") -> None:
-        """Eager runtime node-toggle: enable exactly `enabled` (hook_type, layer_no)
-        pairs and disable the rest, NOW.
-
-        Flips the captured producer nodes on every bound exec (apply_toggle) and
-        activates the host meta gate, both driven by the engine's enabled-set
-        (single source of truth) so reserve/meta/device stay in lockstep.
-
-        CONTRACT: eager apply does not wait on replay events, so call only at a
-        quiescent point (no bound-exec replay in flight) -- e.g. once after warmup.
-        For dynamic / per-step reconfigure use set_active_hooks_lazy (event-guarded).
-        Requires producer nodes registered at capture + execs bound.
-        """
-        eng = self._ring_engine
-        self._validate_toggle_registry("set_active_hooks")
-        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
-        eng.set_enabled_hooks(pairs)
-        err = eng.apply_toggle()
-        if err != 0:
-            raise RuntimeError(f"apply_toggle failed with CUDA error {err}")
-        self._toggle_gate_active = True
-        self._lazy_active = False
-        self._recompute_effective_specs(pairs)
+        """Eager node-toggle reconfigure (quiescent-point only). See
+        ``node_toggle.NodeToggleController.set_active_hooks`` for the contract."""
+        self._toggle_ctrl().set_active_hooks(enabled)
 
     def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
-        """Lazy reconfigure: update the enabled set + host meta gate, but
-        DEFER the device apply to per-graph ensure_graph_current() (called just
-        before each graph replays). set_enabled_hooks bumps the engine's
-        target_version, marking every captured graph stale; the device flip then
-        happens lazily, only on graphs actually replayed. Same guards + gate
-        semantics as set_active_hooks, minus apply_toggle.
-        """
-        eng = self._ring_engine
-        self._validate_toggle_registry("set_active_hooks_lazy")
-        pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
-        eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred
-        self._toggle_gate_active = True
-        self._lazy_active = True
-        self._recompute_effective_specs(pairs)
-
-    def _validate_toggle_registry(self, who: str) -> None:
-        """Registry guards shared by set_active_hooks[_lazy], memoized on the
-        engine's registry version: the registry mutates only at capture / bind /
-        clear time, so re-running the O(graphs x hooks) checks on an unchanged
-        registry is wasted work on every reconfigure. Only a PASS is cached;
-        every registry mutation bumps the version and forces re-validation."""
-        eng = self._ring_engine
-        version = eng.toggle_registry_version()   # read BEFORE validating
-        if version == self._guard_valid_version:
-            return
-        # Guard: gate active but device toggle a no-op (nothing bound/captured)
-        # -> metas filtered while all producers still fire -> desync. Fail loud.
-        if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
-            raise RuntimeError(
-                "%s: no producer nodes registered / no graph exec bound "
-                "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
-                "enable_toggle_capture(True) and call bind_graph_exec() first."
-                % (who, eng.toggle_node_count(), eng.bound_graph_count()))
-        # Guard: non-uniform hook sets across graphs -> a hook in one graph but
-        # not the replayed one pushes an orphan meta.
-        if not eng.toggle_registry_uniform():
-            raise RuntimeError(
-                "%s: captured graphs have non-uniform hook sets; the "
-                "global meta gate cannot stay aligned. Ensure every captured graph "
-                "registers the same hooks." % who)
-        # Guard: node-registry vs exec-binding key mismatch (partial bind) -> a
-        # graph replays default-ON while the meta gate filters -> desync.
-        if not eng.toggle_registry_complete():
-            raise RuntimeError(
-                "%s: toggle registry incomplete -- the set of graphs "
-                "with recorded producer nodes does not match the set of bound execs. "
-                "Every captured graph must be bound (bind_graph_exec) and vice versa."
-                % who)
-        if eng.capture_anomaly_count() > 0:
-            raise RuntimeError(
-                "%s: capture recorded %d producer node(s) node-toggle "
-                "cannot manage -- either a non-kernel tail dependency (multi-op "
-                "producer / capture event-join), or a chunked producer (not "
-                "supported under node-toggle; set dmx_gpu_padding_strip=False to route "
-                "every hook through the basic producer). Refusing to activate "
-                "(fail-closed)." % (who, eng.capture_anomaly_count()))
-        self._guard_valid_version = version
-
-    def _recompute_effective_specs(self, pairs=None) -> None:
-        """Recompute the single effective-enabled set (active ∩ enabled ∩
-        registered) via ONE batched pybind call. Called by set_active_hooks[_lazy]
-        only (the enabled set changes there; registered set is fixed after
-        capture). capacity-reserve + meta-push both read this -> they can never
-        diverge from the device enabled set. Bumps version to invalidate the
-        worker's capacity cache.
-
-        With `pairs` (the enabled set just pushed to the engine), the result is
-        memoized per (registry version, enabled set, active_specs identity), so
-        repeated presets (graduated monitoring levels, profiler sweep cycles)
-        skip the recompute. The cached active_specs reference is compared with
-        `is`; holding it pins the id, so identity cannot be reused."""
-        key = None
-        if pairs is not None:
-            key = (self._ring_engine.toggle_registry_version(), frozenset(pairs))
-            hit = self._effective_specs_cache.get(key)
-            if hit is not None and hit[0] is self._active_specs:
-                self._effective_enabled_specs = hit[1]
-                self._enabled_version += 1
-                return
-        mask = self._ring_engine.effective_enabled_mask(
-            [(s.hook_type, s.layer_no) for s in self._active_specs])
-        self._effective_enabled_specs = [
-            s for s, m in zip(self._active_specs, mask) if m]
-        self._enabled_version += 1
-        if key is not None:
-            if len(self._effective_specs_cache) >= 64:   # ad-hoc sets: bound it
-                self._effective_specs_cache.clear()
-            self._effective_specs_cache[key] = (
-                self._active_specs, self._effective_enabled_specs)
+        """Lazy node-toggle reconfigure (device apply deferred per graph). See
+        ``node_toggle.NodeToggleController.set_active_hooks_lazy``."""
+        self._toggle_ctrl().set_active_hooks_lazy(enabled)
 
     def is_graph_ready(self, raw_graph: int) -> bool:
-        """Read-only replay-time guard: True iff the graph has recorded producer
-        nodes AND a bound exec. False for a graph the serving framework captured
-        at runtime after the warmup window closed -> the replay hook fails loud."""
-        return self._ring_engine.is_graph_ready(raw_graph)
+        """Read-only replay-time guard. See
+        ``node_toggle.NodeToggleController.is_graph_ready``."""
+        return self._toggle_ctrl().is_graph_ready(raw_graph)
 
     def ensure_graph_current(self, raw_graph: int) -> int:
-        """Lazy: apply the deferred toggle to the graph about to replay (no-op if
-        already current). Call right before the graph's replay; raw_graph is the
-        cudaGraph_t handle the graph was bound with."""
-        return self._ring_engine.ensure_graph_current(raw_graph)
+        """Lazy per-graph device apply. See
+        ``node_toggle.NodeToggleController.ensure_graph_current``."""
+        return self._toggle_ctrl().ensure_graph_current(raw_graph)
 
     def record_replay_event(self, raw_graph: int) -> int:
-        """Lazy event guard: record a stream event after a graph's replay so a
-        later ensure_graph_current() waits for it before mutating that exec.
-        Returns the CUDA error (0 = ok); nonzero is FATAL (a missing event would
-        let a later ensure mutate an executing exec)."""
-        return self._ring_engine.record_replay_event(raw_graph)
+        """Lazy event guard (record after replay). See
+        ``node_toggle.NodeToggleController.record_replay_event``."""
+        return self._toggle_ctrl().record_replay_event(raw_graph)
 
     def clear_toggle(self) -> None:
-        """Paired teardown: clear the engine's toggle registry AND deactivate the
-        host gate, so neither lane is left half-configured. Call before a
-        re-capture or when disabling monitoring."""
-        self._ring_engine.clear_toggle_registry()
-        self._toggle_gate_active = False
-        self._lazy_active = False
-        self._effective_enabled_specs = None
-        self._enabled_version += 1
-        self._guard_valid_version = None
-        self._effective_specs_cache.clear()
+        """Paired teardown of registry + host gate. See
+        ``node_toggle.NodeToggleController.clear``."""
+        self._toggle_ctrl().clear()
 
     def submit_cpu_direct(self, cpu_tensor: torch.Tensor,
                           hook_type: int, hook_id: int) -> None:

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -511,7 +511,7 @@ class RingTransport:
         """The specs that actually fire this step -- the single set that must
         drive capacity-reserve, meta-push and device node-enable in lockstep.
         Toggle active -> the precomputed enabled-AND-captured subset; else all
-        active specs (legacy: every active hook fires every step)."""
+        active specs (toggle inactive: every active hook fires every step)."""
         if self._toggle_gate_active and self._effective_enabled_specs is not None:
             return self._effective_enabled_specs
         return self._active_specs

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -630,9 +630,9 @@ class RingTransport:
             raise RuntimeError(
                 "set_active_hooks: capture recorded %d producer node(s) node-toggle "
                 "cannot manage -- either a non-kernel tail dependency (multi-op "
-                "producer / capture event-join), or a chunked/MoE producer (not "
-                "supported with gpu_padding_strip; set dmx_gpu_padding_strip=False to "
-                "route every hook through the basic producer). Refusing to activate "
+                "producer / capture event-join), or a chunked producer (not "
+                "supported under node-toggle; set dmx_gpu_padding_strip=False to route "
+                "every hook through the basic producer). Refusing to activate "
                 "(fail-closed)." % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)
@@ -668,7 +668,7 @@ class RingTransport:
         if eng.capture_anomaly_count() > 0:
             raise RuntimeError(
                 "set_active_hooks_lazy: capture recorded %d producer node(s) node-toggle "
-                "cannot manage (non-kernel tail, or chunked/MoE producer -- set "
+                "cannot manage (non-kernel tail, or chunked producer -- set "
                 "dmx_gpu_padding_strip=False). Refusing to activate."
                 % eng.capture_anomaly_count())
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -445,6 +445,10 @@ class RingTransport:
         # reserve() over-counts vs actual producer writes.
         self._effective_enabled_specs: "Optional[List[HookSpec]]" = None
         self._enabled_version: int = 0   # bumped whenever the enabled set changes
+        # True when the active gate uses the LAZY device-apply path
+        # (set_active_hooks_lazy). The replay guard reads this to decide whether
+        # to ensure_graph_current (lazy) or only validate (eager).
+        self._lazy_active: bool = False
 
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").
         # Set by the active adapter before hook installation.
@@ -620,12 +624,22 @@ class RingTransport:
                 "set_active_hooks: captured graphs have non-uniform hook sets; the "
                 "global meta gate cannot stay aligned. Ensure every captured graph "
                 "registers the same hooks.")
+        # Guard (#4): node-registry and exec-binding key sets must match exactly.
+        # A partial/mismatched bind (a captured graph left unbound, or a bound
+        # graph with no recorded nodes) would let some graph replay with
+        # default-ON producers while the meta gate filters -> desync.
+        if not eng.toggle_registry_complete():
+            raise RuntimeError(
+                "set_active_hooks: toggle registry incomplete -- the set of graphs "
+                "with recorded producer nodes does not match the set of bound execs. "
+                "Every captured graph must be bound (bind_graph_exec) and vice versa.")
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)
         err = eng.apply_toggle()
         if err != 0:
             raise RuntimeError(f"apply_toggle failed with CUDA error {err}")
         self._toggle_gate_active = True
+        self._lazy_active = False
         self._recompute_effective_specs()
 
     def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
@@ -645,9 +659,15 @@ class RingTransport:
         if not eng.toggle_registry_uniform():
             raise RuntimeError(
                 "set_active_hooks_lazy: captured graphs have non-uniform hook sets.")
+        if not eng.toggle_registry_complete():
+            raise RuntimeError(
+                "set_active_hooks_lazy: toggle registry incomplete -- node-registry and "
+                "exec-binding key sets differ (some captured graph unbound, or some "
+                "bound graph has no recorded nodes).")
         pairs = [(int(ht), int(ln)) for (ht, ln) in enabled]
         eng.set_enabled_hooks(pairs)        # bumps target_version; device apply deferred
         self._toggle_gate_active = True
+        self._lazy_active = True
         self._recompute_effective_specs()
 
     def _recompute_effective_specs(self) -> None:
@@ -662,6 +682,12 @@ class RingTransport:
         self._effective_enabled_specs = [
             s for s, m in zip(self._active_specs, mask) if m]
         self._enabled_version += 1
+
+    def is_graph_ready(self, raw_graph: int) -> bool:
+        """Read-only replay-time guard: True iff the graph has recorded producer
+        nodes AND a bound exec. False for a graph vLLM captured at runtime after
+        the warmup window closed -> the replay hook fails loud (#3)."""
+        return self._ring_engine.is_graph_ready(raw_graph)
 
     def ensure_graph_current(self, raw_graph: int) -> int:
         """Lazy: apply the deferred toggle to the graph about to replay (no-op if
@@ -680,6 +706,7 @@ class RingTransport:
         re-capture or when disabling monitoring."""
         self._ring_engine.clear_toggle_registry()
         self._toggle_gate_active = False
+        self._lazy_active = False
         self._effective_enabled_specs = None
         self._enabled_version += 1
 

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -437,10 +437,11 @@ class RingTransport:
         # only governs producers that run INSIDE a replayed decode graph. In a
         # prefill / eager step the producers run unconditionally (no graph to
         # gate), so meta-push and capacity-reserve MUST use the full active set
-        # that step, or they desync (reserve/meta < producers fired). The vLLM
-        # adapter sets this per step (True = decode-graph step, gate applies;
-        # False = prefill/eager step, use full active_specs). Default True so a
-        # synthetic single-graph test that only drives decode keeps gating.
+        # that step, or they desync (reserve/meta < producers fired). The
+        # serving-framework adapter sets this per step (True = decode-graph step,
+        # gate applies; False = prefill/eager step, use full active_specs).
+        # Default True so a synthetic single-graph test that only drives decode
+        # keeps gating.
         self._gated_step: bool = True
 
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -433,6 +433,15 @@ class RingTransport:
         # on first use. None (or absent on a minimally-constructed transport)
         # => toggle inactive => every active spec fires every step.
         self._toggle: "Optional[NodeToggleController]" = None
+        # Per-step gate selector. The toggle gate (SetEnabled on captured nodes)
+        # only governs producers that run INSIDE a replayed decode graph. In a
+        # prefill / eager step the producers run unconditionally (no graph to
+        # gate), so meta-push and capacity-reserve MUST use the full active set
+        # that step, or they desync (reserve/meta < producers fired). The vLLM
+        # adapter sets this per step (True = decode-graph step, gate applies;
+        # False = prefill/eager step, use full active_specs). Default True so a
+        # synthetic single-graph test that only drives decode keeps gating.
+        self._gated_step: bool = True
 
         # Hook selection preset name (e.g. "full", "hidden-states", "logits").
         # Set by the active adapter before hook installation.
@@ -505,6 +514,16 @@ class RingTransport:
             return t.effective_enabled_specs
         return self._active_specs
 
+    def specs_for_step(self) -> "List[HookSpec]":
+        """The spec set that drives meta-push + capacity-reserve THIS step.
+        Decode-graph step -> effective_specs (toggle gate applies); prefill /
+        eager step -> full active_specs (producers run ungated, so meta/reserve
+        must match the full set). When toggle is inactive the two are identical.
+        """
+        if getattr(self, "_gated_step", True):
+            return self.effective_specs
+        return self._active_specs
+
     def _toggle_ctrl(self) -> "NodeToggleController":
         if self._toggle is None:
             from monitoring.node_toggle import NodeToggleController
@@ -554,11 +573,12 @@ class RingTransport:
         shapes = []
         dtypes = []
         flags = []
-        # Iterate the single effective-enabled set: host meta set == device
-        # enabled set == capacity-reserve set (the lockstep gate). When the
-        # toggle is inactive, effective_specs is just _active_specs (all active
-        # hooks fire).
-        for spec in self.effective_specs:
+        # Iterate the per-step spec set: host meta set == device enabled set ==
+        # capacity-reserve set (the lockstep gate). On a decode-graph step this
+        # is the toggle subset; on a prefill/eager step it is the full active
+        # set (producers run ungated there). When toggle is inactive the two are
+        # identical.
+        for spec in self.specs_for_step():
             spec_q_len = (actual_q_len if actual_q_len is not None
                           and spec.dim0_is_actual_tokens
                           else q_len)

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -531,7 +531,7 @@ class RingTransport:
         ``actual_q_len`` in place of ``q_len`` -- so the meta describes
         the unpadded data the producer will actually write under
         padding-strip mode.  Other specs and the no-strip case use
-        ``q_len``.
+        ``q_len`` (today's behavior).
         """
         if self.null_offload:
             return  # kernel launches happen; metas are intentionally skipped

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -700,10 +700,12 @@ class RingTransport:
         cudaGraph_t handle the graph was bound with."""
         return self._ring_engine.ensure_graph_current(raw_graph)
 
-    def record_replay_event(self, raw_graph: int) -> None:
+    def record_replay_event(self, raw_graph: int) -> int:
         """Lazy event guard: record a stream event after a graph's replay so a
-        later ensure_graph_current() waits for it before mutating that exec."""
-        self._ring_engine.record_replay_event(raw_graph)
+        later ensure_graph_current() waits for it before mutating that exec.
+        Returns the CUDA error (0 = ok); nonzero is FATAL (a missing event would
+        let a later ensure mutate an executing exec)."""
+        return self._ring_engine.record_replay_event(raw_graph)
 
     def clear_toggle(self) -> None:
         """Paired teardown: clear the engine's toggle registry AND deactivate the

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -521,8 +521,12 @@ class RingTransport:
         """The specs that actually fire this step -- the single set that must
         drive capacity-reserve, meta-push and device node-enable in lockstep.
         Toggle active -> the precomputed enabled-AND-captured subset; else all
-        active specs (toggle inactive: every active hook fires every step)."""
-        if self._toggle_gate_active and self._effective_enabled_specs is not None:
+        active specs (toggle inactive: every active hook fires every step).
+
+        getattr defaults: a minimally-constructed transport (tests build one
+        via ``RingTransport.__new__``) has no toggle attributes -> inactive."""
+        if (getattr(self, "_toggle_gate_active", False)
+                and getattr(self, "_effective_enabled_specs", None) is not None):
             return self._effective_enabled_specs
         return self._active_specs
 
@@ -717,8 +721,8 @@ class RingTransport:
 
     def is_graph_ready(self, raw_graph: int) -> bool:
         """Read-only replay-time guard: True iff the graph has recorded producer
-        nodes AND a bound exec. False for a graph vLLM captured at runtime after
-        the warmup window closed -> the replay hook fails loud."""
+        nodes AND a bound exec. False for a graph the serving framework captured
+        at runtime after the warmup window closed -> the replay hook fails loud."""
         return self._ring_engine.is_graph_ready(raw_graph)
 
     def ensure_graph_current(self, raw_graph: int) -> int:

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -433,7 +433,7 @@ class RingTransport:
         # unchanged -- every active spec pushes a meta. When True (set by
         # set_active_hooks), pre_push_all_metas pushes metas only for the
         # enabled-AND-captured subset, in LOCKSTEP with the device-side
-        # cudaGraphNodeSetEnabled. The engine's enabled-set (with the #14
+        # cudaGraphNodeSetEnabled. The engine's enabled-set (with the
         # enabled-AND-captured guard) is the single source of truth.
         self._toggle_gate_active: bool = False
         # Single source of truth for "which specs actually fire this step".
@@ -531,7 +531,7 @@ class RingTransport:
         ``actual_q_len`` in place of ``q_len`` -- so the meta describes
         the unpadded data the producer will actually write under
         padding-strip mode.  Other specs and the no-strip case use
-        ``q_len`` (today's behavior).
+        ``q_len``.
         """
         if self.null_offload:
             return  # kernel launches happen; metas are intentionally skipped
@@ -549,10 +549,10 @@ class RingTransport:
         shapes = []
         dtypes = []
         flags = []
-        # Iterate the single effective-enabled set (precomputed in
-        # set_active_hooks). This IS the lockstep node-toggle gate: host meta set
-        # == device enabled set == capacity-reserve set. Toggle-inactive ->
-        # effective_specs is _active_specs (legacy behaviour, unchanged).
+        # Iterate the single effective-enabled set: host meta set == device
+        # enabled set == capacity-reserve set (the lockstep gate). When the
+        # toggle is inactive, effective_specs is just _active_specs (all active
+        # hooks fire).
         for spec in self.effective_specs:
             spec_q_len = (actual_q_len if actual_q_len is not None
                           and spec.dim0_is_actual_tokens
@@ -591,48 +591,36 @@ class RingTransport:
             )
 
     def set_active_hooks(self, enabled: "Iterable[Tuple[int, int]]") -> None:
-        """Set which hooks fire this step, as (hook_type, layer_no) pairs.
+        """Eager runtime node-toggle: enable exactly `enabled` (hook_type, layer_no)
+        pairs and disable the rest, NOW.
 
-        EAGER apply: flips every bound exec NOW via cudaGraphNodeSetEnabled.
-        CONTRACT: only safe at a QUIESCENT point (no replay of any bound exec in
-        flight) -- e.g. once after warmup for a static config. apply_toggle does
-        NOT wait on per-graph replay events, so mutating an exec that the GPU is
-        still executing is UB. For DYNAMIC / per-step reconfigure use
-        set_active_hooks_lazy (its replay-time ensure_graph_current waits on the
-        prior replay event before mutating). It:
-          1. set_enabled_hooks + apply_toggle on the engine -> device side
-             (cudaGraphNodeSetEnabled on the captured producer nodes), and
-          2. activates the host meta gate so pre_push_all_metas pushes metas only
-             for the same enabled set.
-        Both lanes read the engine's enabled-set (single source of truth).
+        Flips the captured producer nodes on every bound exec (apply_toggle) and
+        activates the host meta gate, both driven by the engine's enabled-set
+        (single source of truth) so reserve/meta/device stay in lockstep.
 
-        Requires the producer nodes to have been registered during capture
-        (enable_toggle_capture(True) before capture) and the exec(s) bound via
-        bind_graph_exec(). Hooks not captured are gated off (the engine's #14
-        guard), so they neither fire nor get a meta.
+        CONTRACT: eager apply does not wait on replay events, so call only at a
+        quiescent point (no bound-exec replay in flight) -- e.g. once after warmup.
+        For dynamic / per-step reconfigure use set_active_hooks_lazy (event-guarded).
+        Requires producer nodes registered at capture + execs bound.
         """
         eng = self._ring_engine
-        # Guard (#1): activating the host gate while the device toggle is a no-op
-        # (no exec bound / nothing captured) would filter metas while every
-        # producer still fires at its default-enabled state -> desync. Fail loud.
+        # Guard: gate active but device toggle a no-op (nothing bound/captured)
+        # -> metas filtered while all producers still fire -> desync. Fail loud.
         if eng.bound_graph_count() == 0 or eng.toggle_node_count() == 0:
             raise RuntimeError(
                 "set_active_hooks: no producer nodes registered / no graph exec bound "
                 "(toggle_node_count=%d, bound_graph_count=%d). Capture with "
                 "enable_toggle_capture(True) and call bind_graph_exec() first."
                 % (eng.toggle_node_count(), eng.bound_graph_count()))
-        # Guard (#4): the gate keys on (hook_type,layer) globally; if captured
-        # graphs have different hook sets, a hook in one graph but not the one
-        # replayed this step would push a meta with no payload.
+        # Guard: non-uniform hook sets across graphs -> a hook in one graph but
+        # not the replayed one pushes an orphan meta.
         if not eng.toggle_registry_uniform():
             raise RuntimeError(
                 "set_active_hooks: captured graphs have non-uniform hook sets; the "
                 "global meta gate cannot stay aligned. Ensure every captured graph "
                 "registers the same hooks.")
-        # Guard (#4): node-registry and exec-binding key sets must match exactly.
-        # A partial/mismatched bind (a captured graph left unbound, or a bound
-        # graph with no recorded nodes) would let some graph replay with
-        # default-ON producers while the meta gate filters -> desync.
+        # Guard: node-registry vs exec-binding key mismatch (partial bind) -> a
+        # graph replays default-ON while the meta gate filters -> desync.
         if not eng.toggle_registry_complete():
             raise RuntimeError(
                 "set_active_hooks: toggle registry incomplete -- the set of graphs "
@@ -654,7 +642,7 @@ class RingTransport:
         self._recompute_effective_specs()
 
     def set_active_hooks_lazy(self, enabled: "Iterable[Tuple[int, int]]") -> None:
-        """Phase 4 lazy reconfigure: update the enabled set + host meta gate, but
+        """Lazy reconfigure: update the enabled set + host meta gate, but
         DEFER the device apply to per-graph ensure_graph_current() (called just
         before each graph replays). set_enabled_hooks bumps the engine's
         target_version, marking every captured graph stale; the device flip then
@@ -702,7 +690,7 @@ class RingTransport:
     def is_graph_ready(self, raw_graph: int) -> bool:
         """Read-only replay-time guard: True iff the graph has recorded producer
         nodes AND a bound exec. False for a graph vLLM captured at runtime after
-        the warmup window closed -> the replay hook fails loud (#3)."""
+        the warmup window closed -> the replay hook fails loud."""
         return self._ring_engine.is_graph_ready(raw_graph)
 
     def ensure_graph_current(self, raw_graph: int) -> int:
@@ -720,7 +708,7 @@ class RingTransport:
 
     def clear_toggle(self) -> None:
         """Paired teardown: clear the engine's toggle registry AND deactivate the
-        host gate, so neither lane is left half-configured (#2). Call before a
+        host gate, so neither lane is left half-configured. Call before a
         re-capture or when disabling monitoring."""
         self._ring_engine.clear_toggle_registry()
         self._toggle_gate_active = False

--- a/tests/ring/smoke_toggle_vllm.py
+++ b/tests/ring/smoke_toggle_vllm.py
@@ -78,43 +78,86 @@ llm = LLM(
     },
 )
 
-out = llm.generate(
-    ["The capital of France is", "Large language models are",
-     "In the beginning", "A short story about a robot:"],
-    SamplingParams(temperature=0.0, max_tokens=48),
-)
+# Capture the C++ p2p thread's stderr during generate + shutdown flush.
+# A "shape/bytes mismatch" warning is the visible symptom of a meta<->payload
+# desync (e.g. an eager/prefill step over-firing producers vs the toggle
+# subset). The prompts below MUST exercise prefill (every request prefills),
+# so a regression there surfaces here. Redirect fd 2 (fprintf writes the C
+# FILE* stderr, not sys.stderr), then replay it so visibility is preserved.
+import tempfile
+_saved_fd2 = os.dup(2)
+_cap = tempfile.NamedTemporaryFile(mode="w+", suffix=".p2pstderr", delete=False)
+os.dup2(_cap.fileno(), 2)
+try:
+    out = llm.generate(
+        ["The capital of France is", "Large language models are",
+         "In the beginning", "A short story about a robot:"],
+        SamplingParams(temperature=0.0, max_tokens=48),
+    )
+    # Drain the export pipeline while stderr is still captured so any
+    # late p2p warning is caught too.
+    del llm
+    gc.collect()
+    time.sleep(3.0)
+finally:
+    os.dup2(_saved_fd2, 2)
+    os.close(_saved_fd2)
+_cap.flush(); _cap.seek(0)
+_captured = _cap.read()
+_cap.close()
+sys.stderr.write(_captured)          # preserve worker stderr visibility
+_n_mismatch = _captured.count("shape/bytes mismatch")
+if _n_mismatch:
+    fail(f"{_n_mismatch} p2p 'shape/bytes mismatch' warning(s) -- meta/payload "
+         f"desync (prefill/eager over-fire vs toggle subset). The export data is "
+         f"corrupt even where layer labels look right.")
+
 texts = [o.outputs[0].text for o in out]
 for t in texts:
     print(f"SMOKE_GEN: {t!r}", flush=True)
 if not all(t.strip() for t in texts):
     fail("a prompt produced empty output (generation/desync problem)")
 
-# Clean shutdown so the async export pipeline flushes to ClickHouse.
-del llm
-gc.collect()
-time.sleep(3.0)
-
-# --- strict verification: rows for EXACTLY the enabled layers, right shape ---
-raw = ch(f"SELECT layer_no, count() FROM {DB_TABLE} GROUP BY layer_no ORDER BY layer_no FORMAT TSV")
+# --- verification: decode is gated to the enabled set; prefill is ungated ---
+# Toggle gates only DECODE-graph producers; prefill runs eager (full active
+# set). So in the DB:
+#   - decode rows (shape [1,HIDDEN], one token/step) must be EXACTLY the
+#     enabled layers -- the decode gate, no leakage, no missing layer.
+#   - prefill rows (shape [N>1,HIDDEN], the prompt) carry the full active
+#     set -- enabled layers must be present among them.
+import re
+raw = ch(f"SELECT layer_no, shape, count() FROM {DB_TABLE} "
+         f"GROUP BY layer_no, shape ORDER BY layer_no FORMAT TSV")
 print("SMOKE_DB_RAW:\n" + (raw or "<empty>"), flush=True)
 rows = [ln.split("\t") for ln in raw.splitlines() if ln]
-got_layers = sorted(int(c[0]) for c in rows)
-total = sum(int(c[1]) for c in rows)
-
+total = sum(int(c[2]) for c in rows)
 if total == 0:
     fail("ClickHouse received 0 rows (export/flush problem)")
-if set(got_layers) != ENABLED_LAYERS:
-    fail(f"delivered layers {got_layers} != enabled {sorted(ENABLED_LAYERS)} (lockstep desync)")
 
-import re
-shapes = ch(f"SELECT DISTINCT shape FROM {DB_TABLE} FORMAT TSV").splitlines()
-# hidden-states rows are [q_len, HIDDEN]: q_len=1 (decode) or >1 (prefill chunk).
-bad = [s for s in shapes if not re.fullmatch(rf"\[\d+,{HIDDEN}\]", s)]
+bad = [c[1] for c in rows if not re.fullmatch(rf"\[\d+,{HIDDEN}\]", c[1])]
 if bad:
     fail(f"shapes with wrong hidden dim (expected [*,{HIDDEN}]): {bad}")
 
-print(f"SMOKE_DB_OK: {total} rows, layers={got_layers}, shapes={shapes} "
-      f"(partial-toggle lockstep on a real model)", flush=True)
+def _dim0(shape):
+    return int(shape[1:-1].split(",")[0])
+
+decode_layers = sorted({int(c[0]) for c in rows if _dim0(c[1]) == 1})
+prefill_layers = sorted({int(c[0]) for c in rows if _dim0(c[1]) > 1})
+all_layers = sorted({int(c[0]) for c in rows})
+
+# Decode gate: decode-shaped rows are EXACTLY the enabled layers.
+if set(decode_layers) != ENABLED_LAYERS:
+    fail(f"decode-shaped rows layers {decode_layers} != enabled "
+         f"{sorted(ENABLED_LAYERS)} -- decode gate leaked or dropped a layer")
+# Prefill is ungated: the enabled layers must show up in prefill too, and
+# prefill legitimately carries more layers (full active set, not a desync).
+if not ENABLED_LAYERS <= set(prefill_layers):
+    fail(f"enabled layers missing from prefill-shaped rows {prefill_layers} "
+         f"(prefill should carry the full active set ungated)")
+
+print(f"SMOKE_DB_OK: {total} rows; decode_layers={decode_layers} (==enabled, gated), "
+      f"prefill_layers={all_layers and prefill_layers} (full active set, ungated) "
+      f"-- decode-gated + prefill-passthrough lockstep on a real model", flush=True)
 
 # Leave the table clean for the next run.
 ch(f"DROP TABLE IF EXISTS {DB_TABLE}")

--- a/tests/ring/smoke_toggle_vllm.py
+++ b/tests/ring/smoke_toggle_vllm.py
@@ -1,0 +1,76 @@
+"""Real FULL vLLM server smoke for node-toggle (offline LLM, in-process worker).
+
+Loads Qwen3-0.6B with the DMXGPUWorker, cudagraph_mode=FULL, node-toggle ON with
+a PARTIAL enabled set (last 4 of 28 hidden-state hooks), full pipeline -> ClickHouse.
+Exercises the real lifecycle: capture window -> producer-node recording -> bind
+captured graphs -> set_active_hooks (eager) -> per-replay graph guard -> meta gate
++ reserve in lockstep -> drain/p2p -> DB. A desync or guard failure crashes here.
+
+Asserts (via markers grepped by the runner):
+  - bound >=1 captured graphs, nodes registered,
+  - active hooks set to the partial set,
+  - replay guard active (mode=eager) -- the #3 guard runs in vivo,
+  - generation produces text (no desync/crash),
+  - ClickHouse received rows ONLY for the enabled layers (partial-toggle lockstep).
+"""
+import os
+import sys
+
+MODEL = os.environ["SMOKE_MODEL"]
+DB_TABLE = "smoke_toggle"
+ENABLED = "0:24,0:25,0:26,0:27"          # last 4 layers of Qwen3-0.6B (28 layers)
+ENABLED_LAYERS = {24, 25, 26, 27}
+
+from vllm import LLM, SamplingParams
+
+llm = LLM(
+    model=MODEL,
+    worker_cls="integration.vllm_adapter.DMXGPUWorker",
+    enforce_eager=False,                  # we WANT cuda graphs
+    max_model_len=2048,
+    gpu_memory_utilization=0.40,
+    compilation_config={"cudagraph_mode": "FULL"},
+    additional_config={
+        "dmx_hook_selection": "hidden-states",
+        "dmx_node_toggle": True,
+        "dmx_enabled_hooks": ENABLED,
+        "dmx_ring_payload_mb": 1024,
+        "dmx_ring_pinned_mb": 1024,
+        "dmx_db_host": "localhost",
+        "dmx_db_port": 9000,
+        "dmx_db_table": DB_TABLE,
+        "dmx_drain_flush_timeout_us": 2000,   # flush sparse data within ~2ms
+        "dmx_ch_max_batch_items": 16,         # low insert watermark for the smoke
+    },
+)
+
+out = llm.generate(
+    ["The capital of France is", "Large language models are",
+     "In the beginning", "A short story about a robot:"],
+    SamplingParams(temperature=0.0, max_tokens=48),
+)
+for o in out:
+    print(f"SMOKE_GEN: {o.outputs[0].text!r}", flush=True)
+
+# Clean shutdown so the async export pipeline flushes to ClickHouse (low-volume
+# runs won't hit the insert batch watermark, so a flush-on-close is required).
+import gc, time
+del llm
+gc.collect()
+time.sleep(3.0)
+
+# Verify rows landed for ONLY the enabled layers (partial-toggle lockstep in vivo)
+# via the clickhouse-client CLI (clickhouse_driver isn't in the venv).
+import subprocess
+q = (f"SELECT layer_no, count() FROM {DB_TABLE} GROUP BY layer_no ORDER BY layer_no "
+     f"FORMAT TSV")
+res = subprocess.run(["clickhouse-client", "--query", q], capture_output=True, text=True)
+print("SMOKE_DB_RAW:\n" + (res.stdout.strip() or "<empty>"), flush=True)
+got = sorted(int(l.split("\t")[0]) for l in res.stdout.strip().splitlines() if l)
+if set(got) == ENABLED_LAYERS:
+    print("SMOKE_DB_OK: rows for EXACTLY the enabled layers (partial-toggle lockstep)", flush=True)
+elif got:
+    print(f"SMOKE_DB_MISMATCH: got {got} expected {sorted(ENABLED_LAYERS)}", flush=True)
+else:
+    print("SMOKE_DB_EMPTY", flush=True)
+print("SMOKE_OK", flush=True)

--- a/tests/ring/smoke_toggle_vllm.py
+++ b/tests/ring/smoke_toggle_vllm.py
@@ -71,7 +71,9 @@ llm = LLM(
         "dmx_db_host": "localhost",
         "dmx_db_port": 9000,
         "dmx_db_table": DB_TABLE,
-        "dmx_drain_flush_timeout_us": 2000,   # flush sparse data within ~2ms
+        # NOTE: deliberately NOT setting dmx_drain_flush_timeout_us -- this
+        # exercises the new toggle-on default (50ms) so the default export
+        # behaviour is covered (not just an explicit override).
         "dmx_ch_max_batch_items": 16,         # low insert watermark for the smoke
     },
 )

--- a/tests/ring/smoke_toggle_vllm.py
+++ b/tests/ring/smoke_toggle_vllm.py
@@ -1,25 +1,57 @@
-"""Real FULL vLLM server smoke for node-toggle (offline LLM, in-process worker).
+"""Real FULL-decode vLLM smoke gate for node-toggle (offline LLM, in-process worker).
 
 Loads Qwen3-0.6B with the DMXGPUWorker, cudagraph_mode=FULL, node-toggle ON with
 a PARTIAL enabled set (last 4 of 28 hidden-state hooks), full pipeline -> ClickHouse.
 Exercises the real lifecycle: capture window -> producer-node recording -> bind
 captured graphs -> set_active_hooks (eager) -> per-replay graph guard -> meta gate
-+ reserve in lockstep -> drain/p2p -> DB. A desync or guard failure crashes here.
++ reserve in lockstep -> drain/p2p -> DB.
 
-Asserts (via markers grepped by the runner):
-  - bound >=1 captured graphs, nodes registered,
-  - active hooks set to the partial set,
-  - replay guard active (mode=eager) -- the #3 guard runs in vivo,
-  - generation produces text (no desync/crash),
-  - ClickHouse received rows ONLY for the enabled layers (partial-toggle lockstep).
+This is a SELF-CHECKING GATE: it DROPs its table up front (so any rows seen are
+provably from THIS run -- no historical pollution), then asserts the export
+landed rows for EXACTLY the enabled layers with the right shape, and exits
+NONZERO on any failure. SMOKE_OK + exit 0 only on full success.
+
+Note: vLLM may auto-downgrade cudagraph_mode FULL -> FULL_AND_PIECEWISE when the
+attention backend lacks full-graph support; this validates the FULL-DECODE path
+(the graphs node-toggle binds), not full FULL_AND_PIECEWISE coverage.
+
+Requires: fork vllm on PYTHONPATH, the monitoring .so, a cached model
+(SMOKE_MODEL), ClickHouse on localhost:9000.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER HF_HUB_OFFLINE=1 \
+      VLLM_ENABLE_V1_MULTIPROCESSING=0 SMOKE_MODEL=<path> \
+      PYTHONPATH=$PWD/integration/vllm:$PWD <venv>/bin/python tests/ring/smoke_toggle_vllm.py
 """
+import gc
 import os
+import subprocess
 import sys
+import time
 
 MODEL = os.environ["SMOKE_MODEL"]
 DB_TABLE = "smoke_toggle"
 ENABLED = "0:24,0:25,0:26,0:27"          # last 4 layers of Qwen3-0.6B (28 layers)
 ENABLED_LAYERS = {24, 25, 26, 27}
+HIDDEN = 1024                              # Qwen3-0.6B hidden dim; rows are [q_len, HIDDEN]
+                                           # (q_len=1 for decode, >1 for prefill chunks)
+
+
+def ch(query: str) -> str:
+    """Run a clickhouse-client query; FAIL the smoke if the CLI errors."""
+    r = subprocess.run(["clickhouse-client", "--query", query],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        fail(f"clickhouse-client failed ({r.returncode}): {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def fail(msg: str):
+    print(f"SMOKE_FAIL: {msg}", flush=True)
+    sys.exit(1)
+
+
+# --- fresh table: any rows seen afterwards are provably from THIS run (#2) ---
+ch(f"DROP TABLE IF EXISTS {DB_TABLE}")
 
 from vllm import LLM, SamplingParams
 
@@ -49,28 +81,40 @@ out = llm.generate(
      "In the beginning", "A short story about a robot:"],
     SamplingParams(temperature=0.0, max_tokens=48),
 )
-for o in out:
-    print(f"SMOKE_GEN: {o.outputs[0].text!r}", flush=True)
+texts = [o.outputs[0].text for o in out]
+for t in texts:
+    print(f"SMOKE_GEN: {t!r}", flush=True)
+if not all(t.strip() for t in texts):
+    fail("a prompt produced empty output (generation/desync problem)")
 
-# Clean shutdown so the async export pipeline flushes to ClickHouse (low-volume
-# runs won't hit the insert batch watermark, so a flush-on-close is required).
-import gc, time
+# Clean shutdown so the async export pipeline flushes to ClickHouse.
 del llm
 gc.collect()
 time.sleep(3.0)
 
-# Verify rows landed for ONLY the enabled layers (partial-toggle lockstep in vivo)
-# via the clickhouse-client CLI (clickhouse_driver isn't in the venv).
-import subprocess
-q = (f"SELECT layer_no, count() FROM {DB_TABLE} GROUP BY layer_no ORDER BY layer_no "
-     f"FORMAT TSV")
-res = subprocess.run(["clickhouse-client", "--query", q], capture_output=True, text=True)
-print("SMOKE_DB_RAW:\n" + (res.stdout.strip() or "<empty>"), flush=True)
-got = sorted(int(l.split("\t")[0]) for l in res.stdout.strip().splitlines() if l)
-if set(got) == ENABLED_LAYERS:
-    print("SMOKE_DB_OK: rows for EXACTLY the enabled layers (partial-toggle lockstep)", flush=True)
-elif got:
-    print(f"SMOKE_DB_MISMATCH: got {got} expected {sorted(ENABLED_LAYERS)}", flush=True)
-else:
-    print("SMOKE_DB_EMPTY", flush=True)
+# --- strict verification: rows for EXACTLY the enabled layers, right shape ---
+raw = ch(f"SELECT layer_no, count() FROM {DB_TABLE} GROUP BY layer_no ORDER BY layer_no FORMAT TSV")
+print("SMOKE_DB_RAW:\n" + (raw or "<empty>"), flush=True)
+rows = [ln.split("\t") for ln in raw.splitlines() if ln]
+got_layers = sorted(int(c[0]) for c in rows)
+total = sum(int(c[1]) for c in rows)
+
+if total == 0:
+    fail("ClickHouse received 0 rows (export/flush problem)")
+if set(got_layers) != ENABLED_LAYERS:
+    fail(f"delivered layers {got_layers} != enabled {sorted(ENABLED_LAYERS)} (lockstep desync)")
+
+import re
+shapes = ch(f"SELECT DISTINCT shape FROM {DB_TABLE} FORMAT TSV").splitlines()
+# hidden-states rows are [q_len, HIDDEN]: q_len=1 (decode) or >1 (prefill chunk).
+bad = [s for s in shapes if not re.fullmatch(rf"\[\d+,{HIDDEN}\]", s)]
+if bad:
+    fail(f"shapes with wrong hidden dim (expected [*,{HIDDEN}]): {bad}")
+
+print(f"SMOKE_DB_OK: {total} rows, layers={got_layers}, shapes={shapes} "
+      f"(partial-toggle lockstep on a real model)", flush=True)
+
+# Leave the table clean for the next run.
+ch(f"DROP TABLE IF EXISTS {DB_TABLE}")
 print("SMOKE_OK", flush=True)
+sys.exit(0)

--- a/tests/ring/test_reconfig_lazy_e2e.py
+++ b/tests/ring/test_reconfig_lazy_e2e.py
@@ -1,0 +1,130 @@
+"""Lazy per-graph toggle — engine-level correctness (Phase 4, sub-step 4.1).
+
+Same two-graph reconfigure scenarios as test_reconfig_multigraph_e2e, but driven
+through the LAZY path:
+  - reconfigure via set_active_hooks_lazy() (bumps target_version, updates the
+    meta gate, does NOT apply to the device),
+  - ensure_graph_current(raw_graph) just BEFORE each replay (applies the deferred
+    toggle to that one graph if stale),
+  - record_replay_event(raw_graph) right AFTER each replay (event guard).
+
+Asserts the same observable invariant: replaying graph G delivers exactly the
+current enabled set, aligned, from G — regardless of how many reconfigures
+happened since G last ran. This proves the lazy core: if ensure applies the wrong
+graph / misses a version / leaves a graph stale, the stale graph fires its OLD
+enabled set while the gate pushed the NEW set -> misalignment -> failure here.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> python tests/ring/test_reconfig_lazy_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+OFF_A, OFF_B = 0.0, 100.0
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    collected = []
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append((int(layer_no), float(slice_.reshape(-1)[0].item())))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport.set_step_context(
+        model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+        dim0_offsets=[0], kv_offsets=[0], flattened=True)
+
+    payload = engine.payload_tensor()  # Tensor(a!) alias for the 4-arg producer op
+    srcA = [torch.full((QLEN, HID), OFF_A + j, device="cuda", dtype=torch.float32) for j in range(N)]
+    srcB = [torch.full((QLEN, HID), OFF_B + j, device="cuda", dtype=torch.float32) for j in range(N)]
+
+    gA = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(gA):
+        for j in range(N):
+            torch.ops.ring.producer(payload, srcA[j], HT, j)
+    gA.instantiate()
+    gB = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(gB):
+        for j in range(N):
+            torch.ops.ring.producer(payload, srcB[j], HT, j)
+    gB.instantiate()
+    engine.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
+    engine.bind_graph_exec(gB.raw_cuda_graph(), gB.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    graphs = {"A": (gA, OFF_A), "B": (gB, OFF_B)}
+    cur = {"enabled": None}
+
+    def reconfig(enabled):                         # LAZY: no device apply here
+        cur["enabled"] = sorted(enabled)
+        transport.set_active_hooks_lazy([(HT, j) for j in enabled])
+
+    def replay(name):
+        g, off = graphs[name]
+        keep = cur["enabled"]
+        collected.clear()
+        transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)
+        transport.ensure_graph_current(g.raw_cuda_graph())   # lazy: apply deferred toggle to G
+        g.replay()
+        transport.record_replay_event(g.raw_cuda_graph())    # lazy: event guard
+        torch.cuda.synchronize()
+        engine.flush_and_wait()
+        for _ in range(200):
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+        delivered = sorted(l for l, _ in collected)
+        aligned = all(m == l + off for l, m in collected)
+        tag = f"replay {name} (enabled={keep})"
+        check(delivered == keep, f"{tag}: delivered {delivered} == {keep}")
+        check(aligned, f"{tag}: aligned + from graph {name} (marker==layer+{int(off)})")
+
+    # Same scenarios as the eager multi-graph guardrail, via the lazy path.
+    reconfig([0, 2]); replay("B"); replay("B"); replay("A")     # deferred apply: first-time A
+    reconfig([1, 3]); replay("A"); replay("B")                  # one-version stale (B)
+    reconfig([0, 1, 2, 3]); reconfig([2]); replay("A"); replay("B")  # two-version stale
+    reconfig([]); replay("A"); replay("B")                      # empty
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_reconfig_lazy_e2e.py
+++ b/tests/ring/test_reconfig_lazy_e2e.py
@@ -1,4 +1,4 @@
-"""Lazy per-graph toggle — engine-level correctness (Phase 4, sub-step 4.1).
+"""Lazy per-graph toggle — engine-level correctness.
 
 Same two-graph reconfigure scenarios as test_reconfig_multigraph_e2e, but driven
 through the LAZY path:

--- a/tests/ring/test_reconfig_multigraph_e2e.py
+++ b/tests/ring/test_reconfig_multigraph_e2e.py
@@ -8,9 +8,9 @@ the OBSERVABLE invariant:
     data came from G (per-graph marker), regardless of how many reconfigures
     happened since G was last replayed.
 
-This is implementation-agnostic: it passes under today's eager apply (every graph
-updated on every reconfigure) AND is the safety net for lazy per-graph apply
-(reconfigure only bumps a version; each graph is applied just before it replays).
+This is implementation-agnostic: it passes under the eager apply (every graph
+updated on every reconfigure) AND under the lazy per-graph apply (reconfigure
+only bumps a version; each graph is applied just before it replays).
 The lazy bugs it catches: a stale graph firing its OLD enabled set while the meta
 gate pushed the NEW set (-> desync), applying to the wrong graph, or missing a
 multi-version-stale catch-up. Covered transitions: deferred apply (replay B then

--- a/tests/ring/test_reconfig_multigraph_e2e.py
+++ b/tests/ring/test_reconfig_multigraph_e2e.py
@@ -1,0 +1,140 @@
+"""Multi-graph reconfigure guardrail (prerequisite for lazy per-graph toggle).
+
+Binds TWO captured graphs (A, B) that register the same hook set, then drives a
+sequence of reconfigures and *selective* replays. After every replay it asserts
+the OBSERVABLE invariant:
+
+    replaying graph G delivers exactly the CURRENT enabled set, aligned, and the
+    data came from G (per-graph marker), regardless of how many reconfigures
+    happened since G was last replayed.
+
+This is implementation-agnostic: it passes under today's eager apply (every graph
+updated on every reconfigure) AND is the safety net for lazy per-graph apply
+(reconfigure only bumps a version; each graph is applied just before it replays).
+The lazy bugs it catches: a stale graph firing its OLD enabled set while the meta
+gate pushed the NEW set (-> desync), applying to the wrong graph, or missing a
+multi-version-stale catch-up. Covered transitions: deferred apply (replay B then
+first-time A), one-version stale (alternate A/B across a reconfigure), two-version
+stale (two reconfigures with no replay between), and empty.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> python tests/ring/test_reconfig_multigraph_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+OFF_A, OFF_B = 0.0, 100.0     # per-graph marker offset: A src[j]=j, B src[j]=100+j
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    collected = []   # (layer_no, marker)
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append((int(layer_no), float(slice_.reshape(-1)[0].item())))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport.set_step_context(
+        model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+        dim0_offsets=[0], kv_offsets=[0], flattened=True)
+
+    # Two graphs, same hook set (so toggle_registry_uniform passes), distinct
+    # markers so we can tell which graph delivered.
+    payload = engine.payload_tensor()  # Tensor(a!) alias for the 4-arg producer op
+    srcA = [torch.full((QLEN, HID), OFF_A + j, device="cuda", dtype=torch.float32) for j in range(N)]
+    srcB = [torch.full((QLEN, HID), OFF_B + j, device="cuda", dtype=torch.float32) for j in range(N)]
+
+    gA = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(gA):
+        for j in range(N):
+            torch.ops.ring.producer(payload, srcA[j], HT, j)
+    gA.instantiate()
+    gB = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(gB):
+        for j in range(N):
+            torch.ops.ring.producer(payload, srcB[j], HT, j)
+    gB.instantiate()
+
+    engine.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
+    engine.bind_graph_exec(gB.raw_cuda_graph(), gB.raw_cuda_graph_exec())
+    check(engine.bound_graph_count() == 2, f"bound 2 graphs (got {engine.bound_graph_count()})")
+    check(engine.toggle_registry_uniform(), "registries uniform across A,B")
+
+    engine.set_null_mode(False)
+
+    graphs = {"A": (gA, OFF_A), "B": (gB, OFF_B)}
+    cur = {"enabled": None}
+
+    def reconfig(enabled):
+        cur["enabled"] = sorted(enabled)
+        transport.set_active_hooks([(HT, j) for j in enabled])
+
+    def replay(name):
+        g, off = graphs[name]
+        keep = cur["enabled"]
+        collected.clear()
+        transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)
+        g.replay()
+        torch.cuda.synchronize()
+        engine.flush_and_wait()
+        for _ in range(200):
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+        delivered = sorted(l for l, _ in collected)
+        aligned = all(m == l + off for l, m in collected)          # right enabled set + right GRAPH
+        tag = f"replay {name} (enabled={keep})"
+        check(delivered == keep, f"{tag}: delivered {delivered} == {keep}")
+        check(aligned, f"{tag}: aligned + from graph {name} (marker==layer+{int(off)})")
+
+    # --- deferred apply: reconfigure, replay B twice, THEN first-time A ---
+    reconfig([0, 2]); replay("B"); replay("B"); replay("A")
+    # --- one-version stale: reconfigure, replay A, then B (B was at prev set) ---
+    reconfig([1, 3]); replay("A"); replay("B")
+    # --- two-version stale: two reconfigures, no replay between, then A then B ---
+    reconfig([0, 1, 2, 3]); reconfig([2]); replay("A"); replay("B")
+    # --- empty ---
+    reconfig([]); replay("A"); replay("B")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_reconfig_sequence_e2e.py
+++ b/tests/ring/test_reconfig_sequence_e2e.py
@@ -1,0 +1,123 @@
+"""Reconfigure-sequence alignment guardrail (transport-level lockstep).
+
+Runs a SEQUENCE of set_active_hooks() reconfigures (including empty/full and
+arbitrary transitions) on one captured graph, replaying after each, and verifies
+the meta gate stays aligned every round:
+  - delivered layers == the round's enabled set (host meta set == device enabled),
+  - each delivered slice is aligned (layer_no == payload marker, no desync),
+  - disabled hooks deliver nothing.
+
+This guards the toggle *reconfigure* path through the REAL pipeline
+(producer -> drain -> p2p -> submit): a wrong reconfigure (stale node, wrong
+graph, bad diff seed, or a meta-gate that diverges from the device enabled set)
+would desync and fail here.
+
+Targets the post-#40/#51 backend: producer op is 4-arg
+``producer(ring_payload, x, hook_type, hook_id)``. Option-B: every hook uses the
+basic producer (no gpu_padding_strip), so all nodes are toggle-recorded.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_reconfig_sequence_e2e.py
+Requires the built backend + torch CUDA.
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE          # hidden-dim hook: shape [q_len, hidden_dim]
+N = 4
+QLEN, HID = 4, 8
+fails = 0
+
+# Reconfigure sequence -- exercises every transition kind: partial->partial,
+# disjoint swap, grow to full, full->empty, empty->single, and empty->empty.
+ROUNDS = [[0, 2], [1, 3], [0, 1, 2, 3], [], [2], [0, 3], [], [1]]
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    collected = []   # (layer_no, marker) per submitted slice
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append((int(layer_no), float(slice_.reshape(-1)[0].item())))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()    # the Tensor(a!) alias every producer op takes
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport.set_step_context(
+        model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+        dim0_offsets=[0], kv_offsets=[0], flattened=True)
+
+    # src[j] filled with value j -> slice marker identifies the producer.
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    check(engine.toggle_node_count() == N, f"registered {N} nodes (got {engine.toggle_node_count()})")
+
+    engine.set_null_mode(False)
+
+    for r_i, keep in enumerate(ROUNDS):
+        collected.clear()
+        transport.set_active_hooks([(HT, j) for j in keep])          # device toggle + gate
+        # effective_specs (Layer-2 single source) must equal the enabled set.
+        eff = sorted(s.layer_no for s in transport.effective_specs)
+        check(eff == sorted(keep), f"round {r_i} keep={keep}: effective_specs {eff} == enabled")
+        transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)  # gated meta push
+        g.replay()
+        torch.cuda.synchronize()
+        engine.flush_and_wait()                                      # force drain
+        for _ in range(200):                                         # wait for p2p submit
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+
+        delivered = sorted(l for l, _ in collected)
+        aligned = all(layer == marker for layer, marker in collected)
+        only_enabled = all(l in keep for l, _ in collected)
+        tag = f"round {r_i} keep={keep}"
+        check(delivered == sorted(keep), f"{tag}: delivered {delivered} == enabled {sorted(keep)}")
+        check(aligned, f"{tag}: each slice aligned (layer_no == marker, no desync)")
+        check(only_enabled, f"{tag}: no disabled hook delivered")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_reconfig_sequence_e2e.py
+++ b/tests/ring/test_reconfig_sequence_e2e.py
@@ -12,9 +12,9 @@ This guards the toggle *reconfigure* path through the REAL pipeline
 graph, bad diff seed, or a meta-gate that diverges from the device enabled set)
 would desync and fail here.
 
-Targets the post-#40/#51 backend: producer op is 4-arg
-``producer(ring_payload, x, hook_type, hook_id)``. Option-B: every hook uses the
-basic producer (no gpu_padding_strip), so all nodes are toggle-recorded.
+Every hook uses the basic producer
+``producer(ring_payload, x, hook_type, hook_id)`` (no gpu_padding_strip), so all
+nodes are toggle-recorded.
 
 Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
       python tests/ring/test_reconfig_sequence_e2e.py
@@ -89,7 +89,7 @@ def main():
     for r_i, keep in enumerate(ROUNDS):
         collected.clear()
         transport.set_active_hooks([(HT, j) for j in keep])          # device toggle + gate
-        # effective_specs (Layer-2 single source) must equal the enabled set.
+        # effective_specs (the single source) must equal the enabled set.
         eff = sorted(s.layer_no for s in transport.effective_specs)
         check(eff == sorted(keep), f"round {r_i} keep={keep}: effective_specs {eff} == enabled")
         transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)  # gated meta push

--- a/tests/ring/test_reserve_invariant_e2e.py
+++ b/tests/ring/test_reserve_invariant_e2e.py
@@ -1,4 +1,4 @@
-"""Reserve-invariant guardrail (Layer 3: capacity path reads effective_specs).
+"""Reserve-invariant guardrail (capacity path reads effective_specs).
 
 Drives the REAL adaptor capacity path -- BackendAdaptor._compute_step_plan ->
 prepare_step -> pre_push_all_metas -> replay -> drain -- across a sequence of
@@ -9,11 +9,11 @@ node-toggle reconfigures, and asserts the reserve invariant every round:
   - after flush the ring FULLY DRAINS (payload/task head == tail_committed):
     reserve() matched what producers actually wrote, so the head-tail gap does
     NOT drift. Reserving for the full active_specs while only the enabled subset
-    fires (the pre-Layer-3 bug) would leave head > tail by the over-reserved
-    amount, growing every step -> caught here.
+    fires would leave head > tail by the over-reserved amount, growing every
+    step -> caught here.
 
-Targets the post-#40/#51 backend (4-arg producer op). Option-B: basic producer
-only (no gpu_padding_strip), so every node is toggle-recorded.
+Every hook uses the basic producer (no gpu_padding_strip), so every node is
+toggle-recorded.
 
 Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
       python tests/ring/test_reserve_invariant_e2e.py

--- a/tests/ring/test_reserve_invariant_e2e.py
+++ b/tests/ring/test_reserve_invariant_e2e.py
@@ -1,0 +1,151 @@
+"""Reserve-invariant guardrail (Layer 3: capacity path reads effective_specs).
+
+Drives the REAL adaptor capacity path -- BackendAdaptor._compute_step_plan ->
+prepare_step -> pre_push_all_metas -> replay -> drain -- across a sequence of
+node-toggle reconfigures, and asserts the reserve invariant every round:
+
+  - _compute_step_plan's n_hooks == #enabled hooks (capacity-reserve set ==
+    meta-push set == device-enabled set, all read transport.effective_specs),
+  - after flush the ring FULLY DRAINS (payload/task head == tail_committed):
+    reserve() matched what producers actually wrote, so the head-tail gap does
+    NOT drift. Reserving for the full active_specs while only the enabled subset
+    fires (the pre-Layer-3 bug) would leave head > tail by the over-reserved
+    amount, growing every step -> caught here.
+
+Targets the post-#40/#51 backend (4-arg producer op). Option-B: basic producer
+only (no gpu_padding_strip), so every node is toggle-recorded.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_reserve_invariant_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+from monitoring.adaptor_base import BackendAdaptor
+from monitoring.step_context import StepContext
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+fails = 0
+
+# Includes over-reserve-prone transitions: full->empty, partial, full again.
+ROUNDS = [[0, 1, 2, 3], [0, 2], [], [1], [0, 1, 2, 3], [3], []]
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+class _ProbeAdaptor(BackendAdaptor):
+    """Minimal concrete adaptor: we only exercise the inherited
+    _compute_step_plan, so the abstract methods are stubs."""
+    def detect_model_shape(self, model):        return None
+    def detect_parallel_ranks(self):            return (0, 0, 0, 0)
+    def is_pp_first(self):                        return True
+    def is_pp_last(self):                         return True
+    def build_step_context(self, *raw):          return None
+    def on_capacity_exceeded(self, ctx):         pass
+
+
+def main():
+    collected = []
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append(int(layer_no))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport._active_specs = specs
+
+    # Minimal adaptor wired to our hand-built transport (bypass __init__, which
+    # expects a MonitoringEngine).
+    adaptor = _ProbeAdaptor.__new__(_ProbeAdaptor)
+    adaptor.model_cfg = mcfg
+    adaptor.active_specs = specs
+    adaptor.transport = transport
+    adaptor.ring_engine = engine
+    adaptor._warned_shapes = set()
+
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    def ctx_for():
+        return StepContext(model_id="m", flattened=True, req_ids=["r"],
+                           token_ranges=[(0, QLEN)], dim0_offsets=[0],
+                           kv_offsets=[0], batch=0, q_len=QLEN, kv_dim=0)
+
+    for r_i, keep in enumerate(ROUNDS):
+        collected.clear()
+        transport.set_active_hooks([(HT, j) for j in keep])
+
+        ctx = ctx_for()
+        total_bytes, n_hooks, needs_eager = adaptor._compute_step_plan(ctx)
+        check(n_hooks == len(keep),
+              f"round {r_i} keep={keep}: _compute_step_plan n_hooks={n_hooks} == {len(keep)}")
+
+        if n_hooks > 0:
+            res = engine.prepare_step(total_bytes, n_hooks)
+            check(res == 0, f"round {r_i}: prepare_step RING_OK (got {res})")
+        transport.set_step_context(**ctx.transport_kwargs())
+        transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)
+
+        g.replay()
+        torch.cuda.synchronize()
+        engine.flush_and_wait()
+        for _ in range(200):
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+        engine.flush_and_wait()
+
+        st = engine.get_stats()
+        pgap = st.cpu_payload_head - st.cpu_payload_tail_committed
+        tgap = st.cpu_task_head - st.cpu_task_tail_committed
+        check(pgap == 0 and tgap == 0,
+              f"round {r_i} keep={keep}: ring fully drained "
+              f"(payload_gap={pgap}, task_gap={tgap}) -> reserve == writes")
+        check(sorted(collected) == sorted(keep),
+              f"round {r_i} keep={keep}: delivered {sorted(collected)} == enabled")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_binding.py
+++ b/tests/ring/test_toggle_binding.py
@@ -1,4 +1,4 @@
-"""Phase B test: the node-toggle binding through the REAL backend + producer op.
+"""Node-toggle binding through the REAL backend + producer op.
 
 Drives torch.ops.ring.producer inside a torch CUDA-graph capture (keep_graph=True)
 with the engine active and toggle-capture on, so the producer op records its kernel
@@ -7,13 +7,13 @@ node via cudaStreamGetCaptureInfo. Then exercises the Python binding:
   - is_hook_enabled():   enabled-set single-source gate (for pre_push_all_metas)
   - effective_enabled_mask(): batched gate matches is_hook_enabled
   - apply_toggle():      cudaGraphNodeSetEnabled on torch's raw_cuda_graph_exec using
-                         the capture-recorded handles SUCCEEDS (err 0) -> the whole
-                         Phase 3 mechanism works through the real DMI backend.
+                         the capture-recorded handles SUCCEEDS (err 0) -> the
+                         toggle mechanism works through the real DMI backend.
 
-Note: this targets the post-#40/#51 backend, whose producer op signature is
+Note: the producer op signature is
 ``producer(Tensor(a!) ring_payload, Tensor x, int hook_type, int hook_id)``.
-Option-B assumption: toggle records nodes only from the *basic* producer op, so
-this test uses producer (not producer_prefix/producer_chunked).
+This test drives the *basic* producer op only (producer_prefix has its own gate,
+test_toggle_prefix_e2e).
 
 Run:  CUDA_MODULE_LOADING=EAGER python tests/ring/test_toggle_binding.py
 Requires the built backend (monitoring_native_backend*.so at repo root) + torch CUDA.

--- a/tests/ring/test_toggle_binding.py
+++ b/tests/ring/test_toggle_binding.py
@@ -1,0 +1,115 @@
+"""Phase B test: the node-toggle binding through the REAL backend + producer op.
+
+Drives torch.ops.ring.producer inside a torch CUDA-graph capture (keep_graph=True)
+with the engine active and toggle-capture on, so the producer op records its kernel
+node via cudaStreamGetCaptureInfo. Then exercises the Python binding:
+  - toggle_node_count(): capture-time registration worked
+  - is_hook_enabled():   enabled-set single-source gate (for pre_push_all_metas)
+  - effective_enabled_mask(): batched gate matches is_hook_enabled
+  - apply_toggle():      cudaGraphNodeSetEnabled on torch's raw_cuda_graph_exec using
+                         the capture-recorded handles SUCCEEDS (err 0) -> the whole
+                         Phase 3 mechanism works through the real DMI backend.
+
+Note: this targets the post-#40/#51 backend, whose producer op signature is
+``producer(Tensor(a!) ring_payload, Tensor x, int hook_type, int hook_id)``.
+Option-B assumption: toggle records nodes only from the *basic* producer op, so
+this test uses producer (not producer_prefix/producer_chunked).
+
+Run:  CUDA_MODULE_LOADING=EAGER python tests/ring/test_toggle_binding.py
+Requires the built backend (monitoring_native_backend*.so at repo root) + torch CUDA.
+"""
+import os
+import sys
+
+# Make the repo-root monitoring_native_backend*.so importable regardless of cwd.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+import monitoring_native_backend as ne
+
+N = 4                       # producer "hooks"
+HT = 0                      # hook_type (RESID_PRE)
+ELEMS = 4096
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.task_ring_entries = 4096
+    engine = ne.RingEngine(cfg, None)          # no host engine; we don't observe submits here
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+
+    # The Tensor(a!) mutation-alias arg every producer op now takes.
+    payload = engine.payload_tensor()
+    src = [torch.full((ELEMS,), float(j), device="cuda") for j in range(N)]
+
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            # hook_id == layer_no (see ring_transport._hook_id_from_name)
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+
+    print("[registration]")
+    check(engine.toggle_node_count() == N,
+          f"toggle_node_count == {N} (got {engine.toggle_node_count()})")
+    check(engine.bound_graph_count() == 1,
+          f"bound_graph_count == 1 (got {engine.bound_graph_count()})")
+    check(engine.toggle_registry_uniform(), "single graph -> registry uniform")
+
+    print("[enabled-set gate is_hook_enabled]")
+    # Before any set_enabled_hooks, toggle inactive -> all enabled.
+    check(all(engine.is_hook_enabled(HT, j) for j in range(N)),
+          "all hooks enabled before set_enabled_hooks (toggle inactive)")
+    keep = [0, 2]
+    engine.set_enabled_hooks([(HT, j) for j in keep])
+    gate_ok = all(engine.is_hook_enabled(HT, j) == (j in keep) for j in range(N))
+    check(gate_ok, f"is_hook_enabled matches enabled set {keep}")
+
+    print("[effective_enabled_mask (batched gate)]")
+    mask = engine.effective_enabled_mask([(HT, j) for j in range(N)])
+    check(mask == [1 if j in keep else 0 for j in range(N)],
+          f"effective_enabled_mask matches is_hook_enabled (got {mask})")
+
+    # #14 desync guard: a hook that was never captured must gate OFF even if
+    # someone puts it in the enabled set (else meta pushed with no payload).
+    engine.set_enabled_hooks([(HT, 0), (HT, 99)])   # layer 99 was not captured
+    check(engine.is_hook_enabled(HT, 0) and not engine.is_hook_enabled(HT, 99),
+          "enabled-but-uncaptured hook (HT,99) gated off (#14 guard)")
+
+    print("[apply_toggle on torch exec with capture-recorded handles]")
+    err = engine.apply_toggle()
+    check(err == 0, f"apply_toggle() returns cudaSuccess (got {err})")
+
+    # re-enable all and re-apply
+    engine.set_enabled_hooks([(HT, j) for j in range(N)])
+    check(engine.apply_toggle() == 0, "apply_toggle() ok after re-enable")
+
+    print("[clear_toggle_registry resets state]")
+    engine.clear_toggle_registry()
+    check(engine.toggle_node_count() == 0 and engine.bound_graph_count() == 0,
+          "registry empty after clear")
+    check(engine.is_hook_enabled(HT, 0),
+          "toggle inactive after clear -> all-on gate")
+
+    ne.ring_clear_active_engine()
+    engine.stop()
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_chunked_failclosed_e2e.py
+++ b/tests/ring/test_toggle_chunked_failclosed_e2e.py
@@ -1,7 +1,7 @@
 """Chunked producer fail-closed under node-toggle.
 
-The chunked producer is not toggle-managed (the prefix-path Option A covers basic
-+ prefix only). If one fires during capture, its node is NOT recorded and a
+The chunked producer is not toggle-managed (only the basic and prefix producers
+record their kernel nodes). If one fires during capture, its node is NOT recorded and a
 capture anomaly is flagged, so set_active_hooks / set_active_hooks_lazy must
 REFUSE to activate (fail-closed) -- otherwise it would be a fired-but-unregistered
 producer (silent desync). This gate captures a MIXED graph (basic producers

--- a/tests/ring/test_toggle_chunked_failclosed_e2e.py
+++ b/tests/ring/test_toggle_chunked_failclosed_e2e.py
@@ -1,0 +1,97 @@
+"""Chunked producer fail-closed under node-toggle.
+
+The chunked producer is not toggle-managed (the prefix-path Option A covers basic
++ prefix only). If one fires during capture, its node is NOT recorded and a
+capture anomaly is flagged, so set_active_hooks / set_active_hooks_lazy must
+REFUSE to activate (fail-closed) -- otherwise it would be a fired-but-unregistered
+producer (silent desync). This gate captures a MIXED graph (basic producers
+registered + one chunked producer) and asserts:
+  - capture_anomaly_count() > 0, chunked node NOT registered,
+  - set_active_hooks raises, message names 'chunked' + the remedy,
+  - set_active_hooks_lazy raises too.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_chunked_failclosed_e2e.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+HID = 8
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    engine = ne.RingEngine(cfg, None)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(3)]
+
+    # Mixed graph: two BASIC producers (layers 0,1 -> registered) + one CHUNKED
+    # producer (layer 2 -> anomaly, not registered).
+    src = [torch.full((4, HID), float(j), device="cuda", dtype=torch.float32) for j in range(2)]
+    cx = torch.full((32,), 1.0, device="cuda", dtype=torch.float32)
+    chunk_bytes = torch.tensor([16, 16], dtype=torch.int64, device="cuda")  # K=2
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        torch.ops.ring.producer(payload, src[0], HT, 0)
+        torch.ops.ring.producer(payload, src[1], HT, 1)
+        torch.ops.ring.producer_chunked(payload, cx, chunk_bytes, HT, 2)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+
+    check(engine.toggle_node_count() == 2,
+          f"only the 2 basic producers registered (got {engine.toggle_node_count()})")
+    check(engine.capture_anomaly_count() >= 1,
+          f"chunked producer flagged a capture anomaly (got {engine.capture_anomaly_count()})")
+
+    print("[set_active_hooks must fail closed]")
+    raised = False
+    try:
+        transport.set_active_hooks([(HT, 0)])
+    except RuntimeError as e:
+        msg = str(e)
+        raised = "chunked" in msg and "gpu_padding_strip" in msg
+        print("   ->", msg.split(" -- ")[0] if " -- " in msg else msg[:80])
+    check(raised, "set_active_hooks RAISES naming 'chunked' + the remedy (fail-closed)")
+
+    print("[set_active_hooks_lazy must fail closed too]")
+    raised_lazy = False
+    try:
+        transport.set_active_hooks_lazy([(HT, 0)])
+    except RuntimeError as e:
+        raised_lazy = "chunked" in str(e)
+    check(raised_lazy, "set_active_hooks_lazy RAISES (fail-closed)")
+
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_force_eager_gate_e2e.py
+++ b/tests/ring/test_toggle_force_eager_gate_e2e.py
@@ -1,0 +1,141 @@
+"""force_eager (capacity-overflow) on a gated decode step must still gate.
+
+The eager safety net (HookPoint.forward's force_eager branch) fires producers
+WITHOUT a graph, so cudaGraphNodeSetEnabled cannot gate them. On a gated decode
+step that overflowed -> force_eager, a disabled hook must skip there too, or it
+fires while meta/reserve counted only the enabled subset -> ring desync (same
+shape as the prefill over-fire bug, via a different eager path).
+
+This gate builds real HookPoints, captures them (so they're registered), sets a
+decode subset active, then drives every HookPoint.forward EAGERLY with
+force_eager=True and _gated_step=True (the gated-decode-overflow case).
+
+NOTE the failure mode is content corruption, NOT a ring gap: the eager path
+reserves per-hook (reserve_one, 1:1 with dispatch), so head/tail stay balanced
+even when over-firing. The damage is meta<->payload MISPAIRING -- N producers
+fire but only K metas were pushed, so the flat FIFO pairs the K metas with the
+WRONG K payloads. Each producer writes its layer index as a marker, so the test
+checks delivered (layer_no == payload marker); a disabled hook firing shifts the
+pairing and a row's marker stops matching its label. Teeth: neutering the eager
+gate makes all N fire -> mispaired markers -> FAIL.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_force_eager_gate_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+from monitoring.hook_points import HookPoint
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+SUBSET = [0, 2]
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    collected = []      # (layer_no from meta, marker value from payload)
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        marker = int(round(float(slice_.flatten()[0].item())))
+        collected.append((int(layer_no), marker))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    rt.activate(transport)                      # _active_transport -> transport
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport._active_specs = specs
+
+    payload = engine.payload_tensor()
+    # Build real HookPoints; capture them into a graph so they register, bind it.
+    hps = []
+    for j in range(N):
+        hp = HookPoint()
+        hp._ring_hook_type = HT
+        hp._ring_hook_id = j
+        hp._ring_payload = payload
+        hp._strip_tensor = None
+        hp._strip_row_bytes = 0
+        hp.enabled = True
+        hps.append(hp)
+
+    xs = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32)
+          for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            hps[j](xs[j])               # captures each producer node
+    g.instantiate()
+    engine.enable_toggle_capture(False)
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    transport.set_active_hooks([(HT, j) for j in SUBSET])   # gate active, subset
+
+    # Simulate a gated decode step forced to the eager safety net.
+    transport._gated_step = True
+    transport.force_eager = True
+    transport.set_step_context(model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+                               dim0_offsets=[0], kv_offsets=[0], flattened=True)
+    transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)   # subset metas
+
+    for j in range(N):                  # every HookPoint.forward runs (eager)
+        hps[j](xs[j])
+    torch.cuda.synchronize()
+
+    engine.flush_and_wait()
+    for _ in range(200):
+        if len(collected) >= len(SUBSET):
+            break
+        time.sleep(0.01)
+    time.sleep(0.03)
+    engine.flush_and_wait()
+
+    got_layers = sorted(l for l, _ in collected)
+    check(got_layers == sorted(SUBSET),
+          f"eager force_eager delivered layers {got_layers} == subset {sorted(SUBSET)}")
+    # The teeth: every delivered row's payload marker must equal its label.
+    # A disabled hook firing shifts the FIFO pairing -> marker != layer_no.
+    mispaired = [(l, m) for l, m in collected if l != m]
+    check(not mispaired,
+          f"every row's payload marker matches its layer label "
+          f"(mispaired={mispaired}) -- disabled hooks did NOT fire into the FIFO")
+
+    transport.force_eager = False
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    rt.deactivate()
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_graph_guard_e2e.py
+++ b/tests/ring/test_toggle_graph_guard_e2e.py
@@ -1,0 +1,142 @@
+"""Graph-guard failure paths (fixes #3 + #4).
+
+#4 registry completeness: set_active_hooks must RAISE when the set of graphs with
+   recorded producer nodes != the set of bound execs (partial/mismatched bind).
+
+#3 replay-time guard: with a toggle gate active, replaying a graph that is NOT
+   registered+bound (e.g. one vLLM captured at RUNTIME after DMI closed its
+   capture window) must RAISE -- such a graph's producers run default-ON while
+   the meta gate filters to the enabled subset, which would desync the ring.
+   A registered+bound graph must replay fine.
+
+Targets the post-#40/#51 backend (4-arg producer op). Option-B: basic producer.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_graph_guard_e2e.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+import integration.vllm_adapter as va
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 3
+QLEN, HID = 4, 8
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def _new_engine():
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 32 * 1024 * 1024
+    eng = ne.RingEngine(cfg, None)
+    eng.init(0)
+    return eng
+
+
+def _capture(engine, payload, record):
+    """Capture a graph of N producer ops. record=True -> toggle nodes recorded."""
+    engine.enable_toggle_capture(record)
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+    engine.enable_toggle_capture(False)
+    return g, src   # keep src alive
+
+
+def test_completeness_guard():
+    print("[#4 registry completeness]")
+    eng = _new_engine()
+    ne.ring_set_active_engine(eng)
+    eng.set_null_mode(True)
+    payload = eng.payload_tensor()
+    transport = RingTransport(eng)
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+
+    gA, _sa = _capture(eng, payload, record=True)    # reg_nodes = {A}
+    gB, _sb = _capture(eng, payload, record=False)   # B has NO recorded nodes
+    eng.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
+    eng.bind_graph_exec(gB.raw_cuda_graph(), gB.raw_cuda_graph_exec())  # reg_exec = {A, B}
+
+    check(not eng.toggle_registry_complete(),
+          "toggle_registry_complete() False when reg_nodes={A} != reg_exec={A,B}")
+    raised = False
+    try:
+        transport.set_active_hooks([(HT, 0)])
+    except RuntimeError as e:
+        raised = "incomplete" in str(e)
+    check(raised, "set_active_hooks RAISES on incomplete registry (partial/extra bind)")
+
+    ne.ring_clear_active_engine()
+    eng.stop()
+
+
+def test_replay_guard():
+    print("[#3 replay-time unknown-graph guard]")
+    va._patch_cudagraph_keep_graph()
+    va._DMX_TOGGLE_REPLAY_GUARD = True
+
+    eng = _new_engine()
+    eng.set_null_mode(True)
+    transport = RingTransport(eng)
+    rt.activate(transport)                            # get_active() -> transport; sets engine ptr
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    payload = eng.payload_tensor()
+
+    gA, _sa = _capture(eng, payload, record=True)     # registered
+    eng.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())  # bound -> ready
+    transport.set_active_hooks([(HT, j) for j in range(N)])             # eager gate active
+
+    check(transport.is_graph_ready(gA.raw_cuda_graph()), "graph A is registered+bound (ready)")
+
+    # A is ready -> replay must NOT raise (the guard lets it through).
+    ok = True
+    try:
+        gA.replay(); torch.cuda.synchronize()
+    except RuntimeError:
+        ok = False
+    check(ok, "ready graph A replays through the guard without raising")
+
+    # B is captured WITHOUT recording (simulates a runtime-new graph) -> unknown.
+    gB, _sb = _capture(eng, payload, record=False)
+    check(not transport.is_graph_ready(gB.raw_cuda_graph()), "graph B is NOT ready (unregistered)")
+    raised = False
+    try:
+        gB.replay(); torch.cuda.synchronize()
+    except RuntimeError as e:
+        raised = "FATAL" in str(e) and "NOT registered" in str(e)
+    check(raised, "unknown graph B RAISES fatal at replay (would-be desync blocked)")
+
+    rt.deactivate()
+    va._DMX_TOGGLE_REPLAY_GUARD = False
+    eng.stop()
+
+
+def main():
+    test_completeness_guard()
+    test_replay_guard()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_graph_guard_e2e.py
+++ b/tests/ring/test_toggle_graph_guard_e2e.py
@@ -1,15 +1,13 @@
-"""Graph-guard failure paths (fixes #3 + #4).
+"""Graph-guard failure paths.
 
-#4 registry completeness: set_active_hooks must RAISE when the set of graphs with
+Registry completeness: set_active_hooks must RAISE when the set of graphs with
    recorded producer nodes != the set of bound execs (partial/mismatched bind).
 
-#3 replay-time guard: with a toggle gate active, replaying a graph that is NOT
+Replay-time guard: with a toggle gate active, replaying a graph that is NOT
    registered+bound (e.g. one vLLM captured at RUNTIME after DMI closed its
    capture window) must RAISE -- such a graph's producers run default-ON while
    the meta gate filters to the enabled subset, which would desync the ring.
    A registered+bound graph must replay fine.
-
-Targets the post-#40/#51 backend (4-arg producer op). Option-B: basic producer.
 
 Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
       python tests/ring/test_toggle_graph_guard_e2e.py
@@ -60,7 +58,7 @@ def _capture(engine, payload, record):
 
 
 def test_completeness_guard():
-    print("[#4 registry completeness]")
+    print("[registry completeness]")
     eng = _new_engine()
     ne.ring_set_active_engine(eng)
     eng.set_null_mode(True)
@@ -89,7 +87,7 @@ def test_completeness_guard():
 
 
 def test_replay_guard():
-    print("[#3 replay-time unknown-graph guard]")
+    print("[replay-time unknown-graph guard]")
     va._patch_cudagraph_keep_graph()
     va._DMX_TOGGLE_REPLAY_GUARD = True
 

--- a/tests/ring/test_toggle_graph_guard_e2e.py
+++ b/tests/ring/test_toggle_graph_guard_e2e.py
@@ -131,9 +131,39 @@ def test_replay_guard():
     eng.stop()
 
 
+def test_capture_anomaly_guard():
+    """A capture-time non-kernel tail node (recorded as an anomaly) must make
+    set_active_hooks fail loud (fail-closed) -- registering a wrong node would
+    toggle the wrong graph node. Simulated via the test-only note_capture_anomaly."""
+    print("[capture-anomaly fail-closed]")
+    eng = _new_engine()
+    ne.ring_set_active_engine(eng)
+    eng.set_null_mode(True)
+    payload = eng.payload_tensor()
+    transport = RingTransport(eng)
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    gA, _sa = _capture(eng, payload, record=True)
+    eng.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
+    check(eng.capture_anomaly_count() == 0, "real producer capture -> 0 anomalies (validation ran clean)")
+
+    eng.note_capture_anomaly()   # simulate a non-kernel tail node recorded during capture
+    raised = False
+    try:
+        transport.set_active_hooks([(HT, 0)])
+    except RuntimeError as e:
+        raised = "non-kernel" in str(e)
+    check(raised, "set_active_hooks RAISES when a capture anomaly was recorded (fail-closed)")
+
+    ne.ring_clear_active_engine()
+    eng.stop()
+
+
 def main():
     test_completeness_guard()
     test_replay_guard()
+    test_capture_anomaly_guard()
     print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
     return 1 if fails else 0
 

--- a/tests/ring/test_toggle_graph_guard_e2e.py
+++ b/tests/ring/test_toggle_graph_guard_e2e.py
@@ -21,7 +21,7 @@ import torch
 from monitoring import _native_engine as ne
 from monitoring import ring_transport as rt
 from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
-import integration.vllm_adapter as va
+import integration.vllm_node_toggle as vnt
 
 HT = rt.HOOK_TYPE_RESID_PRE
 N = 3
@@ -88,8 +88,8 @@ def test_completeness_guard():
 
 def test_replay_guard():
     print("[replay-time unknown-graph guard]")
-    va._patch_cudagraph_keep_graph()
-    va._DMX_TOGGLE_REPLAY_GUARD = True
+    vnt._patch_cudagraph_keep_graph()
+    vnt._DMX_TOGGLE_REPLAY_GUARD = True
 
     eng = _new_engine()
     eng.set_null_mode(True)
@@ -125,7 +125,7 @@ def test_replay_guard():
     check(raised, "unknown graph B RAISES fatal at replay (would-be desync blocked)")
 
     rt.deactivate()
-    va._DMX_TOGGLE_REPLAY_GUARD = False
+    vnt._DMX_TOGGLE_REPLAY_GUARD = False
     eng.stop()
 
 

--- a/tests/ring/test_toggle_keepgraph_patch.py
+++ b/tests/ring/test_toggle_keepgraph_patch.py
@@ -1,0 +1,75 @@
+"""Layer-4 unit gate: the node-toggle vLLM wiring that is model-independent.
+
+The full server smoke (launch DMXGPUWorker + dmx_node_toggle, bind N graphs,
+serve) requires the vLLM fork whose hooked models match main's 4-arg producer
+op -- i.e. the integration/vllm submodule at main's pinned commit (Layer 0).
+This test covers the pieces that DON'T need a model:
+
+  - integration.vllm_adapter imports cleanly (wiring/syntax),
+  - _parse_enabled_hooks parses the "ht:layer,..." config string,
+  - _patch_cudagraph_keep_graph() makes torch.cuda.CUDAGraph default to
+    keep_graph=True (so DMI's capture-recorded node handles don't dangle) while
+    staying a CUDAGraph subclass, idempotently, and a no-arg CUDAGraph (how vLLM
+    builds them) still captures + replays.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_keepgraph_patch.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+import integration.vllm_adapter as va
+
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    check(hasattr(va, "DMXGPUWorker") and hasattr(va, "VLLMAdaptor"),
+          "vllm_adapter imports (DMXGPUWorker + VLLMAdaptor present)")
+
+    check(va._parse_enabled_hooks("0:32,0:33") == [(0, 32), (0, 33)],
+          "_parse_enabled_hooks('0:32,0:33')")
+    check(va._parse_enabled_hooks("") is None, "_parse_enabled_hooks('') -> None")
+    check(va._parse_enabled_hooks("14") == [(14, -1)],
+          "_parse_enabled_hooks('14') -> global layer -1")
+
+    Orig = torch.cuda.CUDAGraph
+    va._patch_cudagraph_keep_graph()
+    Patched = torch.cuda.CUDAGraph
+    check(Patched is not Orig and issubclass(Patched, Orig),
+          "keep_graph patch installed as a CUDAGraph subclass")
+    va._patch_cudagraph_keep_graph()
+    check(torch.cuda.CUDAGraph is Patched, "patch is idempotent")
+
+    # vLLM builds graphs as CUDAGraph() with NO args -> must default keep_graph=True.
+    g = torch.cuda.CUDAGraph()
+    check(isinstance(g, Orig), "no-arg CUDAGraph still isinstance(torch.cuda.CUDAGraph)")
+    s = torch.zeros(8, device="cuda")
+    with torch.cuda.graph(g):
+        s.add_(1.0)
+    g.replay()
+    torch.cuda.synchronize()
+    check(float(s[0].item()) == 1.0, "no-arg CUDAGraph captures + replays once")
+    # raw_cuda_graph() only works when keep_graph=True -> proves the default took.
+    try:
+        g.raw_cuda_graph()
+        check(True, "raw_cuda_graph() available -> keep_graph defaulted True")
+    except Exception as e:
+        check(False, f"raw_cuda_graph() failed: {e}")
+
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_keepgraph_patch.py
+++ b/tests/ring/test_toggle_keepgraph_patch.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 import torch
 import integration.vllm_adapter as va
+import integration.vllm_node_toggle as vnt
 
 fails = 0
 
@@ -37,22 +38,22 @@ def main():
     check(hasattr(va, "DMXGPUWorker") and hasattr(va, "VLLMAdaptor"),
           "vllm_adapter imports (DMXGPUWorker + VLLMAdaptor present)")
 
-    check(va._parse_enabled_hooks("0:32,0:33") == [(0, 32), (0, 33)],
+    check(vnt._parse_enabled_hooks("0:32,0:33") == [(0, 32), (0, 33)],
           "_parse_enabled_hooks('0:32,0:33')")
-    check(va._parse_enabled_hooks("14") == [(14, -1)],
+    check(vnt._parse_enabled_hooks("14") == [(14, -1)],
           "_parse_enabled_hooks('14') -> global layer -1")
     # (#5) the three distinct config meanings, no overloaded empty string:
-    check(va._parse_enabled_hooks(None) is None, "_parse_enabled_hooks(None) -> None (unconfigured)")
-    check(va._parse_enabled_hooks("") is None, "_parse_enabled_hooks('') -> None (unconfigured)")
-    check(va._parse_enabled_hooks("none") == [], "_parse_enabled_hooks('none') -> [] (explicit all-off)")
-    check(va._parse_enabled_hooks("NONE") == [], "_parse_enabled_hooks('NONE') -> [] (case-insensitive)")
+    check(vnt._parse_enabled_hooks(None) is None, "_parse_enabled_hooks(None) -> None (unconfigured)")
+    check(vnt._parse_enabled_hooks("") is None, "_parse_enabled_hooks('') -> None (unconfigured)")
+    check(vnt._parse_enabled_hooks("none") == [], "_parse_enabled_hooks('none') -> [] (explicit all-off)")
+    check(vnt._parse_enabled_hooks("NONE") == [], "_parse_enabled_hooks('NONE') -> [] (case-insensitive)")
 
     Orig = torch.cuda.CUDAGraph
-    va._patch_cudagraph_keep_graph()
+    vnt._patch_cudagraph_keep_graph()
     Patched = torch.cuda.CUDAGraph
     check(Patched is not Orig and issubclass(Patched, Orig),
           "keep_graph patch installed as a CUDAGraph subclass")
-    va._patch_cudagraph_keep_graph()
+    vnt._patch_cudagraph_keep_graph()
     check(torch.cuda.CUDAGraph is Patched, "patch is idempotent")
 
     # vLLM builds graphs as CUDAGraph() with NO args -> must default keep_graph=True.

--- a/tests/ring/test_toggle_keepgraph_patch.py
+++ b/tests/ring/test_toggle_keepgraph_patch.py
@@ -1,8 +1,8 @@
-"""Layer-4 unit gate: the node-toggle vLLM wiring that is model-independent.
+"""Unit gate for the node-toggle vLLM wiring that is model-independent.
 
 The full server smoke (launch DMXGPUWorker + dmx_node_toggle, bind N graphs,
-serve) requires the vLLM fork whose hooked models match main's 4-arg producer
-op -- i.e. the integration/vllm submodule at main's pinned commit (Layer 0).
+serve) requires the vLLM fork (the integration/vllm submodule at its pinned
+commit) whose hooked models match the 4-arg producer op.
 This test covers the pieces that DON'T need a model:
 
   - integration.vllm_adapter imports cleanly (wiring/syntax),

--- a/tests/ring/test_toggle_keepgraph_patch.py
+++ b/tests/ring/test_toggle_keepgraph_patch.py
@@ -39,9 +39,13 @@ def main():
 
     check(va._parse_enabled_hooks("0:32,0:33") == [(0, 32), (0, 33)],
           "_parse_enabled_hooks('0:32,0:33')")
-    check(va._parse_enabled_hooks("") is None, "_parse_enabled_hooks('') -> None")
     check(va._parse_enabled_hooks("14") == [(14, -1)],
           "_parse_enabled_hooks('14') -> global layer -1")
+    # (#5) the three distinct config meanings, no overloaded empty string:
+    check(va._parse_enabled_hooks(None) is None, "_parse_enabled_hooks(None) -> None (unconfigured)")
+    check(va._parse_enabled_hooks("") is None, "_parse_enabled_hooks('') -> None (unconfigured)")
+    check(va._parse_enabled_hooks("none") == [], "_parse_enabled_hooks('none') -> [] (explicit all-off)")
+    check(va._parse_enabled_hooks("NONE") == [], "_parse_enabled_hooks('NONE') -> [] (case-insensitive)")
 
     Orig = torch.cuda.CUDAGraph
     va._patch_cudagraph_keep_graph()

--- a/tests/ring/test_toggle_lazy_failpath_e2e.py
+++ b/tests/ring/test_toggle_lazy_failpath_e2e.py
@@ -21,7 +21,7 @@ import torch
 from monitoring import _native_engine as ne
 from monitoring import ring_transport as rt
 from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
-import integration.vllm_adapter as va
+import integration.vllm_node_toggle as vnt
 
 HT = rt.HOOK_TYPE_RESID_PRE
 N = 3
@@ -38,8 +38,8 @@ def check(cond, msg):
 
 
 def main():
-    va._patch_cudagraph_keep_graph()
-    va._DMX_TOGGLE_REPLAY_GUARD = True
+    vnt._patch_cudagraph_keep_graph()
+    vnt._DMX_TOGGLE_REPLAY_GUARD = True
 
     cfg = ne.RingConfig()
     cfg.payload_ring_bytes = 32 * 1024 * 1024
@@ -101,7 +101,7 @@ def main():
     check(ok, "clean lazy apply replays without raising (recovery)")
 
     rt.deactivate()
-    va._DMX_TOGGLE_REPLAY_GUARD = False
+    vnt._DMX_TOGGLE_REPLAY_GUARD = False
     eng.stop()
     print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
     return 1 if fails else 0

--- a/tests/ring/test_toggle_lazy_failpath_e2e.py
+++ b/tests/ring/test_toggle_lazy_failpath_e2e.py
@@ -1,0 +1,113 @@
+"""Lazy apply failure-path gates (fixes #1 + #2, fault-injected).
+
+Uses the engine's test-only fault injection (_test_force_apply_error) to drive
+the device-apply error path deterministically -- cudaGraphNodeSetEnabled itself
+can't be forced to fail from Python. Verifies:
+
+  #2  apply failure -> applied_version NOT marked current (graph stays stale, so
+      a later ensure retries); success -> marked current.
+  #1  with the replay-time guard armed, a failed ensure_graph_current at replay
+      RAISES FATAL (and does NOT replay); a clean ensure replays normally.
+
+Targets the post-#40/#51 backend (4-arg producer op).
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_lazy_failpath_e2e.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+import integration.vllm_adapter as va
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 3
+QLEN, HID = 4, 8
+INJ = 999  # arbitrary nonzero "CUDA error" code
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    va._patch_cudagraph_keep_graph()
+    va._DMX_TOGGLE_REPLAY_GUARD = True
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 32 * 1024 * 1024
+    eng = ne.RingEngine(cfg, None)
+    eng.init(0)
+    eng.set_null_mode(True)
+    eng.start()
+    transport = RingTransport(eng)
+    rt.activate(transport)
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    payload = eng.payload_tensor()
+
+    eng.enable_toggle_capture(True)
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    gA = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(gA):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    gA.instantiate()
+    eng.enable_toggle_capture(False)
+    eng.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
+    raw = gA.raw_cuda_graph()
+
+    # ---- #2: version-on-success-only ----
+    print("[#2 applied_version only on full success]")
+    transport.set_active_hooks_lazy([(HT, j) for j in range(N)])   # target bumped; A stale
+    check(not eng._test_applied_current(raw), "A stale right after lazy reconfigure (deferred)")
+
+    eng._test_force_apply_error(INJ)
+    err = eng.ensure_graph_current(raw)
+    check(err == INJ, f"ensure_graph_current returns injected error ({err})")
+    check(not eng._test_applied_current(raw),
+          "apply FAILED -> applied_version NOT marked current (stays stale, retryable)")
+
+    eng._test_force_apply_error(0)
+    err = eng.ensure_graph_current(raw)
+    check(err == 0, "ensure_graph_current succeeds after clearing injection")
+    check(eng._test_applied_current(raw), "apply SUCCEEDED -> applied_version marked current")
+
+    # ---- #1: replay raises FATAL on apply error ----
+    print("[#1 replay FATAL on lazy apply error]")
+    transport.set_active_hooks_lazy([(HT, 0)])      # bump target -> A stale again
+    eng._test_force_apply_error(INJ)
+    raised = False
+    try:
+        gA.replay(); torch.cuda.synchronize()
+    except RuntimeError as e:
+        raised = "FATAL" in str(e) and "ensure_graph_current" in str(e)
+    check(raised, "failed lazy apply at replay RAISES fatal (no silent desync)")
+
+    eng._test_force_apply_error(0)
+    ok = True
+    try:
+        gA.replay(); torch.cuda.synchronize()
+    except RuntimeError:
+        ok = False
+    check(ok, "clean lazy apply replays without raising (recovery)")
+
+    rt.deactivate()
+    va._DMX_TOGGLE_REPLAY_GUARD = False
+    eng.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_lazy_failpath_e2e.py
+++ b/tests/ring/test_toggle_lazy_failpath_e2e.py
@@ -1,15 +1,13 @@
-"""Lazy apply failure-path gates (fixes #1 + #2, fault-injected).
+"""Lazy apply failure-path gates (fault-injected).
 
 Uses the engine's test-only fault injection (_test_force_apply_error) to drive
 the device-apply error path deterministically -- cudaGraphNodeSetEnabled itself
 can't be forced to fail from Python. Verifies:
 
-  #2  apply failure -> applied_version NOT marked current (graph stays stale, so
-      a later ensure retries); success -> marked current.
-  #1  with the replay-time guard armed, a failed ensure_graph_current at replay
-      RAISES FATAL (and does NOT replay); a clean ensure replays normally.
-
-Targets the post-#40/#51 backend (4-arg producer op).
+  - apply failure -> applied_version NOT marked current (graph stays stale, so
+    a later ensure retries); success -> marked current.
+  - with the replay-time guard armed, a failed ensure_graph_current at replay
+    RAISES FATAL (and does NOT replay); a clean ensure replays normally.
 
 Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
       python tests/ring/test_toggle_lazy_failpath_e2e.py
@@ -67,8 +65,8 @@ def main():
     eng.bind_graph_exec(gA.raw_cuda_graph(), gA.raw_cuda_graph_exec())
     raw = gA.raw_cuda_graph()
 
-    # ---- #2: version-on-success-only ----
-    print("[#2 applied_version only on full success]")
+    # ---- version-on-success-only ----
+    print("[applied_version only on full success]")
     transport.set_active_hooks_lazy([(HT, j) for j in range(N)])   # target bumped; A stale
     check(not eng._test_applied_current(raw), "A stale right after lazy reconfigure (deferred)")
 
@@ -83,8 +81,8 @@ def main():
     check(err == 0, "ensure_graph_current succeeds after clearing injection")
     check(eng._test_applied_current(raw), "apply SUCCEEDED -> applied_version marked current")
 
-    # ---- #1: replay raises FATAL on apply error ----
-    print("[#1 replay FATAL on lazy apply error]")
+    # ---- replay raises FATAL on apply error ----
+    print("[replay FATAL on lazy apply error]")
     transport.set_active_hooks_lazy([(HT, 0)])      # bump target -> A stale again
     eng._test_force_apply_error(INJ)
     raised = False

--- a/tests/ring/test_toggle_negative_desync_e2e.py
+++ b/tests/ring/test_toggle_negative_desync_e2e.py
@@ -1,0 +1,131 @@
+"""Negative test: breaking meta/producer lockstep MUST desync (and the correct
+order MUST stay aligned).
+
+This is the complement of test_reconfig_sequence_e2e. It proves the FIFO-order
+invariant is load-bearing: the drain/p2p match metas to payloads purely by
+arrival order, so if the host meta ORDER diverges from the device producer
+firing order, payloads get mis-associated with the wrong layer (desync). The
+production path never does this because all lanes iterate effective_specs in the
+single firing order; here we deliberately push a REVERSED meta order to show the
+corruption is real.
+
+Each producer writes marker == its layer, so a correctly-aligned delivery has
+layer_no == marker for every row; a desync shows layer_no != marker.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_negative_desync_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def collect_round(engine, collected):
+    """Replay + drain + wait for p2p submit."""
+    torch.cuda.synchronize()
+    engine.flush_and_wait()
+    for _ in range(200):
+        if len(collected) >= N:
+            break
+        time.sleep(0.01)
+    time.sleep(0.03)
+
+
+def main():
+    collected = []
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append((int(layer_no), int(round(float(slice_.reshape(-1)[0].item())))))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport.set_step_context(model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+                               dim0_offsets=[0], kv_offsets=[0], flattened=True)
+
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    # All producers enabled (device fires layers 0..3 in order, markers 0..3).
+    transport.set_active_hooks([(HT, j) for j in range(N)])
+
+    # --- POSITIVE CONTROL: correct meta order via the production path -> aligned.
+    print("[positive: correct order via pre_push_all_metas]")
+    collected.clear()
+    transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)
+    g.replay()
+    collect_round(engine, collected)
+    aligned = all(layer == marker for layer, marker in collected)
+    check(sorted(l for l, _ in collected) == [0, 1, 2, 3] and aligned,
+          f"correct order -> all aligned (layer==marker): {sorted(collected)}")
+
+    # --- NEGATIVE: deliberately REVERSED meta order -> must desync.
+    print("[negative: reversed meta order pushed directly -> must desync]")
+    collected.clear()
+    shape = [QLEN, HID]
+    engine.push_all_metas(
+        hook_types=[HT] * N,
+        layer_nos=[3, 2, 1, 0],                 # REVERSED vs producer firing order
+        shapes=[shape] * N,
+        dtypes=[torch.float32] * N,
+        flags=[0] * N,
+        model_id="m", tp_rank=0, dp_rank=0, ep_rank=0, pp_rank=0,
+        flattened=True, req_ids=["r"], token_ranges=[(0, QLEN)],
+        dim0_offsets=[0], kv_offsets=[0],
+    )
+    g.replay()
+    collect_round(engine, collected)
+    # FIFO pairs meta[i] (layer 3,2,1,0) with payload[i] (marker 0,1,2,3) -> mismatched.
+    mismatched = sum(1 for layer, marker in collected if layer != marker)
+    check(len(collected) == N and mismatched == N,
+          f"reversed order -> ALL rows mis-associated (desync detected): {sorted(collected)}")
+    check(mismatched > 0,
+          "lockstep is load-bearing: breaking meta order corrupts layer<->payload mapping")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_prefill_passthrough_e2e.py
+++ b/tests/ring/test_toggle_prefill_passthrough_e2e.py
@@ -1,0 +1,168 @@
+"""Prefill (eager) steps must NOT be node-toggle-gated -- the separate-path fix.
+
+The toggle's SetEnabled only gates producers running inside a replayed decode
+graph. A prefill / eager step runs producers UNGATED (no graph), so its
+meta-push + capacity-reserve must use the FULL active set that step, not the
+toggle subset. If they used the subset, the eager step would fire N producers
+while reserving/pushing only K metas -> a permanent surplus of (N-K) orphan
+task entries that cascade-corrupt every later row (flat FIFO 1:1 pairing in
+p2p_thread). transport._gated_step selects the per-step set; the vLLM adapter
+sets it False for prefill/eager, True for decode-graph steps.
+
+This gate drives the REAL capacity path (_compute_step_plan -> prepare_step ->
+pre_push_all_metas -> drain) for BOTH a decode-graph step (gated subset, via
+graph replay) and a prefill step (full set, via eager producer launches), and
+asserts each delivers exactly its expected layers AND the ring fully drains
+(gap==0) -- i.e. no surplus, no cascade.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_prefill_passthrough_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+from monitoring.adaptor_base import BackendAdaptor
+from monitoring.step_context import StepContext
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+QLEN, HID = 4, 8
+SUBSET = [0, 2]          # decode-step enabled subset
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+class _ProbeAdaptor(BackendAdaptor):
+    def detect_model_shape(self, model):     return None
+    def detect_parallel_ranks(self):         return (0, 0, 0, 0)
+    def is_pp_first(self):                    return True
+    def is_pp_last(self):                     return True
+    def build_step_context(self, *raw):       return None
+    def on_capacity_exceeded(self, ctx):     pass
+
+
+def drain_collect(engine, collected, want):
+    engine.flush_and_wait()
+    for _ in range(200):
+        if len(collected) >= want:
+            break
+        time.sleep(0.01)
+    time.sleep(0.03)
+    engine.flush_and_wait()
+
+
+def gaps(engine):
+    st = engine.get_stats()
+    return (st.cpu_payload_head - st.cpu_payload_tail_committed,
+            st.cpu_task_head - st.cpu_task_tail_committed)
+
+
+def main():
+    collected = []
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append(int(layer_no))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport._active_specs = specs
+
+    adaptor = _ProbeAdaptor.__new__(_ProbeAdaptor)
+    adaptor.model_cfg = mcfg
+    adaptor.active_specs = specs
+    adaptor.transport = transport
+    adaptor.ring_engine = engine
+    adaptor._warned_shapes = set()
+
+    # Capture the decode graph (all N producers) and bind it.
+    src = [torch.full((QLEN, HID), float(j), device="cuda", dtype=torch.float32)
+           for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(engine.payload_tensor(), src[j], HT, j)
+    g.instantiate()
+    engine.enable_toggle_capture(False)
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    transport.set_active_hooks([(HT, j) for j in SUBSET])   # gate active, subset enabled
+
+    def run_step(gated, fire):
+        """fire: 'graph' (replay, SetEnabled-gated) or 'eager' (direct launches)."""
+        collected.clear()
+        transport._gated_step = gated
+        expect = [s.layer_no for s in transport.specs_for_step()]
+        ctx = StepContext(model_id="m", flattened=True, req_ids=["r"],
+                          token_ranges=[(0, QLEN)], dim0_offsets=[0], kv_offsets=[0],
+                          batch=0, q_len=QLEN, kv_dim=0)
+        total_bytes, n_hooks, _ = adaptor._compute_step_plan(ctx)
+        if n_hooks > 0:
+            assert engine.prepare_step(total_bytes, n_hooks) == 0
+        transport.set_step_context(model_id="m", req_ids=["r"], token_ranges=[(0, QLEN)],
+                                   dim0_offsets=[0], kv_offsets=[0], flattened=True)
+        transport.pre_push_all_metas(batch=0, q_len=QLEN, kv_dim=0)
+        if fire == "graph":
+            g.replay()
+        else:
+            for j in range(N):     # eager: ALL producers fire, ungated
+                torch.ops.ring.producer(engine.payload_tensor(), src[j], HT, j)
+        torch.cuda.synchronize()
+        drain_collect(engine, collected, len(expect))
+        return sorted(expect), sorted(collected)
+
+    print("[decode step: graph replay, gated subset]")
+    expect, got = run_step(gated=True, fire="graph")
+    check(got == expect == sorted(SUBSET), f"decode delivered {got} == subset {sorted(SUBSET)}")
+    pg, tg = gaps(engine)
+    check(pg == 0 and tg == 0, f"ring drained after decode (payload_gap={pg}, task_gap={tg})")
+
+    print("[prefill step: eager launches, FULL set (not gated)]")
+    expect, got = run_step(gated=False, fire="eager")
+    check(got == expect == list(range(N)),
+          f"prefill delivered {got} == full {list(range(N))} (all hooks, ungated)")
+    pg, tg = gaps(engine)
+    check(pg == 0 and tg == 0,
+          f"ring FULLY drained after prefill -- no surplus/cascade (payload_gap={pg}, task_gap={tg})")
+
+    print("[interleave decode again: still aligned after a prefill]")
+    expect, got = run_step(gated=True, fire="graph")
+    check(got == sorted(SUBSET), f"post-prefill decode still {got} == {sorted(SUBSET)}")
+    pg, tg = gaps(engine)
+    check(pg == 0 and tg == 0, f"ring drained after 2nd decode (payload_gap={pg}, task_gap={tg})")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_prefix_e2e.py
+++ b/tests/ring/test_toggle_prefix_e2e.py
@@ -1,4 +1,4 @@
-"""Option A (prefix path): node-toggle works with the gpu_padding_strip producer.
+"""Node-toggle composes with the gpu_padding_strip (prefix) producer.
 
 Drives torch.ops.ring.producer_prefix (the strip producer: reads a device
 row_count scalar at execution, copies only the first row_count rows) inside a
@@ -9,8 +9,9 @@ captured graph with toggle-capture on, and verifies:
     each delivered slice is the correct stripped prefix (marker == layer),
     disabled hooks deliver nothing.
 
-This is the dense hidden-states case (strip on). Chunked/MoE is deliberately NOT
-covered here (it fails loud at set_active_hooks; run toggle on MoE with strip off).
+The chunked producer is deliberately NOT covered here -- it is not
+toggle-managed and fails loud at set_active_hooks
+(see test_toggle_chunked_failclosed_e2e).
 
 Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
       python tests/ring/test_toggle_prefix_e2e.py

--- a/tests/ring/test_toggle_prefix_e2e.py
+++ b/tests/ring/test_toggle_prefix_e2e.py
@@ -1,0 +1,120 @@
+"""Option A (prefix path): node-toggle works with the gpu_padding_strip producer.
+
+Drives torch.ops.ring.producer_prefix (the strip producer: reads a device
+row_count scalar at execution, copies only the first row_count rows) inside a
+captured graph with toggle-capture on, and verifies:
+  - the prefix producer's kernel node IS recorded (toggle_node_count == N) and
+    no capture anomaly (capture_anomaly_count == 0),
+  - reconfigure lockstep holds: delivered layers == enabled set every round,
+    each delivered slice is the correct stripped prefix (marker == layer),
+    disabled hooks deliver nothing.
+
+This is the dense hidden-states case (strip on). Chunked/MoE is deliberately NOT
+covered here (it fails loud at set_active_hooks; run toggle on MoE with strip off).
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_prefix_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+PADDED, ACTUAL, HID = 8, 4, 8          # captured tensor is [PADDED,HID]; strip to ACTUAL rows
+ROW_BYTES = HID * 4                     # float32 bytes per token row
+ROUNDS = [[0, 2], [1, 3], [0, 1, 2, 3], [], [2], [0, 3], [], [1]]
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def main():
+    collected = []   # (layer_no, marker, n_rows)
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        flat = slice_.reshape(-1)
+        collected.append((int(layer_no), int(round(float(flat[0].item()))), slice_.shape[0]))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j) for j in range(N)]
+    transport.set_step_context(model_id="m", req_ids=["r"], token_ranges=[(0, ACTUAL)],
+                               dim0_offsets=[0], kv_offsets=[0], flattened=True)
+
+    # Padded source tensors (value == layer); device row_count scalar = ACTUAL.
+    src = [torch.full((PADDED, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    row_count = torch.tensor([ACTUAL], dtype=torch.int64, device="cuda")
+
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer_prefix(payload, src[j], row_count, ROW_BYTES, HT, j)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+
+    check(engine.toggle_node_count() == N,
+          f"prefix producer nodes recorded: toggle_node_count == {N} (got {engine.toggle_node_count()})")
+    check(engine.capture_anomaly_count() == 0,
+          f"no capture anomaly for prefix producers (got {engine.capture_anomaly_count()})")
+
+    engine.set_null_mode(False)
+
+    for r_i, keep in enumerate(ROUNDS):
+        collected.clear()
+        transport.set_active_hooks([(HT, j) for j in keep])
+        eff = sorted(s.layer_no for s in transport.effective_specs)
+        check(eff == sorted(keep), f"round {r_i} keep={keep}: effective_specs {eff} == enabled")
+        # meta shape uses the STRIPPED row count (ACTUAL), matching the prefix copy.
+        transport.pre_push_all_metas(batch=0, q_len=ACTUAL, kv_dim=0)
+        g.replay()
+        torch.cuda.synchronize()
+        engine.flush_and_wait()
+        for _ in range(200):
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+
+        delivered = sorted(l for l, _, _ in collected)
+        aligned = all(layer == marker for layer, marker, _ in collected)
+        stripped = all(nrows == ACTUAL for _, _, nrows in collected)
+        tag = f"round {r_i} keep={keep}"
+        check(delivered == sorted(keep), f"{tag}: delivered {delivered} == enabled {sorted(keep)}")
+        check(aligned, f"{tag}: each slice aligned (layer==marker, no desync)")
+        check(stripped, f"{tag}: each slice stripped to {ACTUAL} rows (prefix copy correct)")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_prefix_reserve_e2e.py
+++ b/tests/ring/test_toggle_prefix_reserve_e2e.py
@@ -1,0 +1,145 @@
+"""Reserve invariant for the prefix (strip) producer under node-toggle.
+
+Complements test_toggle_prefix_e2e (which checks lockstep + stripped output) by
+driving the REAL capacity path -- adaptor._compute_step_plan -> prepare_step
+(reserve) -> prefix replay -> drain -- and asserting, every round, that the ring
+fully drains (payload_gap == task_gap == 0). That proves CPU-reserved bytes ==
+prefix-kernel written bytes, i.e. the strip byte-accounting stays in lockstep
+even as the per-step actual token count varies.
+
+Each round varies BOTH the enabled subset AND the actual row count (row_count
+device scalar + ctx.actual_q_len), so the reserve must track the stripped size,
+not the padded capture size.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_prefix_reserve_e2e.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+from monitoring.adaptor_base import BackendAdaptor
+from monitoring.step_context import StepContext
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 4
+PADDED, HID = 8, 8
+ROW_BYTES = HID * 4
+# (enabled subset, actual row count) -- vary both, incl. full/empty/partial.
+ROUNDS = [([0, 1, 2, 3], 4), ([0, 2], 2), ([], 4), ([1], 1), ([0, 1, 2, 3], 7), ([3], 3)]
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+class _ProbeAdaptor(BackendAdaptor):
+    def detect_model_shape(self, model):        return None
+    def detect_parallel_ranks(self):            return (0, 0, 0, 0)
+    def is_pp_first(self):                        return True
+    def is_pp_last(self):                         return True
+    def build_step_context(self, *raw):          return None
+    def on_capacity_exceeded(self, ctx):         pass
+
+
+def main():
+    collected = []
+    def submit(model_id, shard_rank, req_id, act_name, layer_no, s, e, slice_):
+        collected.append((int(layer_no), slice_.shape[0]))
+
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 64 * 1024 * 1024
+    cfg.drain_poll_timeout_us = 200
+    engine = ne.RingEngine(cfg, submit)
+    engine.init(0)
+    ne.ring_set_active_engine(engine)
+    engine.enable_toggle_capture(True)
+    engine.set_null_mode(True)
+    engine.start()
+
+    transport = RingTransport(engine)
+    payload = engine.payload_tensor()
+    mcfg = ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                            head_dim=HID // 2, dtype=torch.float32)
+    transport.set_model_cfg(mcfg)
+    # dim0_is_actual_tokens=True -> _compute_step_plan sizes by ctx.actual_q_len.
+    specs = [HookSpec(hook_type=HT, module=None, layer_no=j, dim0_is_actual_tokens=True)
+             for j in range(N)]
+    transport._active_specs = specs
+
+    adaptor = _ProbeAdaptor.__new__(_ProbeAdaptor)
+    adaptor.model_cfg = mcfg
+    adaptor.active_specs = specs
+    adaptor.transport = transport
+    adaptor.ring_engine = engine
+    adaptor._warned_shapes = set()
+
+    src = [torch.full((PADDED, HID), float(j), device="cuda", dtype=torch.float32) for j in range(N)]
+    row_count = torch.tensor([PADDED], dtype=torch.int64, device="cuda")
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer_prefix(payload, src[j], row_count, ROW_BYTES, HT, j)
+    g.instantiate()
+    engine.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    engine.set_null_mode(False)
+
+    for r_i, (keep, actual) in enumerate(ROUNDS):
+        collected.clear()
+        transport.set_active_hooks([(HT, j) for j in keep])
+        row_count.fill_(actual)                       # device count the prefix kernel reads
+        torch.cuda.synchronize()
+
+        ctx = StepContext(model_id="m", flattened=True, req_ids=["r"],
+                          token_ranges=[(0, actual)], dim0_offsets=[0], kv_offsets=[0],
+                          batch=0, q_len=PADDED, kv_dim=0, actual_q_len=actual)
+        total_bytes, n_hooks, _ = adaptor._compute_step_plan(ctx)
+        check(n_hooks == len(keep),
+              f"round {r_i} keep={keep} actual={actual}: plan n_hooks={n_hooks} == {len(keep)}")
+        if n_hooks > 0:
+            res = engine.prepare_step(total_bytes, n_hooks)
+            check(res == 0, f"round {r_i}: prepare_step RING_OK (got {res})")
+        transport.set_step_context(model_id="m", req_ids=["r"], token_ranges=[(0, actual)],
+                                   dim0_offsets=[0], kv_offsets=[0], flattened=True)
+        transport.pre_push_all_metas(batch=0, q_len=PADDED, kv_dim=0, actual_q_len=actual)
+        g.replay()
+        torch.cuda.synchronize()
+        engine.flush_and_wait()
+        for _ in range(200):
+            if len(collected) >= len(keep):
+                break
+            time.sleep(0.01)
+        time.sleep(0.03)
+        engine.flush_and_wait()
+
+        st = engine.get_stats()
+        pgap = st.cpu_payload_head - st.cpu_payload_tail_committed
+        tgap = st.cpu_task_head - st.cpu_task_tail_committed
+        check(pgap == 0 and tgap == 0,
+              f"round {r_i} keep={keep} actual={actual}: ring fully drained "
+              f"(payload_gap={pgap}, task_gap={tgap}) -> reserve == prefix writes")
+        check(sorted(l for l, _ in collected) == sorted(keep),
+              f"round {r_i}: delivered {sorted(l for l,_ in collected)} == enabled")
+        check(all(nrows == actual for _, nrows in collected),
+              f"round {r_i}: each slice stripped to actual={actual} rows")
+
+    engine.flush_and_wait()
+    time.sleep(0.05)
+    ne.ring_clear_active_engine()
+    engine.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_reconfig_cache_e2e.py
+++ b/tests/ring/test_toggle_reconfig_cache_e2e.py
@@ -1,0 +1,131 @@
+"""Reconfigure caches: correctness of the guard-verdict and effective-specs memos.
+
+set_active_hooks[_lazy] memoize two things on the engine's registry version:
+the registry-guard PASS verdict, and the (enabled set -> effective_specs)
+recompute. Both caches trade repeated work for a staleness risk, so this gate
+pins down the two ways they could go wrong:
+
+  Equivalence -- cycling presets must produce effective_specs identical to an
+  uncached recompute, every round (hit or miss), and a changed _active_specs
+  list must miss the cache (identity check).
+
+  Invalidation -- a cached guard PASS must NOT survive a registry mutation:
+  after note_capture_anomaly() the next reconfigure must RAISE even though the
+  same call just succeeded; after clear_toggle + an incomplete re-bind it must
+  RAISE the completeness error.
+
+Run:  CUDA_VISIBLE_DEVICES=<free gpu> CUDA_MODULE_LOADING=EAGER \
+      python tests/ring/test_toggle_reconfig_cache_e2e.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import torch
+from monitoring import _native_engine as ne
+from monitoring import ring_transport as rt
+from monitoring.ring_transport import RingTransport, HookSpec, ModelShapeConfig
+
+HT = rt.HOOK_TYPE_RESID_PRE
+N = 8
+HID = 8
+PRESETS = [[0, 2, 4, 6], [1, 3, 5, 7], [], list(range(N)), [0, 2, 4, 6], [1, 3, 5, 7]]
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    print(("  ok  " if cond else "  FAIL") + "  " + msg)
+    if not cond:
+        fails += 1
+
+
+def fresh_effective(transport, keep):
+    """Uncached ground truth: active specs whose layer is enabled AND registered."""
+    eng = transport._ring_engine
+    mask = eng.effective_enabled_mask(
+        [(s.hook_type, s.layer_no) for s in transport._active_specs])
+    return [s for s, m in zip(transport._active_specs, mask) if m]
+
+
+def setup():
+    cfg = ne.RingConfig()
+    cfg.payload_ring_bytes = 32 * 1024 * 1024
+    eng = ne.RingEngine(cfg, None)
+    eng.init(0)
+    ne.ring_set_active_engine(eng)
+    eng.set_null_mode(True)
+    eng.start()
+    transport = RingTransport(eng)
+    transport.set_model_cfg(ModelShapeConfig(hidden_dim=HID, num_heads=2, num_kv_heads=2,
+                                             head_dim=HID // 2, dtype=torch.float32))
+    transport._active_specs = [HookSpec(hook_type=HT, module=None, layer_no=j)
+                               for j in range(N)]
+    payload = eng.payload_tensor()
+    eng.enable_toggle_capture(True)
+    src = [torch.full((4, HID), float(j), device="cuda", dtype=torch.float32)
+           for j in range(N)]
+    g = torch.cuda.CUDAGraph(keep_graph=True)
+    with torch.cuda.graph(g):
+        for j in range(N):
+            torch.ops.ring.producer(payload, src[j], HT, j)
+    g.instantiate()
+    eng.enable_toggle_capture(False)
+    eng.bind_graph_exec(g.raw_cuda_graph(), g.raw_cuda_graph_exec())
+    return eng, transport, g, src
+
+
+def main():
+    eng, transport, g, _src = setup()
+
+    print("[equivalence: cached presets == fresh recompute]")
+    for r_i, keep in enumerate(PRESETS):
+        transport.set_active_hooks_lazy([(HT, j) for j in keep])
+        got = [(s.hook_type, s.layer_no) for s in transport.effective_specs]
+        want = [(s.hook_type, s.layer_no) for s in fresh_effective(transport, keep)]
+        check(got == want and sorted(ln for _, ln in got) == sorted(keep),
+              f"round {r_i} keep={keep}: effective {sorted(ln for _, ln in got)}")
+    check(len(transport._effective_specs_cache) > 0, "preset cache populated")
+
+    print("[equivalence: _active_specs swap must miss the cache]")
+    transport._active_specs = transport._active_specs[:4]   # new list object
+    transport.set_active_hooks_lazy([(HT, j) for j in range(N)])  # all-on preset
+    got = sorted(s.layer_no for s in transport.effective_specs)
+    check(got == [0, 1, 2, 3],
+          f"effective follows the NEW active list (got {got}, want [0, 1, 2, 3])")
+
+    print("[invalidation: anomaly after a cached PASS]")
+    transport.set_active_hooks([(HT, 0)])     # eager passes; verdict now cached
+    eng.note_capture_anomaly()                # registry mutation -> version bump
+    raised = False
+    try:
+        transport.set_active_hooks([(HT, 0)])
+    except RuntimeError as e:
+        raised = "cannot manage" in str(e)
+    check(raised, "set_active_hooks RAISES after anomaly despite cached verdict")
+
+    print("[invalidation: clear + incomplete re-bind]")
+    transport.clear_toggle()                  # drops registry + transport caches
+    g2 = torch.cuda.CUDAGraph(keep_graph=True)   # captured WITHOUT recording
+    payload = eng.payload_tensor()
+    src2 = torch.zeros(4, HID, device="cuda")
+    with torch.cuda.graph(g2):
+        torch.ops.ring.producer(payload, src2, HT, 0)
+    g2.instantiate()
+    eng.bind_graph_exec(g2.raw_cuda_graph(), g2.raw_cuda_graph_exec())  # bound, no nodes
+    raised = False
+    try:
+        transport.set_active_hooks_lazy([(HT, 0)])
+    except RuntimeError as e:
+        raised = "no producer nodes registered" in str(e) or "incomplete" in str(e)
+    check(raised, "reconfigure after clear+incomplete bind RAISES (no stale PASS)")
+
+    ne.ring_clear_active_engine()
+    eng.stop()
+    print(f"\n{'ALL PASS' if fails == 0 else f'{fails} FAILURES'}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ring/test_toggle_reconfig_cache_e2e.py
+++ b/tests/ring/test_toggle_reconfig_cache_e2e.py
@@ -86,7 +86,7 @@ def main():
         want = [(s.hook_type, s.layer_no) for s in fresh_effective(transport, keep)]
         check(got == want and sorted(ln for _, ln in got) == sorted(keep),
               f"round {r_i} keep={keep}: effective {sorted(ln for _, ln in got)}")
-    check(len(transport._effective_specs_cache) > 0, "preset cache populated")
+    check(len(transport._toggle._cache) > 0, "preset cache populated")
 
     print("[equivalence: _active_specs swap must miss the cache]")
     transport._active_specs = transport._active_specs[:4]   # new list object


### PR DESCRIPTION
# Runtime reconfiguration (node-toggle): low-overhead per-hook monitoring switch

## Summary

Enable/disable individual monitoring (producer) hooks **at runtime, between
CUDA-graph replays**, via `cudaGraphNodeSetEnabled` on the captured producer
kernel nodes — no re-capture, no re-instantiation, no model changes. This is the
enabling primitive for adaptive monitoring (graduated hallucination monitoring,
per-layer profiler sweeps, on-demand debugging): you pay only for the hooks you
turn on, and you can change the set per step.

The feature is independently switchable — with `dmx_node_toggle=false` (default)
the path is identical to stock DMI.

## Design

A monitored decode step runs as a captured CUDA graph; each hook is a producer
kernel node in that graph. Toggling a hook = flipping its node's enabled bit on
the instantiated graph exec (`cudaGraphNodeSetEnabled`); a disabled node becomes
an empty-node traversal (~0.18 µs residual), so idle is near-baseline.

The one invariant that drives the design: every step, three lanes must agree on
**which hooks fire** —

1. **capacity-reserve** (`adaptor_base._compute_step_plan`),
2. **meta-push** (`ring_transport.pre_push_all_metas`),
3. **device node-enable** (the `SetEnabled` state),

or the ring desyncs (reserve ≠ writes, or meta ≠ payload). All three read one
source of truth, `transport.specs_for_step()`.

Two execution modes:
- **eager** (`set_active_hooks`): flip every bound exec immediately; safe at a
  quiescent point (static config after warmup).
- **lazy** (`set_active_hooks_lazy`): defer the device flip to each graph's next
  replay, event-guarded; for per-step / adaptive reconfigure.

**Decode-gated, prefill-passthrough.** The toggle governs only producers inside
a replayed decode graph. Prefill / eager steps run producers ungated, so on
those steps all three lanes use the **full** active set (stock behavior); only
decode-graph steps use the toggle subset. The per-step selector reads vLLM's own
FULL-graph dispatch condition.

## Implementation

Toggle policy and state live in dedicated, toggle-owned modules; the core files
keep only seams and one-line delegates.

- **`monitoring/csrc/ring/toggle_registry.{h,cu}`** — `ToggleRegistry`: node
  registry (graph → producer nodes), graph↔exec bindings, the enabled set,
  eager `apply_all`, lazy per-graph `ensure_current` + replay-event guard, and a
  registry-version guard cache. CUDA-runtime-only; own mutex.
- **`monitoring/node_toggle.py`** — `NodeToggleController`: activation guards
  (fail-closed on incomplete/non-uniform registry), the enabled→effective set
  recompute (memoized), eager/lazy reconfigure.
- **`integration/vllm_node_toggle.py`** — vLLM wiring: `keep_graph` patch +
  replay-time graph guard, config parse, captured-graph bind, post-warmup
  activation.
- Capture-time node recording lives in the producer op
  (`ring_torch_op.cpp`) — fail-closed: anything it can't validate (non-kernel
  tail, unreadable capture state, unsupported producer) flags an anomaly and
  refuses activation.

Composes with `gpu_padding_strip` (basic + prefix producers record their node);
the chunked producer is not toggle-managed and fails closed.

## Performance (H100, Qwen3-8B, 36 hooks)

| Config | Per-step overhead | Note |
|---|---|---|
| toggle off | **+0.10%** | ≈ baseline; 3.7× cheaper idle than `null_mode` |
| per enabled hook | **~3.5 µs** | linear in #enabled |
| full (all hooks) | ≈ plain always-on | ~13 µs machinery over always-on |
| reconfigure (lazy) | **4.4 µs** host-only | flat in #graphs (registry-version cache) |

## Files changed

**New (toggle-owned):**

| File | Lines | Role |
|---|---|---|
| `monitoring/csrc/ring/toggle_registry.{h,cu}` | +100 / +279 | C++ registry + CUDA-graph ops |
| `integration/vllm_node_toggle.py` | +253 | vLLM wiring (patch, guard, bind, activation) |
| `monitoring/node_toggle.py` | +198 | host-side controller (guards, caches, reconfigure) |

**Modified (core — the coupling surface):**

| File | Δ | What |
|---|---|---|
| `monitoring/csrc/ring/ring_engine_py.cu` | +138 / −4 | method delegates + `prepare_step` reserve clamp |
| `monitoring/csrc/ring/ring_engine_py.h` | +86 | declarations |
| `integration/vllm_adapter.py` | +102 / −3 | config reads + flag-gated lifecycle + per-step predicate |
| `monitoring/ring_transport.py` | +93 / −2 | `effective_specs`/`specs_for_step` seam + delegates |
| `monitoring/csrc/ring/ring_torch_op.cpp` | +79 | capture-time node recorder |
| `monitoring/csrc/bindings.cpp` | +73 / −1 | pybind surface |
| `monitoring/hook_points.py` | +12 | eager-path gate |
| `monitoring/adaptor_base.py` | +10 / −2 | capacity seam |
| `ring_torch_op.h` +6, `Makefile` +2 | minor | declaration + build |

Plus 16 ring-gate tests (+2119) and 3 docs (`node_toggle_usage`,
`node_toggle_implementation`, `node_toggle_migration_scope`).

## Coupling interface (behavior when toggle is OFF)

With the toggle off, the only new code that executes is below — each
identity-equivalent to stock (main's unit suite passes unmodified).

| Surface (runs even when OFF) | Off behavior | Per-step cost |
|---|---|---|
| `specs_for_step()` seam (capacity + meta) | returns `active_specs` (same object) | 2 property reads |
| `prepare_step` reserve clamp | identical to main's subtraction in every reachable state; clamps only states main cannot reach | 2 compares |
| `dmx_record_capture_node` in producer ops | first-line early-return on a flag only toggle wiring sets | 1 bool / producer call |
| `_gated_step` compute (vLLM adapter) | gated on `toggle_gate_active` — not computed when off | 0 |
| `hook_points` eager gate | inside the `force_eager` branch + `toggle_gate_active` short-circuit | 0 |
| vLLM wiring | behind the `dmx_node_toggle` flag; `CUDAGraph` not patched when off | 0 |

**The one unavoidable intrusion.** Node-toggle cannot be purely additive: the
lockstep invariant forces `_compute_step_plan` (reserve) and `pre_push_all_metas`
(meta) to read `specs_for_step()` instead of `active_specs` — a real edit to
main's per-step path that runs every step, toggle on or off. It is safe by
construction (off → returns the same `active_specs`; on → all three lanes read
the one set), and is the seam to review hardest. Any future per-step quantity
derived from "which hooks fire" must read `specs_for_step()` for the same reason.

## Tests

15 ring gates (binding, eager/lazy/multigraph reconfigure, reserve-invariant,
graph guard, lazy fault-injection, negative-desync, prefix + reserve, chunked
fail-closed, reconfigure cache, prefill-passthrough, force-eager gate) + a
self-checking FULL-decode vLLM smoke (Qwen3-0.6B → ClickHouse; partial toggle
delivers exactly the enabled layers). Main's unit suite (46) passes unmodified.

## Notes

- Requires `cudagraph_mode=FULL` for decode (the worker raises if a subset is
  requested but no full-decode graph is bound). If an unregistered graph ever
  reaches replay, the guard fails loud rather than silently desyncing.
- Chunked-producer toggle support is deferred until a chunked producer is
  dispatched and ring-space reclamation lands; until then it is fail-closed.