### PR TITLE
Support Phi-3 on vLLM 0.27.1

### DIFF
--- a/docs/vllm-0.27.1-phi3-audit.md
+++ b/docs/vllm-0.27.1-phi3-audit.md
@@ -1,0 +1,57 @@
+# Phi-3 model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only `Phi3ForCausalLM`
+architecture in a bounded TP1 BF16 V1 offline cell. It does not extend the
+verdict to untested parallel, quantized, serving, or speculative modes.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/phi3.py`, `Phi3ForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-phi3`, commit `b4965771d8a4cc25afad81732d86180ab105796d` |
+| Production checkpoint | `microsoft/Phi-3.5-mini-instruct`, revision `2fe192450127e6a83f7441aef6e3ca586c338b77` |
+| Focused fixture | `optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM`, revision `e2c91eceaf7aa2b6e7ff09b89cd4f8e79eb8131c` |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, eager and default CUDA graph, full canonical DMI hook inventory |
+| Excluded | TP>1, PP/DP/EP/SP, V2, serve/async, speculative, LoRA, quantization, embedding/classification tasks, remote-code variants |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01 | verified | The target `phi3.py` is an eight-line thin subclass of the exact target Llama implementation. |
+| M02-M04 | verified for the claimed cell | Upstream Phi-3 changes no constructor or numerical forward path. DMI therefore reuses the already-audited hooked Llama model rather than duplicating it. Production eager/graph strict public parity verifies the long-RoPE configuration path. |
+| M05-M09 | excluded where applicable | PP, speculative, distributed ownership, MoE, and quantized paths were not run and are not claimed. |
+| M10 | adapted-verified | Phi-3's only upstream class delta is `packed_modules_mapping = {qkv_proj: [qkv_proj], gate_up_proj: [gate_up_proj]}` for already-fused checkpoint tensors. DMI uses a distinct Phi-3 subclass that copies this map; it is deliberately not placed in the generic Llama alias set. Both official production shards loaded successfully. |
+| M11-M13 | verified for TP1 | The inherited Llama hook boundaries and module-free inventory are unchanged. The tiny fixture's full-hook compare model produced byte-identical eager/graph ClickHouse tensors. |
+| M14 | bounded | Only `Phi3ForCausalLM` text generation is remapped. Phi-3 Vision, Phi-3 Small, embedding/classification, remote-code, LoRA, and quantized implementations do not inherit this verdict. |
+| M15 | verified for the dense fixture | The audited implementation contains only Llama-style dense attention/MLP layers; no heterogeneous hook family is fabricated. |
+| R01-R03 | verified | Upstream resolves `Phi3ForCausalLM` to `phi3:Phi3ForCausalLM`; DMI resolves it one-to-one to `phi3_p:Phi3PForCausalLM`. The remap is distinct from Llama specifically to preserve packing. |
+| R04-R07 | verified | Official-wheel lazy registration resolves the exported class without eager model import or parent CUDA initialization, through the already-audited 0.27.1 registry surface. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Focused packing/registry contracts | 29/29 selected tests passed; the final expansion focused sweep passed 240/240. The contract fails if Phi-3 is added to generic Llama aliases or if ordinary split Q/K/V and gate/up packing returns. |
+| Tiny public eager+graph | 2/2 full 12-case API-only tests passed in 82.29 s with strict baseline/monitored equality. |
+| Tiny eager full-hook transport | 4,320/4,320 independent D2D references were byte-identical to ClickHouse rows. |
+| Tiny CUDA-graph full-hook transport | 4,320/4,320 independent D2D references were byte-identical to ClickHouse rows. |
+| Production eager | 1/1 public test passed in 32.78 s. |
+| Production eager+graph | 2/2 public tests passed in 107.00 s. The checkpoint's two 7.6 GB total fused-weight shards and long-RoPE config loaded successfully. |
+| Lifecycle | No worker exception, force-kill, TCPStore warning, residual vLLM process, residual capture, or GPU allocation remained. |
+
+The tiny fixture establishes hook values and transport correctness cheaply; the
+official checkpoint separately closes the real fused-weight loader and
+representative public-output gate. Storage row count is not compared across
+unrelated executions: the byte oracle reconstructs exact per-request token
+ranges within the same execution.
+
+## Support decision
+
+`Phi3ForCausalLM` is supported for the named TP1 BF16 V1 offline eager/default-
+graph cell at the exact commits above. The supported architecture includes the
+official Phi-3.5 Mini checkpoint exercised here, but a checkpoint with materially
+different remote code, quantization, task wrapper, or runner branch requires its
+own cell. All excluded modes remain untested rather than implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -86,6 +86,13 @@ tiny fixture. The official `google/gemma-3-1b-it` checkpoint was gated for the
 available account, so the real-checkpoint completion gate remains open and the
 row is not yet `supported`.
 
+Phi-3 is `supported` for the bounded TP1 BF16 V1 offline eager/default-graph
+cell at integration commit `b4965771d8a4`. The
+[`Phi-3 audit`](vllm-0.27.1-phi3-audit.md) records strict public tests on the
+official `microsoft/Phi-3.5-mini-instruct` checkpoint plus byte-identical
+eager/graph full-hook transport on a tiny fixture. TP>1, PP, quantization,
+serving, speculative, and non-text task variants remain excluded.
+
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving
 beyond `static-only`.

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -40,7 +40,7 @@ monitoring.
 ## Model architecture coverage
 
 The monitored variants currently exist for GPT-2, Qwen2/Qwen2.5, Qwen3,
-Qwen2-MoE, Llama, and an experimental Gemma 3 text variant. The vLLM 0.27.1
+Qwen2-MoE, Llama, Phi-3, and an experimental Gemma 3 text variant. The vLLM 0.27.1
 baseline port has focused, public API, accelerator,
 and scoped storage evidence for all five variants; exact topology verdicts are
 recorded in the 0.27.1 compatibility audit rather than inferred from import
@@ -51,6 +51,11 @@ that upstream vLLM implements directly with its
 Llama class (Aquila, Cwm, InternLM/InternLM3, IQuestCoder, legacy LLaMA, and
 Xverse) are remapped to the same monitored Llama variant but require separate
 runtime evidence before they are claimed.
+
+Phi-3 has a distinct monitored subclass even though upstream reuses Llama's
+math: its fused QKV and gate/up checkpoint packing is different. The bounded
+support cell and official Phi-3.5 Mini evidence are recorded in the
+[Phi-3 audit](vllm-0.27.1-phi3-audit.md).
 
 See the
 [`vLLM 0.27.1 compatibility audit`](vllm-0.27.1-port-audit.md) for the

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -146,6 +146,7 @@ _LLAMA_COMPAT_ARCHES = {
 _ARCH_REMAP = {
     "Gemma3ForCausalLM": "Gemma3PForCausalLM",
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
+    "Phi3ForCausalLM": "Phi3PForCausalLM",
     "Qwen2ForCausalLM": "Qwen2PForCausalLM",
     "Qwen2MoeForCausalLM": "Qwen2MoePForCausalLM",
     "Qwen3ForCausalLM": "Qwen3PForCausalLM",
@@ -169,6 +170,7 @@ _DMI_MODEL_VARIANTS = {
     "Qwen2MoePForCausalLM": "qwen2_moe_p:Qwen2MoePForCausalLM",
     "Qwen3PForCausalLM": "qwen3_p:Qwen3PForCausalLM",
     "LlamaPForCausalLM": "llama_p:LlamaPForCausalLM",
+    "Phi3PForCausalLM": "phi3_p:Phi3PForCausalLM",
 }
 
 

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -27,6 +27,9 @@ _COMPARE_MODEL_VARIANTS = {
     ),
     "Qwen3CompareForCausalLM": "qwen3_compare:Qwen3CompareForCausalLM",
     "LlamaCompareForCausalLM": "llama_compare:LlamaCompareForCausalLM",
+    "Phi3CompareForCausalLM": (
+        "phi3_compare:Phi3CompareForCausalLM"
+    ),
 }
 
 
@@ -56,6 +59,7 @@ _ARCH_REMAP = {
     "Qwen2MoeForCausalLM": "Qwen2MoeCompareForCausalLM",
     "Qwen3ForCausalLM": "Qwen3CompareForCausalLM",
     "LlamaForCausalLM": "LlamaCompareForCausalLM",
+    "Phi3ForCausalLM": "Phi3CompareForCausalLM",
 }
 
 # Hook names that are TP-sharded

--- a/tests/test_phi3_p_contract.py
+++ b/tests/test_phi3_p_contract.py
@@ -1,0 +1,43 @@
+"""CPU contracts for the Phi-3 DMI thin variant."""
+
+import pytest
+
+from integration.vllm_adapter import (
+    _ARCH_REMAP,
+    _LLAMA_COMPAT_ARCHES,
+)
+from vllm.model_executor.models.llama_p import LlamaPForCausalLM
+from vllm.model_executor.models.phi3 import Phi3ForCausalLM
+from vllm.model_executor.models.phi3_compare import Phi3CompareForCausalLM
+from vllm.model_executor.models.phi3_p import Phi3PForCausalLM
+
+
+pytestmark = pytest.mark.framework_fork
+
+
+def test_phi3_has_a_distinct_remap_for_its_fused_weight_packing() -> None:
+    assert "Phi3ForCausalLM" not in _LLAMA_COMPAT_ARCHES
+    assert _ARCH_REMAP["Phi3ForCausalLM"] == "Phi3PForCausalLM"
+
+
+def test_phi3_variant_reuses_llama_math_but_preserves_phi3_packing() -> None:
+    assert issubclass(Phi3PForCausalLM, LlamaPForCausalLM)
+    assert (
+        Phi3PForCausalLM.packed_modules_mapping
+        == Phi3ForCausalLM.packed_modules_mapping
+        == {
+            "qkv_proj": ["qkv_proj"],
+            "gate_up_proj": ["gate_up_proj"],
+        }
+    )
+    assert (
+        Phi3PForCausalLM.hf_to_vllm_mapper
+        is LlamaPForCausalLM.hf_to_vllm_mapper
+    )
+
+
+def test_phi3_compare_variant_preserves_the_same_packing_contract() -> None:
+    assert (
+        Phi3CompareForCausalLM.packed_modules_mapping
+        == Phi3ForCausalLM.packed_modules_mapping
+    )

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -39,6 +39,7 @@ MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 MODEL_ARG = os.environ.get("DMI_BLACKBOX_MODEL", "qwen2")
 MODEL_ID = MODEL_ALIASES.get(MODEL_ARG, MODEL_ARG)

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -76,6 +76,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
         "qwen2",
         "qwen3",
         "llama",
+        "phi3",
         "qwen2_moe",
     ):
         assert any(case_id.startswith(f"public-{model}-") for case_id in case_ids)
@@ -84,6 +85,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
         assert f"storage-{model}-cudagraph-tp2" in case_ids
     assert "storage-gemma3-eager-tp1" in case_ids
     assert "storage-gemma3-cudagraph-tp1" in case_ids
+    assert "storage-phi3-eager-tp1" in case_ids
+    assert "storage-phi3-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -96,6 +99,23 @@ def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
 
     storage = cases["storage-gemma3-cudagraph-tp1"]
     assert storage.environment["E2E_MODEL_SUBFOLDER"] == "hf"
+    assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+
+
+def test_phi3_public_matrix_uses_the_production_checkpoint() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-phi3-tp1-eager-graph"]
+    assert public.model_id == "microsoft/Phi-3.5-mini-instruct"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "microsoft/Phi-3.5-mini-instruct"
+    )
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "512"
+
+    storage = cases["storage-phi3-cudagraph-tp1"]
+    assert storage.model_id == (
+        "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM"
+    )
     assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
 
 

--- a/tests/tools/README.md
+++ b/tests/tools/README.md
@@ -78,6 +78,18 @@ python tests/tools/check_vllm_storage.py \
   --model-id <unique-capture-id>
 ```
 
+Phi-3 release validation uses the official checkpoint for public parity and the
+tiny fixture for the independent full-hook value oracle:
+
+```bash
+DMI_BLACKBOX_MODEL=microsoft/Phi-3.5-mini-instruct \
+  DMI_BLACKBOX_CUDAGRAPH=1 CUDA_VISIBLE_DEVICES=0 \
+  pytest -q -s tests/test_vllm_blackbox.py
+
+E2E_GPUS=0 E2E_MAX_MODEL_LEN=128 E2E_MAX_NUM_BATCHED_TOKENS=128 \
+  bash tests/tools/run_tp_compare_vllm.sh phi3 cudagraph 1
+```
+
 Set `DMI_BLACKBOX_ARTIFACT_DIR` to retain each mode's generated cases and raw
 baseline/monitored JSON instead of relying on pytest's temporary directory.
 

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -76,10 +76,11 @@ def _blackbox_case(
     tp_size: int,
     memory_utilization: float,
     model_subfolder: str | None = None,
+    model_arg: str | None = None,
     max_model_len: int = 512,
 ) -> MatrixCase:
     environment = {
-        "DMI_BLACKBOX_MODEL": model_key,
+        "DMI_BLACKBOX_MODEL": model_arg or model_key,
         "DMI_BLACKBOX_TP_SIZE": str(tp_size),
         "DMI_BLACKBOX_GPU_MEMORY_UTILIZATION": str(memory_utilization),
         "DMI_BLACKBOX_CUDAGRAPH": "1",
@@ -156,6 +157,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "tests/test_vllm_027_model_contracts.py",
             "tests/test_gemma3_p_inventory.py",
             "tests/test_model_artifacts.py",
+            "tests/test_phi3_p_contract.py",
             "tests/test_vllm_storage_contracts.py",
             "tests/test_qwen2_p_inventory.py",
             "tests/test_vllm_blackbox_contract.py",
@@ -179,6 +181,14 @@ def build_cases(phase: str) -> list[MatrixCase]:
             memory_utilization=0.2,
             model_subfolder="hf",
             max_model_len=128,
+        ),
+        _blackbox_case(
+            "phi3",
+            "microsoft/Phi-3.5-mini-instruct",
+            tp_size=1,
+            memory_utilization=0.75,
+            model_arg="microsoft/Phi-3.5-mini-instruct",
+            max_model_len=512,
         ),
         _blackbox_case("gpt2", "gpt2", tp_size=1, memory_utilization=0.5),
         _blackbox_case(
@@ -213,6 +223,16 @@ def build_cases(phase: str) -> list[MatrixCase]:
                 1,
                 ref_max_len=128,
                 model_subfolder="hf",
+                max_model_len=128,
+            )
+        )
+        storage.append(
+            _storage_case(
+                "phi3",
+                "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
+                mode,
+                1,
+                ref_max_len=128,
                 max_model_len=128,
             )
         )

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -25,6 +25,7 @@ MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 
 

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -26,6 +26,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 
 

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -23,6 +23,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 
 

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -22,6 +22,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 
 


### PR DESCRIPTION
Stacked after Gemma 3 PR #75. Adds a distinct Phi-3 remap that preserves upstream fused weight packing, an agent-authored M/R checklist audit, official-checkpoint public release cells, and tiny-fixture independent storage-value cells. Evidence: focused 240/240; tiny public eager/graph 2/2; tiny eager storage 4,320/4,320; tiny graph storage 4,320/4,320; official microsoft/Phi-3.5-mini-instruct eager 1/1 and eager+graph 2/2 strict public parity. Scope is TP1 BF16 V1 offline eager/default graph. TP>1, PP/DP/EP/SP, V2, quantization, serving, speculative, LoRA, and non-text tasks are excluded.