### PR TITLE
Support vLLM 0.19 with fail-closed compatibility tests

### DIFF
--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -9,6 +9,23 @@ DMI plugs into vLLM through:
 integration.vllm_adapter.DMXGPUWorker
 ```
 
+The pinned integration is based on vLLM 0.19.0. A statically validated 0.18.0
+port is also maintained as the `dmi-v0.18.0` branch in the vLLM submodule. The
+adapter uses vLLM's public out-of-tree model registry, so the bundled monitored model
+classes also work with a matching official vLLM wheel without installing the
+whole submodule as an editable package.
+
+## Supported model architectures
+
+The monitored variants currently cover GPT-2, Qwen2/Qwen2.5, Qwen3,
+Qwen2-MoE, and Llama. Architectures that upstream vLLM implements directly
+with its Llama class (Aquila, Cwm, InternLM/InternLM3, IQuestCoder, legacy
+LLaMA, and Xverse) are remapped to the same monitored Llama variant.
+
+Model support is architecture-based, so different checkpoint sizes in the
+same family do not require another DMI model class. Quantized checkpoints and
+nonstandard remote-code implementations still require separate validation.
+
 Pass it through `worker_cls=` in the offline `LLM(...)` API or `--worker-cls`
 in `vllm serve`.
 
@@ -87,6 +104,30 @@ exactly as with plain `LLM`. A nonempty `dmx_db_host` and
 exposes only its own request's internals; for the whole batch as one
 `[batch, seq, hidden]` tensor use `get_internal(model_id)` from
 `monitoring.internal_mapper`.
+
+Persistence is asynchronous. For a complete read before an explicit
+`stop_monitoring`, enable a bounded drain timeout and use the public retry
+contract instead of sleeping for an assumed duration:
+
+```python
+from transformers import AutoConfig
+
+# additional_config={..., "dmx_drain_flush_timeout_us": 100_000}
+expected_layers = AutoConfig.from_pretrained(
+    "Qwen/Qwen3-0.6B"
+).num_hidden_layers
+out[0].dmi_internal.require(
+    "hidden_states",
+    count=expected_layers,
+    retry=True,
+    timeout_s=30.0,
+    poll_s=0.25,
+)
+hidden_states = out[0].dmi_internal.hidden_states
+```
+
+Without a drain timeout, call
+`llm.collective_rpc("stop_monitoring")` before the authoritative read.
 
 ## vLLM serve
 

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum, auto
 import os
+from pathlib import Path
 import re
 import warnings
 from typing import Any, List, Optional, Tuple
@@ -38,6 +39,7 @@ import torch
 
 from vllm import LLM
 from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
+from vllm.model_executor.models import ModelRegistry
 from vllm.v1.worker.gpu_worker import Worker
 
 from monitoring import ring_transport
@@ -116,12 +118,75 @@ def normalize_vllm_request_id(req_id: str) -> str:
 
 
 # Architecture remap so vLLM's registry resolves to the hooked variant.
+#
+# Keep the Llama aliases aligned with upstream registry entries that resolve
+# directly to ``llama.LlamaForCausalLM``.  These architectures therefore use
+# the same implementation and can safely share DMI's hooked Llama variant.
+_LLAMA_COMPAT_ARCHES = {
+    "AquilaModel",
+    "AquilaForCausalLM",
+    "CwmForCausalLM",
+    "InternLMForCausalLM",
+    "InternLM3ForCausalLM",
+    "IQuestCoderForCausalLM",
+    "LlamaForCausalLM",
+    "LLaMAForCausalLM",
+    "XverseForCausalLM",
+}
+
 _ARCH_REMAP = {
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
+    "Qwen2ForCausalLM": "Qwen2PForCausalLM",
     "Qwen2MoeForCausalLM": "Qwen2MoePForCausalLM",
     "Qwen3ForCausalLM": "Qwen3PForCausalLM",
-    "LlamaForCausalLM": "LlamaPForCausalLM",
+    **{arch: "LlamaPForCausalLM" for arch in _LLAMA_COMPAT_ARCHES},
 }
+
+
+# DMI model variants can be consumed in two ways:
+#
+# 1. the integration/vllm fork registers them in its own registry.py; or
+# 2. an official vLLM wheel imports this adapter, which exposes the submodule's
+#    model directory as an out-of-tree model package and registers lazy class
+#    references through vLLM's public ModelRegistry API.
+#
+# Lazy strings are important here: importing model implementations eagerly in
+# the parent process can initialize CUDA before vLLM forks its workers.
+_DMI_MODEL_VARIANTS = {
+    "GPT2PLMHeadModel": "gpt2_p:GPT2PLMHeadModel",
+    "Qwen2PForCausalLM": "qwen2_p:Qwen2PForCausalLM",
+    "Qwen2MoePForCausalLM": "qwen2_moe_p:Qwen2MoePForCausalLM",
+    "Qwen3PForCausalLM": "qwen3_p:Qwen3PForCausalLM",
+    "LlamaPForCausalLM": "llama_p:LlamaPForCausalLM",
+}
+
+
+def _register_dmi_model_variants() -> None:
+    """Register bundled DMI models when running against an official wheel."""
+
+    import vllm.model_executor.models as model_package
+
+    model_dir = Path(__file__).resolve().parent / "vllm/vllm/model_executor/models"
+    if not model_dir.is_dir():
+        raise RuntimeError(f"DMI vLLM model directory is missing: {model_dir}")
+
+    package_path = str(model_dir)
+    if package_path not in model_package.__path__:
+        model_package.__path__.append(package_path)
+
+    registered = set(ModelRegistry.get_supported_archs())
+    module_prefix = "vllm.model_executor.models."
+    for architecture, target in _DMI_MODEL_VARIANTS.items():
+        if architecture in registered:
+            continue
+        module_name, class_name = target.split(":", 1)
+        ModelRegistry.register_model(
+            architecture,
+            f"{module_prefix}{module_name}:{class_name}",
+        )
+
+
+_register_dmi_model_variants()
 
 
 # ---------------------------------------------------------------------------
@@ -1431,7 +1496,7 @@ class DMXGPUWorker(Worker):
         self._dmx_pp_rank = pp_rank
         self._dmx_tp_size = get_tp_group().world_size
 
-    def load_model(self) -> None:
+    def load_model(self, *args: Any, **kwargs: Any) -> None:
         # Remap the architecture string in the HF config so vLLM's
         # registry resolves to the hooked variant (Qwen3PForCausalLM
         # etc.).  Mutates vllm_config in place.
@@ -1440,7 +1505,10 @@ class DMXGPUWorker(Worker):
         new_archs = [_ARCH_REMAP.get(a, a) for a in archs]
         hf_cfg.architectures = new_archs
 
-        super().load_model()
+        # vLLM 0.19 added the keyword-only ``load_dummy_weights`` argument;
+        # forwarding the call unchanged keeps this worker compatible with
+        # both the older no-argument API and the newer one.
+        super().load_model(*args, **kwargs)
 
         # Now the model is materialized; install hooks via the adapter.
         if self.adaptor is None:
@@ -1499,9 +1567,18 @@ class DMXGPUWorker(Worker):
             adaptor._step_state = _VLLMStepState()
 
     def stop_monitoring(self) -> None:
-        """Flush and stop DMI engine.  Reentrant: second call no-ops."""
+        """Flush and stop DMI, surfacing incomplete-shutdown failures.
+
+        Cleanup remains exhaustive and reentrant: every component gets a stop
+        attempt even if an earlier one fails, then the explicit caller receives
+        one aggregated error. ``shutdown()`` keeps its best-effort semantics.
+        """
+        errors: list[tuple[str, Exception]] = []
         if torch.cuda.is_available():
-            torch.cuda.synchronize()
+            try:
+                torch.cuda.synchronize()
+            except Exception as exc:
+                errors.append(("torch.cuda.synchronize", exc))
 
         if self.adaptor is not None:
             engine = self.adaptor.engine
@@ -1509,24 +1586,32 @@ class DMXGPUWorker(Worker):
             if ring_engine is not None:
                 try:
                     ring_engine.stop()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    errors.append(("ring_engine.stop", exc))
             try:
                 ring_transport.deactivate()
-            except Exception:
-                pass
+            except Exception as exc:
+                errors.append(("ring_transport.deactivate", exc))
             try:
                 engine.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                errors.append(("monitoring_engine.close", exc))
             self.adaptor = None
 
         if self._dmx_host_engine is not None:
             try:
                 self._dmx_host_engine.stop()
-            except Exception:
-                pass
+            except Exception as exc:
+                errors.append(("host_engine.stop", exc))
             self._dmx_host_engine = None
+
+        if errors:
+            summary = "; ".join(
+                f"{operation}: {error}" for operation, error in errors
+            )
+            raise RuntimeError(
+                f"DMI monitoring shutdown was incomplete: {summary}"
+            ) from errors[0][1]
 
     def shutdown(self) -> None:
         import logging
@@ -1535,8 +1620,14 @@ class DMXGPUWorker(Worker):
                 "DMI engine not explicitly stopped before shutdown. "
                 "Data may be incomplete. Call stop_monitoring() first."
             )
-        # Best-effort flush (may be killed by vLLM's 8 s deadline).
-        self.stop_monitoring()
+        # Best-effort flush (may be killed by vLLM's 8 s deadline). Explicit
+        # collective_rpc("stop_monitoring") calls still receive failures.
+        try:
+            self.stop_monitoring()
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "DMI monitoring shutdown was incomplete during worker teardown"
+            )
         super().shutdown()
 
 
@@ -1546,7 +1637,29 @@ def _attach_dmi_internal(outputs, model_id, reader=None):
     request -- the same object HF's ``out.dmi_internal`` gives you."""
     for r in outputs:
         rid = normalize_vllm_request_id(r.request_id)
-        r.dmi_internal = make_lazy_internal(model_id, reader=reader, request_ids=[rid])
+        prompt_token_ids = getattr(r, "prompt_token_ids", None) or ()
+        candidates = getattr(r, "outputs", None) or ()
+        generated_token_ids = (
+            getattr(candidates[0], "token_ids", None) or ()
+            if candidates
+            else ()
+        )
+        # The last sampled token is returned but is never fed through another
+        # model forward, so no activation exists for it. Describe coverage as
+        # one logical interval; the reader coalesces vLLM's physical prefill /
+        # decode segments before validating completeness.
+        forwarded_tokens = max(
+            0, len(prompt_token_ids) + len(generated_token_ids) - 1
+        )
+        token_ranges = (
+            {rid: ((0, forwarded_tokens),)} if forwarded_tokens else None
+        )
+        r.dmi_internal = make_lazy_internal(
+            model_id,
+            reader=reader,
+            request_ids=[rid],
+            token_ranges=token_ranges,
+        )
     return outputs
 
 

--- a/monitoring/internal_mapper.py
+++ b/monitoring/internal_mapper.py
@@ -50,6 +50,21 @@ def _request_sort_key(request_id: str) -> tuple:
     return tuple(key)
 
 
+def _coalesce_token_ranges(
+    ranges: tuple[tuple[int, int], ...],
+) -> tuple[tuple[int, int], ...]:
+    """Merge overlapping/adjacent ranges without hiding token gaps."""
+    merged: list[list[int]] = []
+    for start, end in sorted(ranges):
+        if end <= start:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return tuple((start, end) for start, end in merged)
+
+
 def _reassemble_per_layer(rows: list) -> tuple[torch.Tensor, ...]:
     """Reassemble a per-layer hook (residual stream, mlp, ...).
 
@@ -439,8 +454,12 @@ class _LazyInternal:
         # common "writer still pending" case without scanning every layer.
         check_layer = layers[-1] if layers else None
         for request_id in self._request_ids:
-            expected = self._expected_non_empty_ranges(request_id)
-            actual = self._actual_ranges_for_request(rows, request_id, check_layer)
+            expected = _coalesce_token_ranges(
+                self._expected_non_empty_ranges(request_id)
+            )
+            actual = _coalesce_token_ranges(
+                self._actual_ranges_for_request(rows, request_id, check_layer)
+            )
             if actual != expected:
                 raise IncompleteInternalError(
                     f"{field} token ranges are incomplete for "

--- a/tests/_clickhouse_test_utils.py
+++ b/tests/_clickhouse_test_utils.py
@@ -1,0 +1,26 @@
+"""Narrow ClickHouse cleanup helpers for E2E test captures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def delete_capture_from_meta(metadata_dir: str | Path) -> None:
+    """Synchronously delete only the capture named by a runner's metadata."""
+    metadata_path = Path(metadata_dir) / "meta.json"
+    if not metadata_path.is_file():
+        return
+
+    metadata = json.loads(metadata_path.read_text())
+    model_id = metadata["model_id"]
+    import clickhouse_driver
+
+    client = clickhouse_driver.Client(
+        metadata["db_host"], port=int(metadata["db_port"])
+    )
+    client.execute(
+        "ALTER TABLE default.offload DELETE WHERE model_id = %(model_id)s",
+        {"model_id": model_id},
+        settings={"mutations_sync": 1},
+    )

--- a/tests/_requirements.py
+++ b/tests/_requirements.py
@@ -67,13 +67,17 @@ def require_gpus(n: int):
 
 
 def require_clickhouse(host: str | None = None, port: int | None = None):
-    """Skip unless a ClickHouse TCP port is reachable.
+    """Skip unless the Python driver exists and ClickHouse is reachable.
 
     Host/port default to the ``DMX_DB_HOST`` / ``DMX_DB_PORT`` env vars (and
     finally ``127.0.0.1:9000``), matching the runners' connection defaults.
     """
     host = host or os.environ.get("DMX_DB_HOST", "127.0.0.1")
     port = int(port if port is not None else os.environ.get("DMX_DB_PORT", "9000"))
+    if importlib.util.find_spec("clickhouse_driver") is None:
+        return pytest.mark.skipif(
+            True, reason="clickhouse-driver is not installed"
+        )
     reachable = False
     try:
         with socket.create_connection((host, port), timeout=1.0):

--- a/tests/blackbox/__init__.py
+++ b/tests/blackbox/__init__.py
@@ -1,0 +1,1 @@
+"""Public-API-only black-box test support for DMI integrations."""

--- a/tests/blackbox/case_generation.py
+++ b/tests/blackbox/case_generation.py
@@ -1,0 +1,47 @@
+"""Deterministic prompt generation for public-API differential tests."""
+
+from __future__ import annotations
+
+import random
+
+
+_SUBJECTS = (
+    "a cache entry",
+    "the final token",
+    "request 0007",
+    "a multilingual user",
+    "an empty-looking value '   '",
+    "a shared prefix",
+)
+_ACTIONS = (
+    "is summarized as",
+    "should remain distinct from",
+    "continues with",
+    "maps deterministically to",
+    "contains punctuation such as []{}<>",
+)
+_SUFFIXES = (
+    "one concise sentence.",
+    "three comma-separated words.",
+    "a JSON-like value without code fences.",
+    "Unicode text: naïve, Ελληνικά, 한글.",
+    "the number immediately after 999.",
+)
+
+
+def generate_prompts(*, seed: int, count: int) -> list[str]:
+    """Generate reproducible, unique strings using no model internals."""
+    if count < 0:
+        raise ValueError("count must be non-negative")
+
+    rng = random.Random(seed)
+    prompts = []
+    for index in range(count):
+        subject = rng.choice(_SUBJECTS)
+        action = rng.choice(_ACTIONS)
+        suffix = rng.choice(_SUFFIXES)
+        nonce = rng.randrange(1_000_000)
+        prompts.append(
+            f"case={index:03d}; nonce={nonce:06d}\n{subject} {action} {suffix}"
+        )
+    return prompts

--- a/tests/blackbox/cases/transparency.json
+++ b/tests/blackbox/cases/transparency.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vllm-transparency-core",
+  "prompts": [
+    "The capital of France is",
+    "Hi",
+    "Unicode and emoji: café, 東京, 🚀",
+    "Shared prefix for cache behavior: alpha beta gamma, first continuation:",
+    "Shared prefix for cache behavior: alpha beta gamma, second continuation:",
+    "This deliberately longer request creates a ragged batch beside short prompts. Repeatable public API behavior matters more than the semantic quality of this continuation."
+  ]
+}

--- a/tests/blackbox/contracts.py
+++ b/tests/blackbox/contracts.py
@@ -1,0 +1,39 @@
+"""Contracts shared by public-API DMI black-box tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_TRANSPARENCY_FIELDS = (
+    "schema_version",
+    "model",
+    "cudagraph",
+    "prompts",
+    "prompt_token_ids",
+    "token_ids",
+    "texts",
+    "finish_reasons",
+    "stop_reasons",
+)
+
+
+def transparency_mismatches(
+    baseline: dict[str, Any],
+    monitored: dict[str, Any],
+) -> list[str]:
+    """Return public output fields changed by enabling DMI monitoring."""
+
+    missing = [
+        field
+        for field in _TRANSPARENCY_FIELDS
+        if field not in baseline or field not in monitored
+    ]
+    if missing:
+        return [f"missing required field: {field}" for field in missing]
+
+    return [
+        field
+        for field in _TRANSPARENCY_FIELDS
+        if baseline[field] != monitored[field]
+    ]

--- a/tests/compare_disk_vs_ch.py
+++ b/tests/compare_disk_vs_ch.py
@@ -65,15 +65,30 @@ def _bytes_identical(a: torch.Tensor, b: torch.Tensor) -> bool:
 
 
 def read_clickhouse(db_host: str, db_port: int,
-                    database: str = "default", table: str = "offload"):
-    """Read all rows from ClickHouse, return dict keyed by (req_id, act_name, layer, shard, start, end)."""
+                    database: str = "default", table: str = "offload",
+                    model_id: str | None = None):
+    """Read ClickHouse rows keyed by request/hook/token range.
+
+    ``model_id`` should identify one test run. It remains optional for the
+    legacy Hugging Face comparator, which owns a freshly cleared table.
+    """
     import clickhouse_driver
     ch_client = clickhouse_driver.Client(db_host, port=db_port)
-    raw_rows = ch_client.execute(
+    query = (
         f"SELECT model_id, request_id, act_name, layer_no, shard_rank, "
         f"start_token_idx, end_token_idx, dtype, shape, bytes "
-        f"FROM {database}.{table}",
-        settings={"strings_as_bytes": True})
+        f"FROM {database}.{table}"
+    )
+    params = None
+    if model_id is not None:
+        query += " WHERE model_id = %(model_id)s"
+        params = {"model_id": model_id}
+    if params is None:
+        raw_rows = ch_client.execute(
+            query, settings={"strings_as_bytes": True})
+    else:
+        raw_rows = ch_client.execute(
+            query, params, settings={"strings_as_bytes": True})
 
     ch_data: dict[tuple, torch.Tensor] = {}
     for row in raw_rows:

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -33,14 +33,14 @@ class CompareWorker(DMXGPUWorker):
         self._compare_output_dir: str = ""
         self._compare_step: int = 0
 
-    def load_model(self) -> None:
+    def load_model(self, *args, **kwargs) -> None:
         # Remap to compare variant
         hf_cfg = self.vllm_config.model_config.hf_config
         archs = getattr(hf_cfg, "architectures", [])
         new_archs = [_ARCH_REMAP.get(a, a) for a in archs]
         hf_cfg.architectures = new_archs
 
-        super().load_model()
+        super().load_model(*args, **kwargs)
 
         # Allocate compare buffers. Use max_num_batched_tokens (not
         # E2E_REF_MAX_LEN) because profiling runs the model with that many

--- a/tests/ref_disk_worker.py
+++ b/tests/ref_disk_worker.py
@@ -35,14 +35,14 @@ class RefDiskWorker(Worker):
         self._tp_rank: int = 0
         self._tp_size: int = 1
 
-    def load_model(self) -> None:
+    def load_model(self, *args, **kwargs) -> None:
         # Remap to ref variant
         hf_cfg = self.vllm_config.model_config.hf_config
         archs = getattr(hf_cfg, "architectures", [])
         new_archs = [_ARCH_REMAP.get(a, a) for a in archs]
         hf_cfg.architectures = new_archs
 
-        super().load_model()
+        super().load_model(*args, **kwargs)
 
         from vllm.distributed.parallel_state import get_tp_group
         self._tp_rank = get_tp_group().rank_in_group

--- a/tests/test_blackbox_case_generation.py
+++ b/tests/test_blackbox_case_generation.py
@@ -1,0 +1,27 @@
+"""CPU contracts for deterministic public-input testcase generation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.blackbox.case_generation import generate_prompts
+
+
+pytestmark = pytest.mark.cpu
+
+
+def test_generated_cases_are_reproducible_and_unique():
+    first = generate_prompts(seed=17, count=20)
+    second = generate_prompts(seed=17, count=20)
+
+    assert first == second
+    assert len(first) == len(set(first)) == 20
+
+
+def test_generated_cases_change_with_seed():
+    assert generate_prompts(seed=1, count=5) != generate_prompts(seed=2, count=5)
+
+
+def test_generated_case_count_is_validated():
+    with pytest.raises(ValueError, match="non-negative"):
+        generate_prompts(seed=0, count=-1)

--- a/tests/test_internal_mapper.py
+++ b/tests/test_internal_mapper.py
@@ -396,6 +396,39 @@ def test_lazy_internal_requirement_retries_missing_token_ranges_until_success():
     assert reader.calls == 2
 
 
+def test_token_range_validation_accepts_different_contiguous_segmentation():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(2, 4)),
+        _row("0:0", 0, 2, torch.ones(1, 4)),
+    ]
+    internal = make_lazy_internal(
+        "m",
+        PrefixReader(rows),
+        request_ids=("0:0",),
+        token_ranges={"0:0": ((0, 3),)},
+    )
+    internal.require("hidden_states", count=1, match_token_ranges=True)
+
+    assert tuple(internal.hidden_states[0].shape) == (1, 3, 4)
+
+
+def test_token_range_validation_does_not_coalesce_across_gaps():
+    rows = [
+        _row("0:0", 0, 0, torch.ones(1, 4)),
+        _row("0:0", 0, 2, torch.ones(1, 4)),
+    ]
+    internal = make_lazy_internal(
+        "m",
+        PrefixReader(rows),
+        request_ids=("0:0",),
+        token_ranges={"0:0": ((0, 3),)},
+    )
+    internal.require("hidden_states", count=1, match_token_ranges=True)
+
+    with pytest.raises(IncompleteInternalError, match="token ranges are incomplete"):
+        internal.hidden_states
+
+
 def test_lazy_internal_requirement_retry_timeout_raises_incomplete():
     rows = [_row("0:0", 0, 0, torch.ones(3, 4))]
     reader = SequenceReader([rows])

--- a/tests/test_qwen2_p_inventory.py
+++ b/tests/test_qwen2_p_inventory.py
@@ -1,0 +1,144 @@
+"""CPU checks for the monitored Qwen2 model's canonical hook inventory."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import torch.nn as nn
+
+from monitoring.hook_points import HookPoint
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_MLP_POST,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+)
+
+
+def _load_qwen2_p_class():
+    try:
+        from vllm.model_executor.models.qwen2_p import Qwen2PForCausalLM
+
+        return Qwen2PForCausalLM
+    except ModuleNotFoundError:
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "integration/vllm/vllm/model_executor/models/qwen2_p.py"
+        )
+        name = "vllm.model_executor.models.qwen2_p"
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module.Qwen2PForCausalLM
+
+
+class _FakeAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hook_q = HookPoint()
+        self.hook_k = HookPoint()
+        self.hook_v = HookPoint()
+        self.hook_z = HookPoint()
+
+
+class _FakeMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hook_post = HookPoint()
+
+
+class _FakeLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = _FakeAttention()
+        self.mlp = _FakeMLP()
+        for name in (
+            "hook_resid_pre",
+            "hook_ln1",
+            "hook_attn_out",
+            "hook_resid_mid",
+            "hook_ln2",
+            "hook_mlp_in",
+            "hook_mlp_out",
+        ):
+            setattr(self, name, HookPoint())
+
+
+class _FakeModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_FakeLayer(), _FakeLayer()])
+        self.start_layer = 0
+        self.end_layer = len(self.layers)
+        self.hook_embed = HookPoint()
+        self.hook_resid_final = HookPoint()
+        self.hook_final_ln = HookPoint()
+
+
+def _fake_qwen2_p():
+    cls = _load_qwen2_p_class()
+    model = cls.__new__(cls)
+    nn.Module.__init__(model)
+    model.model = _FakeModel()
+    model.hook_token_ids = HookPoint()
+    model.hook_final_logits = HookPoint()
+    return model
+
+
+def test_qwen2_inventory_has_all_dense_hook_types_per_layer():
+    model = _fake_qwen2_p()
+    specs = model.get_hook_specs()
+    per_layer = {
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_LN1,
+        HOOK_TYPE_Q,
+        HOOK_TYPE_K,
+        HOOK_TYPE_V,
+        HOOK_TYPE_Z,
+        HOOK_TYPE_ATTN_OUT,
+        HOOK_TYPE_RESID_MID,
+        HOOK_TYPE_LN2,
+        HOOK_TYPE_MLP_IN,
+        HOOK_TYPE_MLP_POST,
+        HOOK_TYPE_MLP_OUT,
+    }
+
+    assert {s.hook_type for s in specs if s.layer_no == 0} == per_layer
+    assert {s.hook_type for s in specs if s.layer_no == 1} == per_layer
+    assert {s.hook_type for s in specs if s.layer_no == -1} == {
+        HOOK_TYPE_TOKEN_IDS,
+        HOOK_TYPE_EMBED,
+        HOOK_TYPE_RESID_FINAL,
+        HOOK_TYPE_FINAL_LN,
+        HOOK_TYPE_FINAL_LOGITS,
+    }
+    assert all(s.module is not None for s in specs)
+
+
+def test_qwen2_model_wide_inventory_is_module_free():
+    specs = _fake_qwen2_p().get_hook_specs(model_wide=True)
+
+    assert len(specs) == 29
+    assert all(s.module is None for s in specs)
+    assert all(
+        s.dim0_is_actual_tokens
+        for s in specs
+        if s.hook_type != HOOK_TYPE_FINAL_LOGITS
+    )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,24 @@
+"""CPU tests for precise external-resource guards."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests import _requirements
+
+
+pytestmark = pytest.mark.cpu
+
+
+def test_clickhouse_guard_reports_missing_python_driver(monkeypatch):
+    monkeypatch.setattr(
+        _requirements.importlib.util,
+        "find_spec",
+        lambda name: None if name == "clickhouse_driver" else object(),
+    )
+
+    marker = _requirements.require_clickhouse("127.0.0.1", 9000)
+
+    assert marker.name == "skipif"
+    assert marker.args == (True,)
+    assert marker.kwargs["reason"] == "clickhouse-driver is not installed"

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -1,0 +1,118 @@
+"""Black-box DMI transparency test using only vLLM's public offline API."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from tests._requirements import require_cuda, require_model_cache, require_vllm
+from tests.blackbox.case_generation import generate_prompts
+from tests.blackbox.contracts import transparency_mismatches
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RUNNER = PROJECT_ROOT / "tests/tools/smoke_vllm_model.py"
+CASES = PROJECT_ROOT / "tests/blackbox/cases/transparency.json"
+MODEL_ALIASES = {
+    "gpt2": "gpt2",
+    "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",
+    "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
+    "qwen3": "Qwen/Qwen3-0.6B",
+    "llama": "meta-llama/Llama-3.1-8B",
+}
+MODEL_ARG = os.environ.get("DMI_BLACKBOX_MODEL", "qwen2")
+MODEL_ID = MODEL_ALIASES.get(MODEL_ARG, MODEL_ARG)
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.vllm,
+    pytest.mark.e2e,
+    require_cuda(),
+    require_vllm(),
+    require_model_cache(MODEL_ID),
+]
+
+
+def _run(
+    mode: str,
+    output: Path,
+    *,
+    cases: Path,
+    cudagraph: bool,
+) -> dict:
+    command = [
+        sys.executable,
+        str(RUNNER),
+        "--mode",
+        mode,
+        "--model",
+        MODEL_ARG,
+        "--cases",
+        str(cases),
+        "--output",
+        str(output),
+    ]
+    if cudagraph:
+        command.append("--cudagraph")
+
+    env = dict(os.environ)
+    env.setdefault("HF_HUB_OFFLINE", "1")
+    env.setdefault("TRANSFORMERS_OFFLINE", "1")
+    result = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"{mode} black-box runner failed with rc={result.returncode}\n"
+        f"stdout:\n{result.stdout[-4000:]}\n"
+        f"stderr:\n{result.stderr[-4000:]}"
+    )
+    assert output.is_file(), f"{mode} runner did not create {output}"
+    return json.loads(output.read_text())
+
+
+@pytest.mark.parametrize(
+    "cudagraph",
+    [False, True]
+    if os.environ.get("DMI_BLACKBOX_CUDAGRAPH", "0") == "1"
+    else [False],
+    ids=lambda enabled: "cudagraph" if enabled else "eager",
+)
+def test_monitoring_is_transparent_at_the_public_vllm_api(tmp_path, cudagraph):
+    core = json.loads(CASES.read_text())
+    seed = int(os.environ.get("DMI_BLACKBOX_SEED", "20260812"))
+    generated_count = int(os.environ.get("DMI_BLACKBOX_GENERATED_CASES", "6"))
+    core["name"] = f"{core['name']}+generated"
+    core["seed"] = seed
+    core["prompts"].extend(generate_prompts(seed=seed, count=generated_count))
+    cases = tmp_path / "cases.json"
+    cases.write_text(json.dumps(core, indent=2, ensure_ascii=False) + "\n")
+
+    baseline = _run(
+        "baseline",
+        tmp_path / "baseline.json",
+        cases=cases,
+        cudagraph=cudagraph,
+    )
+    monitored = _run(
+        "monitored",
+        tmp_path / "monitored.json",
+        cases=cases,
+        cudagraph=cudagraph,
+    )
+
+    mismatches = transparency_mismatches(baseline, monitored)
+    assert not mismatches, (
+        f"DMI changed public vLLM fields: {mismatches}\n"
+        f"case_seed={seed}\n"
+        f"baseline={json.dumps(baseline, indent=2, ensure_ascii=False)}\n"
+        f"monitored={json.dumps(monitored, indent=2, ensure_ascii=False)}"
+    )

--- a/tests/test_vllm_blackbox_contract.py
+++ b/tests/test_vllm_blackbox_contract.py
@@ -1,0 +1,63 @@
+"""CPU tests for the public vLLM transparency-result contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from tests.blackbox.contracts import transparency_mismatches
+
+
+pytestmark = pytest.mark.cpu
+
+
+def _payload() -> dict:
+    return {
+        "schema_version": 1,
+        "mode": "baseline",
+        "model": "model",
+        "cudagraph": False,
+        "prompts": ["hello"],
+        "prompt_token_ids": [[1]],
+        "token_ids": [[2]],
+        "texts": ["world"],
+        "finish_reasons": ["length"],
+        "stop_reasons": [None],
+    }
+
+
+def test_transparency_ignores_only_the_execution_mode_label():
+    baseline = _payload()
+    monitored = deepcopy(baseline)
+    monitored["mode"] = "monitored"
+
+    assert transparency_mismatches(baseline, monitored) == []
+
+
+@pytest.mark.parametrize(
+    "field,replacement",
+    [
+        ("prompt_token_ids", [[9]]),
+        ("token_ids", [[9]]),
+        ("texts", ["changed"]),
+        ("finish_reasons", ["stop"]),
+        ("stop_reasons", [42]),
+    ],
+)
+def test_transparency_reports_changed_public_output(field, replacement):
+    baseline = _payload()
+    monitored = deepcopy(baseline)
+    monitored[field] = replacement
+
+    assert transparency_mismatches(baseline, monitored) == [field]
+
+
+def test_transparency_reports_missing_fields_before_comparison():
+    baseline = _payload()
+    monitored = deepcopy(baseline)
+    del monitored["token_ids"]
+
+    assert transparency_mismatches(baseline, monitored) == [
+        "missing required field: token_ids"
+    ]

--- a/tests/test_vllm_comparator_contract.py
+++ b/tests/test_vllm_comparator_contract.py
@@ -1,0 +1,108 @@
+"""CPU regression tests for fail-closed vLLM comparators."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.compare_disk_vs_ch import read_clickhouse
+from tests.vllm_identical_comparator import bitwise_check, compare_logprobs
+
+
+pytestmark = pytest.mark.cpu
+
+
+def _compare(tmp_path, baseline, candidate):
+    baseline_path = tmp_path / "baseline.pt"
+    candidate_path = tmp_path / "candidate.pt"
+    torch.save(baseline, baseline_path)
+    torch.save(candidate, candidate_path)
+    checks = []
+
+    def record(name, passed, detail=""):
+        checks.append({"name": name, "passed": passed, "detail": detail})
+
+    compare_logprobs(
+        str(baseline_path),
+        str(candidate_path),
+        {},
+        record,
+        label="baseline vs candidate",
+    )
+    assert len(checks) == 1
+    return checks[0]
+
+
+def test_bitwise_comparison_fails_on_dtype_mismatch():
+    result = bitwise_check(
+        torch.tensor([1.0], dtype=torch.float16),
+        torch.tensor([1.0], dtype=torch.bfloat16),
+        "dtype",
+    )
+
+    assert not result["passed"]
+    assert "dtype mismatch" in result["detail"]
+
+
+def test_logprob_comparison_fails_on_token_length_only_mismatch(tmp_path):
+    logprobs = torch.zeros((2, 4), dtype=torch.float32)
+    result = _compare(
+        tmp_path,
+        {0: {"token_ids": [1, 2], "logprobs": logprobs}},
+        {0: {"token_ids": [1], "logprobs": logprobs}},
+    )
+
+    assert not result["passed"]
+    assert "token_ids differ" in result["detail"]
+
+
+def test_logprob_comparison_fails_instead_of_truncating_shape(tmp_path):
+    baseline = torch.zeros((2, 4), dtype=torch.float32)
+    candidate = torch.zeros((2, 3), dtype=torch.float32)
+    result = _compare(
+        tmp_path,
+        {0: {"token_ids": [1, 2], "logprobs": baseline}},
+        {0: {"token_ids": [1, 2], "logprobs": candidate}},
+    )
+
+    assert not result["passed"]
+    assert "shape mismatch" in result["detail"]
+
+
+def test_logprob_comparison_requires_full_vocab_data(tmp_path):
+    result = _compare(
+        tmp_path,
+        {0: {"token_ids": [1], "logprobs": None}},
+        {0: {"token_ids": [1], "logprobs": None}},
+    )
+
+    assert not result["passed"]
+    assert "unavailable" in result["detail"]
+
+
+def test_clickhouse_reader_filters_to_one_capture(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def __init__(self, host, port):
+            assert (host, port) == ("db", 9000)
+
+        def execute(self, query, params, settings):
+            calls.append((query, params, settings))
+            return []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "clickhouse_driver",
+        SimpleNamespace(Client=FakeClient),
+    )
+
+    data, count = read_clickhouse("db", 9000, model_id="capture-123")
+
+    assert data == {}
+    assert count == 0
+    assert "WHERE model_id = %(model_id)s" in calls[0][0]
+    assert calls[0][1] == {"model_id": "capture-123"}

--- a/tests/test_vllm_dmillm.py
+++ b/tests/test_vllm_dmillm.py
@@ -13,7 +13,14 @@ from integration.vllm_adapter import _attach_dmi_internal, normalize_vllm_reques
 
 
 def _fake_outputs(*request_ids):
-    return [SimpleNamespace(request_id=rid) for rid in request_ids]
+    return [
+        SimpleNamespace(
+            request_id=rid,
+            prompt_token_ids=[10, 11],
+            outputs=[SimpleNamespace(token_ids=[20, 21, 22])],
+        )
+        for rid in request_ids
+    ]
 
 
 def test_tags_each_output_with_lazy_internal():
@@ -29,6 +36,16 @@ def test_per_request_isolation():
     # Each output's internal is keyed only by its own (normalized) request_id.
     assert outs[0].dmi_internal._request_ids == (normalize_vllm_request_id("req-a"),)
     assert outs[1].dmi_internal._request_ids == (normalize_vllm_request_id("req-b"),)
+
+
+def test_expected_token_coverage_comes_from_public_request_output():
+    outs = _fake_outputs("req-a")
+
+    _attach_dmi_internal(outs, "m", reader=None)
+
+    rid = normalize_vllm_request_id("req-a")
+    # 2 prompt + 3 generated - the final unforwarded sampled token.
+    assert outs[0].dmi_internal._token_ranges == {rid: ((0, 4),)}
 
 
 def test_reader_passed_through():

--- a/tests/test_vllm_dmillm_e2e.py
+++ b/tests/test_vllm_dmillm_e2e.py
@@ -17,17 +17,29 @@ import sys
 import tempfile
 
 import pytest
-import torch
+
+from tests._requirements import (
+    require_clickhouse,
+    require_cuda,
+    require_model_cache,
+    require_vllm,
+)
+
+
+MODEL = os.environ.get("E2E_MODEL", "Qwen/Qwen3-0.6B")
 
 pytestmark = [
     pytest.mark.gpu,
     pytest.mark.vllm,
     pytest.mark.clickhouse,
     pytest.mark.e2e,
+    require_cuda(),
+    require_clickhouse(),
+    require_vllm(),
+    require_model_cache(MODEL),
 ]
 
 
-@pytest.mark.skipif(not torch.backends.cuda.is_built(), reason="CUDA not built")
 def test_vllm_dmillm_e2e():
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     run_dir = tempfile.mkdtemp(prefix="vllm_dmillm_")
@@ -37,16 +49,37 @@ def test_vllm_dmillm_e2e():
 
     try:
         r = subprocess.run(
-            [sys.executable, "-m", "tests.vllm_dmillm_runner", "--result-file", result_file],
+            [
+                sys.executable,
+                "-m",
+                "tests.vllm_dmillm_runner",
+                "--model",
+                MODEL,
+                "--result-file",
+                result_file,
+            ],
             env=env, capture_output=True, text=True, cwd=project_root,
         )
-        if not os.path.exists(result_file):
-            pytest.skip(
-                f"DMILLM runner could not run (vLLM / ClickHouse / deps missing?):\n"
-                f"{r.stderr[-1500:]}"
+        results = None
+        if os.path.exists(result_file):
+            with open(result_file) as f:
+                results = json.load(f)
+        if r.returncode != 0:
+            failed = (
+                [test for test in results["tests"] if not test["passed"]]
+                if results is not None
+                else "result file missing"
             )
-        with open(result_file) as f:
-            results = json.load(f)
+            pytest.fail(
+                f"DMILLM runner failed with rc={r.returncode}\n"
+                f"failed checks: {failed}\n"
+                f"stdout:\n{r.stdout[-4000:]}\n"
+                f"stderr:\n{r.stderr[-4000:]}"
+            )
+        if results is None:
+            pytest.fail(
+                "DMILLM runner exited successfully without producing its result file"
+            )
         failed = [t for t in results["tests"] if not t["passed"]]
         assert not failed, f"failed checks: {failed}"
     finally:

--- a/tests/test_vllm_identical.py
+++ b/tests/test_vllm_identical.py
@@ -2,7 +2,7 @@
 (GPU buffer D2D capture → disk) and monitored model (ring transport → ClickHouse).
 
 Four steps, parent never touches CUDA:
-  0. Sanity check: original vs ref model logprobs (informational, never fails)
+  0. Transparency check: original, ref, and monitored model logprobs
   1. Reference run (RefDiskWorker, D2D capture → disk)
   2. Monitored run (DMXGPUWorker, ring transport → ClickHouse)
   3. Comparator (CPU only, logprob comparison + bitwise tensor check)
@@ -38,13 +38,34 @@ import sys
 import tempfile
 
 import pytest
-import torch
+
+from tests._requirements import (
+    require_clickhouse,
+    require_cuda,
+    require_model_cache,
+    require_vllm,
+)
+from tests._clickhouse_test_utils import delete_capture_from_meta
+
+
+_MODEL_ALIASES = {
+    "gpt2": "gpt2",
+    "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
+    "qwen3": "Qwen/Qwen3-0.6B",
+    "llama": "meta-llama/Llama-3.1-8B",
+}
+_MODEL_KEY = os.environ.get("E2E_MODEL", "gpt2")
+_MODEL_ID = _MODEL_ALIASES.get(_MODEL_KEY, _MODEL_KEY)
 
 pytestmark = [
     pytest.mark.gpu,
     pytest.mark.vllm,
     pytest.mark.clickhouse,
     pytest.mark.e2e,
+    require_cuda(),
+    require_clickhouse(),
+    require_vllm(),
+    require_model_cache(_MODEL_ID),
 ]
 
 _MODEL_REF_FILES = {
@@ -55,12 +76,10 @@ _MODEL_REF_FILES = {
 }
 
 
-@pytest.mark.skipif(
-    not torch.backends.cuda.is_built(), reason="CUDA not built")
 def test_vllm_identical(subtests):
     """Bitwise comparison: ref model (disk) vs monitored model (ClickHouse)."""
 
-    model_key = os.environ.get("E2E_MODEL", "gpt2")
+    model_key = _MODEL_KEY
     hooks = os.environ.get("E2E_HOOK_SELECTION", "vllm-full")
     max_len = int(os.environ.get("E2E_REF_MAX_LEN", "8192"))
     enforce_eager = os.environ.get("E2E_ENFORCE_EAGER", "1")
@@ -72,7 +91,7 @@ def test_vllm_identical(subtests):
 
     ref_filename = _MODEL_REF_FILES.get(model_key)
     if ref_filename is None:
-        pytest.skip(f"No ref model for {model_key}")
+        pytest.fail(f"No reference model is declared for {model_key}")
     model_file = os.path.join(models_dir, ref_filename)
 
     keep_artifacts = os.environ.get("E2E_KEEP_ARTIFACTS", "0") == "1"
@@ -135,9 +154,11 @@ def test_vllm_identical(subtests):
             with open(os.path.join(run_dir, "compile_orig.log"), "w") as f:
                 f.write(r0a.stderr)
         if r0a.returncode != 0:
-            print(r0a.stderr[-2000:] if r0a.stderr else "", flush=True)
-            print("  WARNING: original logprob run failed, skipping sanity check")
-            orig_logprobs_file = None
+            pytest.fail(
+                f"Original logprob runner failed (rc={r0a.returncode})\n"
+                f"stdout:\n{r0a.stdout[-4000:]}\n"
+                f"stderr:\n{r0a.stderr[-4000:]}"
+            )
 
         print("  [0/4] Sanity check: ref model logprobs...", flush=True)
         ref_lp_env = dict(sub_env)
@@ -152,26 +173,34 @@ def test_vllm_identical(subtests):
             with open(os.path.join(run_dir, "compile_ref_logprob.log"), "w") as f:
                 f.write(r0b.stderr)
         if r0b.returncode != 0:
-            print(r0b.stderr[-2000:] if r0b.stderr else "", flush=True)
-            print("  WARNING: ref logprob run failed, skipping sanity check")
-            ref_logprobs_file = None
+            pytest.fail(
+                f"Reference logprob runner failed (rc={r0b.returncode})\n"
+                f"stdout:\n{r0b.stdout[-4000:]}\n"
+                f"stderr:\n{r0b.stderr[-4000:]}"
+            )
 
         # Step 0c: Monitored model logprobs (baseline vs monitored comparison)
         mon_logprobs_file = os.path.join(run_dir, "logprobs_mon.pt")
         print("  [0/4] Sanity check: monitored model logprobs...", flush=True)
+        mon_lp_env = dict(sub_env)
+        # This phase validates public outputs only; keep transport active but
+        # disable persistence so its rows cannot pollute the tensor comparator.
+        mon_lp_env["DMX_DB_HOST"] = ""
         r0c = subprocess.run(
             [sys.executable, "-m", "tests.vllm_logprob_runner",
              "--output", mon_logprobs_file, "--monitored"],
-            env=sub_env, capture_output=True, text=True, cwd=project_root,
+            env=mon_lp_env, capture_output=True, text=True, cwd=project_root,
         )
         print(r0c.stdout[-1000:] if r0c.stdout else "", flush=True)
         if dump_compiled and r0c.stderr:
             with open(os.path.join(run_dir, "compile_mon_logprob.log"), "w") as f:
                 f.write(r0c.stderr)
         if r0c.returncode != 0:
-            print(r0c.stderr[-2000:] if r0c.stderr else "", flush=True)
-            print("  WARNING: monitored logprob run failed, skipping")
-            mon_logprobs_file = None
+            pytest.fail(
+                f"Monitored logprob runner failed (rc={r0c.returncode})\n"
+                f"stdout:\n{r0c.stdout[-4000:]}\n"
+                f"stderr:\n{r0c.stderr[-4000:]}"
+            )
 
         # Step 1: Reference run
         print("\n  [1/4] Reference run (RefDiskWorker)...", flush=True)
@@ -214,7 +243,7 @@ def test_vllm_identical(subtests):
             print(r2.stderr[-3000:] if r2.stderr else "", flush=True)
             pytest.fail(f"Monitored runner failed (rc={r2.returncode})")
 
-        # Step 3: Comparator (includes logprob sanity check if available)
+        # Step 3: Comparator (includes required public-output checks)
         print("\n  [3/4] Comparing (bitwise check)...", flush=True)
         cmp_cmd = [
             sys.executable, "-m", "tests.vllm_identical_comparator",
@@ -255,7 +284,10 @@ def test_vllm_identical(subtests):
         # Always restore ref model file
         if os.path.exists(backup_file):
             shutil.copy2(backup_file, model_file)
-        if keep_artifacts:
-            print(f"\n  [kept] run_dir = {run_dir}", flush=True)
-        else:
-            shutil.rmtree(run_dir, ignore_errors=True)
+        try:
+            delete_capture_from_meta(mon_dir)
+        finally:
+            if keep_artifacts:
+                print(f"\n  [kept] run_dir = {run_dir}", flush=True)
+            else:
+                shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/test_vllm_request_order_fix.py
+++ b/tests/test_vllm_request_order_fix.py
@@ -8,6 +8,7 @@ import sys
 from types import SimpleNamespace
 
 import numpy as np
+from packaging.version import Version
 import pytest
 import torch
 import torch.nn as nn
@@ -76,12 +77,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PINNED_VLLM_ROOT = (REPO_ROOT / "integration" / "vllm").resolve()
 
 
-def test_runtime_uses_the_pinned_source_and_extension():
+def test_runtime_uses_a_coherent_supported_vllm_installation():
     source = Path(vllm.__file__).resolve()
     extension = Path(vllm._C.__file__).resolve()
 
-    assert source.is_relative_to(PINNED_VLLM_ROOT)
-    assert extension.is_relative_to(PINNED_VLLM_ROOT)
+    if source.is_relative_to(PINNED_VLLM_ROOT):
+        assert extension.is_relative_to(PINNED_VLLM_ROOT)
+        return
+
+    # The adapter can lazily register the bundled model variants with an
+    # official wheel.  Keep source and native extension from that same wheel,
+    # and constrain this path to the versions covered by the port matrix.
+    assert source.parent == extension.parent
+    version = Version(vllm.__version__)
+    assert (version.major, version.minor) in {(0, 17), (0, 18), (0, 19)}
 
 
 def _scheduler(order=("A", "B"), counts=(2, 3), total=None):
@@ -1582,6 +1591,55 @@ def test_worker_resets_state_when_upstream_raises(monkeypatch):
     with pytest.raises(RuntimeError, match="upstream failure"):
         worker.execute_model(_scheduler())
     assert adaptor._step_state.phase is VLLMStepPhase.IDLE
+
+
+def test_explicit_monitoring_stop_reports_failure_after_full_cleanup(monkeypatch):
+    events = []
+
+    def fail_ring_stop():
+        events.append("ring_stop")
+        raise RuntimeError("ring flush failed")
+
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = SimpleNamespace(
+        ring_engine=SimpleNamespace(stop=fail_ring_stop),
+        engine=SimpleNamespace(close=lambda: events.append("engine_close")),
+    )
+    worker._dmx_host_engine = SimpleNamespace(
+        stop=lambda: events.append("host_stop")
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        "integration.vllm_adapter.ring_transport.deactivate",
+        lambda: events.append("deactivate"),
+    )
+
+    with pytest.raises(RuntimeError, match="ring_engine.stop: ring flush failed"):
+        worker.stop_monitoring()
+
+    assert events == ["ring_stop", "deactivate", "engine_close", "host_stop"]
+    assert worker.adaptor is None
+    assert worker._dmx_host_engine is None
+
+
+def test_monitoring_stop_is_reentrant_after_success(monkeypatch):
+    events = []
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.adaptor = SimpleNamespace(
+        ring_engine=SimpleNamespace(stop=lambda: events.append("ring_stop")),
+        engine=SimpleNamespace(close=lambda: events.append("engine_close")),
+    )
+    worker._dmx_host_engine = None
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        "integration.vllm_adapter.ring_transport.deactivate",
+        lambda: events.append("deactivate"),
+    )
+
+    worker.stop_monitoring()
+    worker.stop_monitoring()
+
+    assert events == ["ring_stop", "deactivate", "engine_close"]
 
 
 def test_ec_transfer_producer_passthrough_never_arms(monkeypatch):

--- a/tests/test_vllm_rowcnt.py
+++ b/tests/test_vllm_rowcnt.py
@@ -39,28 +39,42 @@ import sys
 import tempfile
 
 import pytest
-import torch
+
+from tests._requirements import (
+    require_clickhouse,
+    require_cuda,
+    require_model_cache,
+    require_vllm,
+)
+from tests._clickhouse_test_utils import delete_capture_from_meta
+
+
+_MODEL_ALIASES = {
+    "gpt2": "gpt2",
+    "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",
+    "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
+    "qwen3": "Qwen/Qwen3-0.6B",
+}
+_MODEL_KEY = os.environ.get("E2E_MODEL", "gpt2")
+_MODEL_ID = _MODEL_ALIASES.get(_MODEL_KEY, _MODEL_KEY)
 
 pytestmark = [
     pytest.mark.gpu,
     pytest.mark.vllm,
     pytest.mark.clickhouse,
     pytest.mark.e2e,
+    require_cuda(),
+    require_clickhouse(),
+    require_vllm(),
+    require_model_cache(_MODEL_ID),
 ]
 
-_MODEL_ALIASES = {
-    "gpt2": "gpt2",
-    "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
-    "qwen3": "Qwen/Qwen3-0.6B",
-}
 
-@pytest.mark.skipif(
-    not torch.backends.cuda.is_built(), reason="CUDA not built")
 def test_vllm_rowcnt(subtests):
     """vLLM row-count validation: monitored run + row-count check."""
 
-    model_key = os.environ.get("E2E_MODEL", "gpt2")
-    model_id = _MODEL_ALIASES.get(model_key, model_key)
+    model_key = _MODEL_KEY
+    model_id = _MODEL_ID
 
     # Translate the public E2E_HOOK_SELECTION input into the internal
     # DMX_HOOK_SELECTION runtime contract that the runner actually reads.
@@ -93,7 +107,11 @@ def test_vllm_rowcnt(subtests):
             env=sub_env, capture_output=True, text=True, cwd=project_root,
         )
         if r2.returncode != 0:
-            pytest.fail(f"Monitored runner failed:\n{r2.stderr[-2000:]}")
+            pytest.fail(
+                f"Monitored runner failed with rc={r2.returncode}\n"
+                f"stdout:\n{r2.stdout[-4000:]}\n"
+                f"stderr:\n{r2.stderr[-4000:]}"
+            )
 
         # Step 2: Comparator (CPU only, row-count validation)
         print("  [2/2] Checking row counts...", flush=True)
@@ -105,7 +123,15 @@ def test_vllm_rowcnt(subtests):
             env=sub_env, capture_output=True, text=True, cwd=project_root,
         )
         if r3.returncode != 0:
-            pytest.fail(f"Comparator failed:\n{r3.stderr[-2000:]}")
+            pytest.fail(
+                f"Comparator failed with rc={r3.returncode}\n"
+                f"stdout:\n{r3.stdout[-4000:]}\n"
+                f"stderr:\n{r3.stderr[-4000:]}"
+            )
+        if not os.path.exists(result_file):
+            pytest.fail(
+                "Comparator exited successfully without producing its result file"
+            )
 
         # Read results
         with open(result_file) as f:
@@ -117,4 +143,7 @@ def test_vllm_rowcnt(subtests):
                 assert test["passed"], test.get("detail", "")
 
     finally:
-        shutil.rmtree(run_dir, ignore_errors=True)
+        try:
+            delete_capture_from_meta(mon_dir)
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/test_vllm_version_compat.py
+++ b/tests/test_vllm_version_compat.py
@@ -1,0 +1,68 @@
+"""CPU-only compatibility checks for supported vLLM worker APIs."""
+
+from types import SimpleNamespace
+
+from vllm.model_executor.models import ModelRegistry
+from vllm.v1.worker.gpu_worker import Worker
+
+from integration.vllm_adapter import (
+    DMXGPUWorker,
+    _ARCH_REMAP,
+    _DMI_MODEL_VARIANTS,
+    _LLAMA_COMPAT_ARCHES,
+)
+
+
+def test_llama_registry_aliases_use_the_hooked_variant():
+    expected = {
+        "AquilaModel",
+        "AquilaForCausalLM",
+        "CwmForCausalLM",
+        "InternLMForCausalLM",
+        "InternLM3ForCausalLM",
+        "IQuestCoderForCausalLM",
+        "LlamaForCausalLM",
+        "LLaMAForCausalLM",
+        "XverseForCausalLM",
+    }
+
+    assert _LLAMA_COMPAT_ARCHES == expected
+    assert {_ARCH_REMAP[arch] for arch in expected} == {"LlamaPForCausalLM"}
+
+
+def test_qwen2_uses_its_hooked_variant():
+    assert _ARCH_REMAP["Qwen2ForCausalLM"] == "Qwen2PForCausalLM"
+
+
+def test_bundled_variants_are_registered_with_official_vllm():
+    supported = set(ModelRegistry.get_supported_archs())
+
+    assert set(_DMI_MODEL_VARIANTS) <= supported
+    for architecture in _DMI_MODEL_VARIANTS:
+        model_cls = ModelRegistry._try_load_model_cls(architecture)
+        assert model_cls is not None
+        assert model_cls.__name__ == architecture
+
+
+def test_load_model_forwards_newer_vllm_keyword_arguments(monkeypatch):
+    calls = []
+
+    def fake_load_model(self, *args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(Worker, "load_model", fake_load_model)
+
+    worker = DMXGPUWorker.__new__(DMXGPUWorker)
+    worker.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"])
+        )
+    )
+    worker.adaptor = None
+
+    worker.load_model(load_dummy_weights=True)
+
+    assert calls == [((), {"load_dummy_weights": True})]
+    assert worker.vllm_config.model_config.hf_config.architectures == [
+        "LlamaPForCausalLM"
+    ]

--- a/tests/tools/README.md
+++ b/tests/tools/README.md
@@ -18,6 +18,7 @@ the vLLM runtime); they are not CPU-safe.
 | `identical_vllm.sh` | Wrapper around the vLLM bitwise-identical pytest check. |
 | `verify_vllm.sh` | vLLM row-count + identical verification sweep across ring sizes. |
 | `verify_hf.sh` | HF E2E correctness sweep across ring sizes. |
+| `smoke_vllm_model.py` | Baseline/monitored public-output smoke for a new vLLM version or model; no ClickHouse required. |
 
 Example:
 
@@ -25,6 +26,33 @@ Example:
 # from the repo root
 LD_PRELOAD=/path/to/libstdc++.so.6 CUDA_VISIBLE_DEVICES=0,1 \
   bash tests/tools/run_regression.sh
+```
+
+The formal API-only differential gate combines the curated corpus under
+`tests/blackbox/cases/` with reproducible generated prompts, runs baseline and
+monitored vLLM in separate processes, and compares prompt tokens, generated
+tokens, text, and stop metadata:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 pytest -q -s tests/test_vllm_blackbox.py
+
+# Reproduce or broaden a generated corpus.
+DMI_BLACKBOX_SEED=20260812 DMI_BLACKBOX_GENERATED_CASES=20 \
+  CUDA_VISIBLE_DEVICES=0 pytest -q -s tests/test_vllm_blackbox.py
+```
+
+For manual diagnosis, run both modes against the same case manifest and compare
+their JSON outputs:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python tests/tools/smoke_vllm_model.py \
+  --mode baseline --model qwen2 \
+  --cases tests/blackbox/cases/transparency.json \
+  --output /tmp/qwen2-baseline.json
+CUDA_VISIBLE_DEVICES=0 python tests/tools/smoke_vllm_model.py \
+  --mode monitored --model qwen2 \
+  --cases tests/blackbox/cases/transparency.json \
+  --output /tmp/qwen2-monitored.json
 ```
 
 > Native CUDA ring tests live separately under `tests/ring/` (built via its

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -1,0 +1,131 @@
+"""Run a deterministic baseline or DMI vLLM smoke and save token IDs.
+
+This tool needs one CUDA GPU and local model weights, but not ClickHouse. It is
+intended for version/model port validation before the full transport suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+MODEL_ALIASES = {
+    "gpt2": "gpt2",
+    "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",
+    "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
+    "qwen3": "Qwen/Qwen3-0.6B",
+    "llama": "meta-llama/Llama-3.1-8B",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("baseline", "monitored"), required=True)
+    parser.add_argument("--model", default="qwen2")
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        help="JSON corpus with a top-level prompts list.",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--max-model-len", type=int, default=512)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.4)
+    parser.add_argument("--ring-mb", type=int, default=64)
+    parser.add_argument("--hook-selection", default="resid_pre")
+    parser.add_argument("--cudagraph", action="store_true")
+    return parser.parse_args()
+
+
+def _load_prompts(cases_path: Path | None) -> list[str]:
+    if cases_path is None:
+        return ["The capital of France is", "2 + 2 ="]
+
+    payload = json.loads(cases_path.read_text())
+    prompts = payload.get("prompts")
+    if (
+        not isinstance(prompts, list)
+        or not prompts
+        or not all(isinstance(prompt, str) for prompt in prompts)
+    ):
+        raise ValueError(f"{cases_path} must contain a non-empty string prompts list")
+    return prompts
+
+
+def _optional_list(value):
+    return None if value is None else list(value)
+
+
+def main() -> None:
+    args = _parse_args()
+    os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    from vllm import LLM, SamplingParams
+
+    model_id = MODEL_ALIASES.get(args.model, args.model)
+    kwargs = {
+        "model": model_id,
+        "dtype": "bfloat16",
+        "max_model_len": args.max_model_len,
+        "max_num_batched_tokens": args.max_model_len,
+        "enforce_eager": not args.cudagraph,
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "disable_log_stats": True,
+    }
+    if args.mode == "monitored":
+        kwargs.update(
+            worker_cls="integration.vllm_adapter.DMXGPUWorker",
+            additional_config={
+                "dmx_hook_selection": args.hook_selection,
+                "dmx_ring_payload_mb": args.ring_mb,
+                "dmx_ring_pinned_mb": args.ring_mb,
+                "dmx_db_host": "",
+            },
+        )
+
+    prompts = _load_prompts(args.cases)
+    llm = LLM(**kwargs)
+    try:
+        outputs = llm.generate(
+            prompts,
+            SamplingParams(temperature=0.0, max_tokens=args.max_tokens),
+        )
+        payload = {
+            "schema_version": 1,
+            "mode": args.mode,
+            "model": model_id,
+            "cudagraph": args.cudagraph,
+            "prompts": prompts,
+            "prompt_token_ids": [
+                _optional_list(output.prompt_token_ids) for output in outputs
+            ],
+            "token_ids": [list(output.outputs[0].token_ids) for output in outputs],
+            "texts": [output.outputs[0].text for output in outputs],
+            "finish_reasons": [
+                output.outputs[0].finish_reason for output in outputs
+            ],
+            "stop_reasons": [output.outputs[0].stop_reason for output in outputs],
+        }
+    finally:
+        try:
+            if args.mode == "monitored":
+                llm.collective_rpc("stop_monitoring")
+        finally:
+            del llm
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2) + "\n")
+
+    print(json.dumps(payload, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -11,6 +11,7 @@ Usage:
 import os
 import sys
 import tempfile
+import uuid
 
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "0")
 
@@ -29,7 +30,11 @@ def main():
     from vllm import LLM, SamplingParams
 
     model_key = os.environ.get("E2E_MODEL", "gpt2")
-    model_id = _MODEL_ALIASES.get(model_key, model_key)
+    checkpoint_model_id = _MODEL_ALIASES.get(model_key, model_key)
+    capture_model_id = os.environ.get(
+        "E2E_DMX_MODEL_ID",
+        f"vllm-compare::{model_key}::{uuid.uuid4().hex}",
+    )
     num_prompts = int(os.environ.get("E2E_NUM_PROMPTS", "8"))
     max_new_tokens = int(os.environ.get("E2E_MAX_NEW_TOKENS", "20"))
     enforce_eager = os.environ.get("E2E_ENFORCE_EAGER", "1") == "1"
@@ -46,14 +51,6 @@ def main():
 
     prompts = [f"The answer to question {i+1} is" for i in range(num_prompts)]
 
-    # Drop existing table
-    import clickhouse_driver
-    ch_client = clickhouse_driver.Client(db_host, port=db_port)
-    try:
-        ch_client.execute("DROP TABLE IF EXISTS default.offload")
-    except Exception:
-        pass
-
     mode = "eager" if enforce_eager else "compiled"
     print(f"[compare] model={model_key} tp={tp_size} mode={mode} "
           f"hooks={hook_selection} prompts={num_prompts} tokens={max_new_tokens}",
@@ -61,10 +58,11 @@ def main():
     print(f"[compare] ref_dir={compare_dir}", flush=True)
 
     kwargs = dict(
-        model=model_id,
+        model=checkpoint_model_id,
         dtype=model_dtype,
         worker_cls="tests.compare_worker.CompareWorker",
         additional_config={
+            "dmx_model_id": capture_model_id,
             "dmx_hook_selection": hook_selection,
             "dmx_ring_payload_mb": ring_payload_mb,
             "dmx_ring_pinned_mb": ring_pinned_mb,
@@ -88,10 +86,7 @@ def main():
     # Explicit per-worker flush+stop before teardown. Without this, the
     # implicit DMXGPUWorker.shutdown() races vLLM's 8s deadline and may
     # drop tail rows -- exactly the data we're about to compare.
-    try:
-        llm.collective_rpc("stop_monitoring")
-    except Exception:
-        pass
+    llm.collective_rpc("stop_monitoring")
     del llm
     torch.cuda.empty_cache()
 
@@ -100,7 +95,8 @@ def main():
 
     from tests.compare_disk_vs_ch import read_clickhouse, compare
 
-    ch_data, num_rows = read_clickhouse(db_host, db_port)
+    ch_data, num_rows = read_clickhouse(
+        db_host, db_port, model_id=capture_model_id)
     passed, failed = compare(compare_dir, ch_data, num_rows)
 
     if failed > 0:

--- a/tests/vllm_dmillm_runner.py
+++ b/tests/vllm_dmillm_runner.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import os
 import sys
-import time
+import uuid
 
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
 
@@ -31,68 +31,106 @@ def main() -> None:
 
     import torch
     import clickhouse_driver
+    from transformers import AutoConfig
     from vllm import SamplingParams
     from integration.vllm_adapter import DMILLM
 
     host = os.environ.get("DMX_DB_HOST", "localhost")
     port = int(os.environ.get("DMX_DB_PORT", "9000"))
-    model_id = f"test_dmillm::{os.getpid()}"
+    model_id = f"test_dmillm::{uuid.uuid4().hex}"[:120]
     client = clickhouse_driver.Client(host=host, port=port)
-    client.execute("ALTER TABLE default.offload DELETE WHERE model_id=%(m)s", {"m": model_id})
-
-    llm = DMILLM(
-        args.model,
-        additional_config={
-            "dmx_model_id": model_id, "dmx_hook_selection": "resid_pre",
-            "dmx_db_host": host, "dmx_db_port": port,
-        },
-        max_model_len=512, enforce_eager=True, gpu_memory_utilization=0.5,
+    client.execute(
+        "ALTER TABLE default.offload DELETE WHERE model_id=%(m)s",
+        {"m": model_id},
     )
-    prompts = ["The capital of France is", "Hello"]
-    outputs = llm.generate(prompts, SamplingParams(temperature=0.0, max_tokens=8))
 
-    # No-flush read: rely on the 100ms drain-flush timeout (default since the
-    # drain-flush change) to land captures in ClickHouse without stop_monitoring.
-    time.sleep(2.0)
-    no_stop = _shapes(outputs)
-    for o in outputs:
-        o.dmi_internal.clear_cache()
+    expected_layers = int(AutoConfig.from_pretrained(args.model).num_hidden_layers)
+    llm = None
+    stopped = False
+    try:
+        llm = DMILLM(
+            args.model,
+            additional_config={
+                "dmx_model_id": model_id,
+                "dmx_hook_selection": "resid_pre",
+                "dmx_db_host": host,
+                "dmx_db_port": port,
+                # This test intentionally verifies bounded asynchronous reads.
+                # The production default is 0 (flush on pressure or stop).
+                "dmx_drain_flush_timeout_us": 100_000,
+            },
+            max_model_len=512,
+            enforce_eager=True,
+            gpu_memory_utilization=0.5,
+        )
+        prompts = ["The capital of France is", "Hello"]
+        outputs = llm.generate(
+            prompts, SamplingParams(temperature=0.0, max_tokens=8)
+        )
 
-    # Explicit flush, then re-read as the authoritative baseline.
-    llm.collective_rpc("stop_monitoring")
-    time.sleep(0.5)
-    internals = [o.dmi_internal.hidden_states for o in outputs]
-    after_stop = [(len(hs), hs[0].shape[1]) for hs in internals]
+        # Replace fixed sleeps with the public bounded-retry contract. This
+        # rejects both missing fields and partial layer sets.
+        for output in outputs:
+            output.dmi_internal.require(
+                "hidden_states",
+                count=expected_layers,
+                retry=True,
+                timeout_s=15.0,
+                poll_s=0.1,
+                match_token_ranges=True,
+            )
+        before_stop = _shapes(outputs)
+        for output in outputs:
+            output.dmi_internal.clear_cache()
 
-    tests = [
-        {"name": "outputs_are_native",
-         "passed": len(outputs) == 2 and all(o.outputs[0].text for o in outputs),
-         "detail": [o.outputs[0].text for o in outputs]},
-        # Auto-drain: internals reach ClickHouse without an explicit stop_monitoring.
-        {"name": "readable_without_stop_monitoring",
-         "passed": no_stop == after_stop and all(layers > 0 for layers, _ in no_stop),
-         "detail": {"no_stop": no_stop, "after_stop": after_stop}},
-        # Per-request: each is its own [1, seq, hidden] (batch dim 1).
-        {"name": "per_request_hidden_states",
-         "passed": all(len(hs) > 0 and hs[0].dim() == 3 and hs[0].shape[0] == 1
-                       for hs in internals),
-         "detail": after_stop},
-        # Ragged prompts -> independent seq lengths (no cross-padding).
-        {"name": "per_request_isolated_lengths",
-         "passed": len({s for _, s in after_stop}) > 1,
-         "detail": [s for _, s in after_stop]},
-        {"name": "available_lists_hidden_states",
-         "passed": "hidden_states" in outputs[0].dmi_internal.available,
-         "detail": outputs[0].dmi_internal.available},
-    ]
+        # Explicit flush, then re-read as the authoritative baseline.
+        llm.collective_rpc("stop_monitoring")
+        stopped = True
+        internals = [output.dmi_internal.hidden_states for output in outputs]
+        after_stop = [(len(hs), hs[0].shape[1]) for hs in internals]
 
-    client.execute("ALTER TABLE default.offload DELETE WHERE model_id=%(m)s", {"m": model_id})
-    with open(args.result_file, "w") as f:
-        json.dump({"tests": tests}, f)
+        tests = [
+            {"name": "outputs_are_native",
+             "passed": len(outputs) == 2 and all(o.outputs[0].text for o in outputs),
+             "detail": [o.outputs[0].text for o in outputs]},
+            {"name": "bounded_async_read_is_complete",
+             "passed": before_stop == after_stop
+                       and all(layers == expected_layers
+                               for layers, _ in before_stop),
+             "detail": {"before_stop": before_stop,
+                        "after_stop": after_stop}},
+            # Per-request: each is its own [1, seq, hidden] (batch dim 1).
+            {"name": "per_request_hidden_states",
+             "passed": all(len(hs) > 0 and hs[0].dim() == 3
+                           and hs[0].shape[0] == 1 for hs in internals),
+             "detail": after_stop},
+            # Ragged prompts -> independent seq lengths (no cross-padding).
+            {"name": "per_request_isolated_lengths",
+             "passed": len({s for _, s in after_stop}) > 1,
+             "detail": [s for _, s in after_stop]},
+            {"name": "available_lists_hidden_states",
+             "passed": "hidden_states" in outputs[0].dmi_internal.available,
+             "detail": outputs[0].dmi_internal.available},
+        ]
 
-    del llm
-    torch.cuda.empty_cache()
-    sys.exit(0 if all(t["passed"] for t in tests) else 1)
+        with open(args.result_file, "w") as f:
+            json.dump({"tests": tests}, f)
+        success = all(test["passed"] for test in tests)
+    finally:
+        try:
+            if llm is not None and not stopped:
+                llm.collective_rpc("stop_monitoring")
+        finally:
+            client.execute(
+                "ALTER TABLE default.offload DELETE WHERE model_id=%(m)s",
+                {"m": model_id},
+                settings={"mutations_sync": 1},
+            )
+            if llm is not None:
+                del llm
+            torch.cuda.empty_cache()
+
+    sys.exit(0 if success else 1)
 
 
 if __name__ == "__main__":

--- a/tests/vllm_identical_comparator.py
+++ b/tests/vllm_identical_comparator.py
@@ -43,10 +43,8 @@ def bitwise_check(a: torch.Tensor, b: torch.Tensor, label: str) -> dict:
         return {"name": label, "passed": False,
                 "detail": f"device mismatch: {a.device} vs {b.device}"}
     if a.dtype != b.dtype:
-        print(f"  [WARNING] {label}: dtype mismatch {a.dtype} vs {b.dtype} — SKIPPED",
-              flush=True)
-        return {"name": label, "passed": True,
-                "detail": f"SKIPPED dtype mismatch: {a.dtype} vs {b.dtype}"}
+        return {"name": label, "passed": False,
+                "detail": f"dtype mismatch: {a.dtype} vs {b.dtype}"}
     if a.shape != b.shape:
         return {"name": label, "passed": False,
                 "detail": f"shape mismatch: {list(a.shape)} vs {list(b.shape)}"}
@@ -63,23 +61,24 @@ def bitwise_check(a: torch.Tensor, b: torch.Tensor, label: str) -> dict:
 
 def compare_logprobs(orig_path: str, ref_path: str, results: dict,
                      _check_fn, label: str = "original vs ref") -> None:
-    """Compare full-vocab logprobs between two models.
-
-    Informational only — never marks tests as failed.
-    Prints summary line FIRST, then details.
-    """
+    """Require exact token IDs and full-vocabulary logprobs."""
     orig_data = torch.load(orig_path, weights_only=False, map_location="cpu")
     ref_data = torch.load(ref_path, weights_only=False, map_location="cpu")
 
-    # First pass: check all prompts, collect results
-    all_exact = True
-    n_prompts = 0
+    all_exact = bool(orig_data) and set(orig_data) == set(ref_data)
+    n_prompts = len(orig_data)
     n_exact = 0
     worst_diff = 0.0
     details = []
 
+    missing = sorted(set(orig_data) - set(ref_data))
+    unexpected = sorted(set(ref_data) - set(orig_data))
+    if missing:
+        details.append(f"missing prompts in comparison run: {missing}")
+    if unexpected:
+        details.append(f"unexpected prompts in comparison run: {unexpected}")
+
     for prompt_idx in sorted(orig_data.keys()):
-        n_prompts += 1
         orig = orig_data[prompt_idx]
         ref = ref_data.get(prompt_idx)
         if ref is None:
@@ -89,47 +88,61 @@ def compare_logprobs(orig_path: str, ref_path: str, results: dict,
 
         if orig["token_ids"] != ref["token_ids"]:
             all_exact = False
-            diff_pos = next(
-                i for i, (a, b) in enumerate(
-                    zip(orig["token_ids"], ref["token_ids"]))
-                if a != b)
-            details.append(f"    prompt[{prompt_idx}]: token_ids DIFFER at pos {diff_pos}")
+            mismatch = next(
+                (i for i, (a, b) in enumerate(
+                    zip(orig["token_ids"], ref["token_ids"])) if a != b),
+                min(len(orig["token_ids"]), len(ref["token_ids"])),
+            )
+            details.append(
+                f"prompt[{prompt_idx}]: token_ids differ at pos {mismatch} "
+                f"(lengths {len(orig['token_ids'])} vs {len(ref['token_ids'])})"
+            )
             continue
 
         orig_lp = orig["logprobs"]
         ref_lp = ref["logprobs"]
         if orig_lp is None or ref_lp is None:
-            details.append(f"    prompt[{prompt_idx}]: logprobs N/A")
-            continue
-
-        min_len = min(orig_lp.shape[0], ref_lp.shape[0])
-        min_vocab = min(orig_lp.shape[1], ref_lp.shape[1])
-        a = orig_lp[:min_len, :min_vocab]
-        b = ref_lp[:min_len, :min_vocab]
-
-        if a.dtype != b.dtype:
             all_exact = False
-            details.append(f"    prompt[{prompt_idx}]: dtype mismatch {a.dtype} vs {b.dtype}")
-            continue
-        if a.shape != b.shape:
-            all_exact = False
-            details.append(f"    prompt[{prompt_idx}]: shape mismatch {list(a.shape)} vs {list(b.shape)}")
+            details.append(f"prompt[{prompt_idx}]: full-vocab logprobs unavailable")
             continue
 
-        if _bytes_identical(a, b):
+        if orig_lp.dtype != ref_lp.dtype:
+            all_exact = False
+            details.append(
+                f"prompt[{prompt_idx}]: dtype mismatch "
+                f"{orig_lp.dtype} vs {ref_lp.dtype}"
+            )
+            continue
+        if orig_lp.shape != ref_lp.shape:
+            all_exact = False
+            details.append(
+                f"prompt[{prompt_idx}]: shape mismatch "
+                f"{list(orig_lp.shape)} vs {list(ref_lp.shape)}"
+            )
+            continue
+
+        if _bytes_identical(orig_lp, ref_lp):
             n_exact += 1
             continue
 
         all_exact = False
-        diff = (a.float() - b.float()).abs().max().item()
+        diff = (orig_lp.float() - ref_lp.float()).abs().max().item()
         worst_diff = max(worst_diff, diff)
-        details.append(f"    prompt[{prompt_idx}]: DIFFER max_abs_diff={diff:.6e}")
+        details.append(f"prompt[{prompt_idx}]: max_abs_diff={diff:.6e}")
 
-    # SUMMARY LINE — always visible even if output is truncated
+    check_name = "logprobs_" + re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+    detail = (
+        f"BITWISE EXACT ({n_exact}/{n_prompts} prompts)"
+        if all_exact
+        else f"{n_exact}/{n_prompts} exact, worst={worst_diff:.6e}; "
+             + "; ".join(details[:8])
+    )
+    _check_fn(check_name, all_exact, detail)
+
     if all_exact:
         print(f"  [LOGPROBS {label}] BITWISE EXACT ({n_exact}/{n_prompts} prompts)", flush=True)
     else:
-        detail_str = "; ".join(d.strip() for d in details)
+        detail_str = "; ".join(details[:8])
         print(f"  [LOGPROBS {label}] DIFFER ({n_exact}/{n_prompts} exact, "
               f"worst={worst_diff:.6e}) -- {detail_str}", flush=True)
 
@@ -157,6 +170,7 @@ def main():
         mon_meta = json.load(f)
     db_host = mon_meta["db_host"]
     db_port = mon_meta["db_port"]
+    capture_model_id = mon_meta["model_id"]
 
     results = {"tests": [], "passed": 0, "failed": 0}
 
@@ -172,7 +186,7 @@ def main():
             msg += f" -- {detail}"
         print(msg, flush=True)
 
-    # Step 0: Logprob sanity checks (informational, never fails)
+    # Step 0: public-output transparency checks.
     if args.orig_logprobs and args.ref_logprobs:
         compare_logprobs(args.orig_logprobs, args.ref_logprobs, results, _check,
                          label="original vs ref")
@@ -187,7 +201,8 @@ def main():
         raw_rows = ch_client.execute(
             "SELECT model_id, request_id, act_name, layer_no, shard_rank, "
             "start_token_idx, end_token_idx, dtype, shape, bytes "
-            "FROM default.offload",
+            "FROM default.offload WHERE model_id = %(model_id)s",
+            {"model_id": capture_model_id},
             settings={"strings_as_bytes": True})
     except Exception as e:
         _check("db_readable", False, str(e))
@@ -294,7 +309,7 @@ def main():
                 ch_t = candidates[0][1]
             elif len(candidates) > 1:
                 # Multiple segments — find overlapping ones and concatenate
-                segments = [(k[3], k[4], v) for k, v in candidates]
+                segments = [(k[4], k[5], v) for k, v in candidates]
                 segments.sort(key=lambda x: x[0])
                 # Find segments that overlap with [start, end)
                 matching = [v for s, e, v in segments if s < end and e > start]

--- a/tests/vllm_logprob_runner.py
+++ b/tests/vllm_logprob_runner.py
@@ -10,6 +10,7 @@ Usage:
 """
 import argparse
 import os
+import uuid
 
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
 
@@ -35,12 +36,12 @@ _ARCH_REMAP = {
 class RefLogprobWorker(Worker):
     """Minimal worker that remaps architecture to ref variant."""
 
-    def load_model(self) -> None:
+    def load_model(self, *args, **kwargs) -> None:
         hf_cfg = self.vllm_config.model_config.hf_config
         archs = getattr(hf_cfg, "architectures", [])
         new_archs = [_ARCH_REMAP.get(a, a) for a in archs]
         hf_cfg.architectures = new_archs
-        super().load_model()
+        super().load_model(*args, **kwargs)
 
 
 def main():
@@ -111,8 +112,13 @@ def main():
     if args.ref:
         kwargs["worker_cls"] = "tests.vllm_logprob_runner.RefLogprobWorker"
     elif args.monitored:
+        capture_model_id = os.environ.get(
+            "E2E_DMX_MODEL_ID",
+            f"vllm-logprobs::{model_key}::{uuid.uuid4().hex}",
+        )
         kwargs["worker_cls"] = "integration.vllm_adapter.DMXGPUWorker"
         kwargs["additional_config"] = {
+            "dmx_model_id": capture_model_id,
             "dmx_hook_selection": hook_selection,
             "dmx_ring_payload_mb": ring_payload_mb,
             "dmx_ring_pinned_mb": ring_pinned_mb,
@@ -174,10 +180,7 @@ def main():
 
     # Flush DMI workers explicitly only for the monitored path.
     if args.monitored:
-        try:
-            llm.collective_rpc("stop_monitoring")
-        except Exception:
-            pass
+        llm.collective_rpc("stop_monitoring")
     del llm
     torch.cuda.empty_cache()
 

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -8,6 +8,7 @@ Usage:
 import argparse
 import json
 import os
+import uuid
 
 os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
 
@@ -16,6 +17,7 @@ import torch
 
 _MODEL_ALIASES = {
     "gpt2": "gpt2",
+    "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B",
@@ -30,7 +32,11 @@ def main():
     from vllm import LLM, SamplingParams
 
     model_key = os.environ.get("E2E_MODEL", "gpt2")
-    model_id = _MODEL_ALIASES.get(model_key, model_key)
+    checkpoint_model_id = _MODEL_ALIASES.get(model_key, model_key)
+    capture_model_id = os.environ.get(
+        "E2E_DMX_MODEL_ID",
+        f"vllm-e2e::{model_key}::{uuid.uuid4().hex}",
+    )
     num_prompts = int(os.environ.get("E2E_NUM_PROMPTS", "8"))
     max_new_tokens = int(os.environ.get("E2E_MAX_NEW_TOKENS", "20"))
     enforce_eager = os.environ.get("E2E_ENFORCE_EAGER", "1") == "1"
@@ -46,19 +52,12 @@ def main():
 
     prompts = [f"The answer to question {i+1} is" for i in range(num_prompts)]
 
-    # Drop existing table
-    try:
-        import clickhouse_driver
-        client = clickhouse_driver.Client(db_host, port=db_port)
-        client.execute("DROP TABLE IF EXISTS default.offload")
-    except Exception:
-        pass
-
     kwargs = dict(
-        model=model_id,
+        model=checkpoint_model_id,
         dtype=model_dtype,
         worker_cls="integration.vllm_adapter.DMXGPUWorker",
         additional_config={
+            "dmx_model_id": capture_model_id,
             "dmx_hook_selection": hook_selection,
             "dmx_ring_payload_mb": ring_payload_mb,
             "dmx_ring_pinned_mb": ring_pinned_mb,
@@ -85,7 +84,12 @@ def main():
     params = SamplingParams(temperature=0.0, max_tokens=max_new_tokens)
     outputs = llm.generate(prompts, params)
 
-    # Save metadata
+    # Explicit per-worker flush+stop before recording a successful run. The
+    # implicit DMXGPUWorker.shutdown() path can race vLLM's shutdown deadline.
+    # Do not swallow failures: incomplete ClickHouse data must fail the test.
+    llm.collective_rpc("stop_monitoring")
+
+    # Save metadata only after monitoring has flushed successfully.
     os.makedirs(args.output_dir, exist_ok=True)
     generated = {}
     for i, o in enumerate(outputs):
@@ -94,7 +98,8 @@ def main():
 
     with open(os.path.join(args.output_dir, "meta.json"), "w") as f:
         json.dump({
-            "model_id": model_id,
+            "model_id": capture_model_id,
+            "checkpoint_model_id": checkpoint_model_id,
             "num_prompts": num_prompts,
             "max_new_tokens": max_new_tokens,
             "generated_tokens": generated,
@@ -102,13 +107,6 @@ def main():
             "db_port": db_port,
         }, f)
 
-    # Explicit per-worker flush+stop before LLM teardown. The implicit
-    # path via DMXGPUWorker.shutdown() races vLLM's 8s deadline and warns
-    # "Data may be incomplete." collective_rpc fans out to every TP rank.
-    try:
-        llm.collective_rpc("stop_monitoring")
-    except Exception:
-        pass
     del llm
     torch.cuda.empty_cache()
     print(f"[vllm_monitored_runner] Done", flush=True)

--- a/tests/vllm_request_order_fix_gpu.py
+++ b/tests/vllm_request_order_fix_gpu.py
@@ -141,8 +141,8 @@ class ProbeWorker(DMXGPUWorker):
         runner._prepare_inputs = observed_prepare
         runner._determine_batch_execution_and_padding = observed_determine
 
-    def load_model(self) -> None:
-        super().load_model()
+    def load_model(self, *args, **kwargs) -> None:
+        super().load_model(*args, **kwargs)
         from vllm.distributed.utils import get_pp_indices
 
         adaptor = self.adaptor

--- a/tests/vllm_rowcnt_comparator.py
+++ b/tests/vllm_rowcnt_comparator.py
@@ -35,6 +35,7 @@ def main():
         mon_meta = json.load(f)
     db_host = mon_meta["db_host"]
     db_port = mon_meta["db_port"]
+    capture_model_id = mon_meta["model_id"]
 
     results = {"tests": [], "passed": 0, "failed": 0}
 
@@ -50,14 +51,16 @@ def main():
             msg += f" -- {detail}"
         print(msg, flush=True)
 
-    # Read ClickHouse — get all rows (table was dropped before monitored run)
+    # Read only this run. Historical and concurrent rows must not influence
+    # either row counts or value comparisons.
     import clickhouse_driver
     ch_client = clickhouse_driver.Client(db_host, port=db_port)
     try:
         raw_rows = ch_client.execute(
             "SELECT model_id, request_id, act_name, layer_no, shard_rank, "
             "start_token_idx, end_token_idx, dtype, shape, bytes "
-            "FROM default.offload",
+            "FROM default.offload WHERE model_id = %(model_id)s",
+            {"model_id": capture_model_id},
             settings={"strings_as_bytes": True})
     except Exception as e:
         _check("db_readable", False, str(e))


### PR DESCRIPTION
## Summary

- advance the vLLM submodule from the original 0.17.1 integration to the versioned [`dmi-v0.19.0`](https://github.com/ProjectDMX/vllm-DMI/tree/dmi-v0.19.0) line; also publish [`dmi-v0.18.0`](https://github.com/ProjectDMX/vllm-DMI/tree/dmi-v0.18.0) as a static-validation port
- register bundled hooked model variants through vLLM's public lazy `ModelRegistry` API so a matching official wheel can use GPT-2, Qwen2/Qwen2.5, Qwen2-MoE, Qwen3, and audited Llama aliases
- adapt worker `load_model` forwarding for the vLLM 0.19 API and make explicit monitoring shutdown fail closed while retaining best-effort worker teardown
- add deterministic public-API baseline/monitored differential tests, seeded black-box case generation, strict comparator contracts, and model inventory checks
- isolate every ClickHouse test capture by a unique model ID, remove global table drops, synchronously clean test rows, and validate complete asynchronous `DMILLM` token coverage

## Validation

Environment: Python 3.12.8, PyTorch 2.10.0+cu128, official vLLM 0.19.0 wheel, RTX 4090, local ClickHouse.

- `audit_vllm_port.py --runtime`: no errors; all five DMI variants resolve to their intended classes
- focused compatibility/contract suite: `173 passed`
- public API black-box baseline vs monitored, eager: `1 passed`
- public API black-box baseline vs monitored, CUDA graph: `1 passed`
- ClickHouse row-count E2E: `1 passed, 5 subtests passed`
- `DMILLM` per-request internal-read E2E: `1 passed`
- `git diff --check`: passed
- verified all test capture prefixes contain zero rows after cleanup

## Evidence boundaries

- vLLM 0.19.0 has runtime evidence for Qwen2/Qwen2.5 on a single GPU, including eager, CUDA graph, ClickHouse, and `DMILLM` paths.
- vLLM 0.18.0 has static/import validation only; this PR does not claim runtime support for it yet.
- TP and PP were not rerun in this pass. Quantized and `trust_remote_code` checkpoints remain separate validation targets.
- The repository-wide `pytest -m cpu` currently has one pre-existing failure in `test_ring_transport_no_framework_strings.py`: two existing comments in `monitoring/ring_transport.py` contain the framework name outside its attribution block. This PR does not modify that file; all other selected CPU tests passed.
