### PR TITLE
Add Mistral support for vLLM 0.27.1

### DIFF
--- a/docs/vllm-0.27.1-mistral-audit.md
+++ b/docs/vllm-0.27.1-mistral-audit.md
@@ -1,0 +1,73 @@
+# Mistral model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only `MistralForCausalLM`
+architecture in a bounded TP1 BF16 V1 offline cell. It does not extend the
+verdict to other Mistral architectures, alternate loaders, parallel modes, or
+unexercised configuration branches.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/mistral.py`, `MistralForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-mistral`, commit `8c89ec33bbc5f08027fb1aab6b55c1287cf45f89` |
+| Production checkpoint | `mistralai/Mistral-7B-Instruct-v0.2`, revision `63a8b081895390a26e140280378bc85ec8bce07a` |
+| Focused fixture | `openaccess-ai-collective/tiny-mistral`, revision `2a2db3d57a46dd87d62c12b50bb8c34cc1afe126` |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph, full canonical DMI hook inventory |
+| Excluded | TP>1, PP/DP/EP/SP, V2, serve/async, speculative/Eagle, LoRA, quantization, `--load-format mistral`, embedding/classification tasks, remote-code variants, Mistral 3 and multimodal wrappers |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01 | verified | The exact target file defines independent Mistral MLP, attention, decoder, model, and causal-LM classes. DMI compares against that file rather than inferring compatibility from the family name. |
+| M02-M04 | bounded and adapted-verified | For the named checkpoints, Mistral attention is numerically Llama attention because `llama_4_scaling` is absent, and the decoder is numerically the Llama decoder because `ada_rms_norm_t_cond` is absent. DMI reuses the audited hooked Llama math and fails closed if either branch is enabled. Tiny and production eager/graph public differential tests verify the accepted path. |
+| M05-M09 | excluded where applicable | Pipeline, speculative, TP>1, EP/MoE, and quantized paths were not run and are not claimed. |
+| M10 | adapted-verified for standard HF weights | Mistral preserves Llama split-weight packing but changes LoRA embedding declarations and defines a Mistral/consolidated name remapper with Q/K permutation. The DMI subclass keeps `embedding_modules = {}`, the upstream `mistral_mapping`, and the exact remapper. The official three-shard, 14.48 GB HF checkpoint loaded in both eager and graph tests. The alternate Mistral load format remains excluded because it was not run. |
+| M11-M13 | verified for TP1 | The accepted math path inherits the audited Llama hook boundaries: eleven canonical families per layer and five model-wide families. The eight-layer fixture therefore exposes 93 families. Independent compare buffers and ClickHouse transport were byte-identical in eager and graph executions. Model-wide/module-free semantics are inherited from the exact Llama DMI implementation and locked by a method-identity contract. |
+| M14 | bounded | Only text `MistralForCausalLM` is remapped. `Ministral3ForCausalLM`, Mistral Large 3, Mistral 3 conditional generation, Mixtral, Pixtral, embedding/task heads, remote-code, quantized, and alternate-loader implementations do not inherit this verdict. |
+| M15 | verified for the claimed layer kind | Both exercised checkpoints contain homogeneous dense attention/MLP layers; no MoE, SSM, multimodal, or heterogeneous hook family is fabricated. |
+| R01-R03 | verified | Upstream resolves `MistralForCausalLM` to `mistral:MistralForCausalLM`; DMI resolves it one-to-one to `mistral_p:MistralPForCausalLM`. It is intentionally not added to the broad Llama alias set because its loader and embedding declarations differ. |
+| R04-R07 | verified | The 0.27.1 out-of-tree lazy-registration surface resolves the exported DMI and compare classes without changing the public architecture. Registry, remap, class-attribute, fail-closed, and release-matrix contracts pass in a CPU process. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Focused model and matrix contracts | 20/20 selected tests passed; the final expansion focused sweep passed 246/246. Tests reject broad Llama aliasing, loss of the Mistral mapping/remapper, changed hook inventory, acceptance of unaudited math branches, and unsafe fixture/memory settings. |
+| Tiny public eager+graph | 2/2 full 12-case API-only tests passed in 85.82 s with strict baseline/monitored equality and no ambiguity or stability exemption. |
+| Tiny eager full-hook transport | 14,880/14,880 independent D2D reference rows were byte-identical to ClickHouse rows. |
+| Tiny CUDA-graph full-hook transport | 14,880/14,880 independent D2D reference rows were byte-identical to ClickHouse rows. |
+| Production eager+graph | 2/2 full 12-case API-only tests passed in 124.35 s with strict baseline/monitored equality. |
+| Lifecycle | No worker exception, force-kill, teardown warning, residual vLLM process, residual capture, or GPU allocation remained after the accepted runs. |
+
+The storage oracle compares values generated inside the same execution; it does
+not infer correctness from generation success or compare unrelated row counts.
+The production public oracle separately proves real checkpoint loading and
+observable transparency.
+
+## Fixture qualification evidence
+
+The first candidate,
+`sanchit-gandhi/tiny-random-MistralForCausalLM-1-layer`, was rejected before
+release use. Its four-dimensional attention heads are below the target
+FlexAttention graph compiler's minimum embedding dimension of 16. In eager
+mode, the tiny model also caused vLLM to derive enough KV blocks for a 53.17 GiB
+physical-to-logical metadata allocation. Those are upstream fixture/runtime
+prerequisite failures, not DMI mismatches.
+
+The accepted fixture has 32-dimensional heads, eight layers, BF16 weights, and
+the intended `MistralForCausalLM` architecture. Its release cells pin
+`gpu_memory_utilization=0.2`, `max_model_len=128`, and
+`max_num_batched_tokens=128`; CPU contracts prevent those bounds or the fixture
+identity from drifting silently.
+
+## Support decision
+
+`MistralForCausalLM` is supported for the named TP1 BF16 V1 offline standard-HF
+eager/default-graph cell at the exact commits above. A checkpoint that enables
+Llama-4 attention scaling, adaptive conditional RMS normalization, an alternate
+loader, quantization, remote code, or a different architecture requires its own
+audit and runtime cell. All excluded modes remain untested rather than
+implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -93,6 +93,15 @@ official `microsoft/Phi-3.5-mini-instruct` checkpoint plus byte-identical
 eager/graph full-hook transport on a tiny fixture. TP>1, PP, quantization,
 serving, speculative, and non-text task variants remain excluded.
 
+Mistral is `supported` for the bounded TP1 BF16 V1 offline eager/default-graph
+cell at integration commit `8c89ec33bbc5`. The
+[`Mistral audit`](vllm-0.27.1-mistral-audit.md) records strict public parity on
+the official `mistralai/Mistral-7B-Instruct-v0.2` checkpoint and byte-identical
+eager/graph full-hook transport on a qualified small fixture. Configurations
+that enable Llama-4 attention scaling or adaptive conditional RMS normalization,
+alternate loaders, TP>1, quantization, serving, speculative, and non-text
+variants remain excluded.
+
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving
 beyond `static-only`.

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -40,7 +40,7 @@ monitoring.
 ## Model architecture coverage
 
 The monitored variants currently exist for GPT-2, Qwen2/Qwen2.5, Qwen3,
-Qwen2-MoE, Llama, Phi-3, and an experimental Gemma 3 text variant. The vLLM 0.27.1
+Qwen2-MoE, Llama, Phi-3, Mistral, and an experimental Gemma 3 text variant. The vLLM 0.27.1
 baseline port has focused, public API, accelerator,
 and scoped storage evidence for all five variants; exact topology verdicts are
 recorded in the 0.27.1 compatibility audit rather than inferred from import
@@ -56,6 +56,13 @@ Phi-3 has a distinct monitored subclass even though upstream reuses Llama's
 math: its fused QKV and gate/up checkpoint packing is different. The bounded
 support cell and official Phi-3.5 Mini evidence are recorded in the
 [Phi-3 audit](vllm-0.27.1-phi3-audit.md).
+
+Mistral also has a distinct bounded subclass: its accepted configuration reuses
+the hooked Llama math, while DMI preserves Mistral's loader/remapper and fails
+closed on its unaudited attention-scaling and adaptive-normalization branches.
+The official 7B public evidence, qualified small fixture, and byte-identical
+storage evidence are recorded in the
+[Mistral audit](vllm-0.27.1-mistral-audit.md).
 
 See the
 [`vLLM 0.27.1 compatibility audit`](vllm-0.27.1-port-audit.md) for the

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -146,6 +146,7 @@ _LLAMA_COMPAT_ARCHES = {
 _ARCH_REMAP = {
     "Gemma3ForCausalLM": "Gemma3PForCausalLM",
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
+    "MistralForCausalLM": "MistralPForCausalLM",
     "Phi3ForCausalLM": "Phi3PForCausalLM",
     "Qwen2ForCausalLM": "Qwen2PForCausalLM",
     "Qwen2MoeForCausalLM": "Qwen2MoePForCausalLM",
@@ -170,6 +171,7 @@ _DMI_MODEL_VARIANTS = {
     "Qwen2MoePForCausalLM": "qwen2_moe_p:Qwen2MoePForCausalLM",
     "Qwen3PForCausalLM": "qwen3_p:Qwen3PForCausalLM",
     "LlamaPForCausalLM": "llama_p:LlamaPForCausalLM",
+    "MistralPForCausalLM": "mistral_p:MistralPForCausalLM",
     "Phi3PForCausalLM": "phi3_p:Phi3PForCausalLM",
 }
 

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -27,6 +27,9 @@ _COMPARE_MODEL_VARIANTS = {
     ),
     "Qwen3CompareForCausalLM": "qwen3_compare:Qwen3CompareForCausalLM",
     "LlamaCompareForCausalLM": "llama_compare:LlamaCompareForCausalLM",
+    "MistralCompareForCausalLM": (
+        "mistral_compare:MistralCompareForCausalLM"
+    ),
     "Phi3CompareForCausalLM": (
         "phi3_compare:Phi3CompareForCausalLM"
     ),
@@ -59,6 +62,7 @@ _ARCH_REMAP = {
     "Qwen2MoeForCausalLM": "Qwen2MoeCompareForCausalLM",
     "Qwen3ForCausalLM": "Qwen3CompareForCausalLM",
     "LlamaForCausalLM": "LlamaCompareForCausalLM",
+    "MistralForCausalLM": "MistralCompareForCausalLM",
     "Phi3ForCausalLM": "Phi3CompareForCausalLM",
 }
 

--- a/tests/test_mistral_p_contract.py
+++ b/tests/test_mistral_p_contract.py
@@ -1,0 +1,75 @@
+"""CPU contracts for the bounded Mistral DMI variant."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from integration.vllm_adapter import _ARCH_REMAP, _LLAMA_COMPAT_ARCHES
+from vllm.model_executor.models.llama_p import LlamaPForCausalLM
+from vllm.model_executor.models.mistral import MistralForCausalLM
+from vllm.model_executor.models.mistral_compare import (
+    MistralCompareForCausalLM,
+)
+from vllm.model_executor.models.mistral_p import (
+    MistralPForCausalLM,
+    _reject_unsupported_mistral_branches,
+)
+
+
+pytestmark = pytest.mark.framework_fork
+
+
+def _vllm_config(**config_values):
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(**config_values))
+    )
+
+
+def test_mistral_has_a_distinct_bounded_remap() -> None:
+    assert "MistralForCausalLM" not in _LLAMA_COMPAT_ARCHES
+    assert _ARCH_REMAP["MistralForCausalLM"] == "MistralPForCausalLM"
+
+
+def test_mistral_variant_preserves_upstream_class_contracts() -> None:
+    assert issubclass(MistralPForCausalLM, LlamaPForCausalLM)
+    assert MistralPForCausalLM.embedding_modules == {}
+    assert (
+        MistralPForCausalLM.mistral_mapping
+        == MistralForCausalLM.mistral_mapping
+    )
+    assert (
+        MistralPForCausalLM.packed_modules_mapping
+        == MistralForCausalLM.packed_modules_mapping
+    )
+    assert (
+        MistralPForCausalLM.maybe_remap_mistral
+        is MistralForCausalLM.maybe_remap_mistral
+    )
+    assert (
+        MistralPForCausalLM.get_hook_specs
+        is LlamaPForCausalLM.get_hook_specs
+    )
+    assert MistralCompareForCausalLM.embedding_modules == {}
+
+
+@pytest.mark.parametrize(
+    "config_values, branch",
+    [
+        ({"llama_4_scaling": {"beta": 0.1}}, "llama_4_scaling"),
+        ({"ada_rms_norm_t_cond": True}, "ada_rms_norm_t_cond"),
+    ],
+)
+def test_mistral_fails_closed_on_unaudited_math_branches(
+    config_values, branch
+) -> None:
+    with pytest.raises(NotImplementedError, match=branch):
+        _reject_unsupported_mistral_branches(_vllm_config(**config_values))
+
+
+def test_mistral_accepts_the_v02_standard_config_contract() -> None:
+    _reject_unsupported_mistral_branches(
+        _vllm_config(
+            llama_4_scaling=None,
+            ada_rms_norm_t_cond=False,
+        )
+    )

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -39,6 +39,7 @@ MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "mistral": "openaccess-ai-collective/tiny-mistral",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 MODEL_ARG = os.environ.get("DMI_BLACKBOX_MODEL", "qwen2")

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -76,6 +76,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
         "qwen2",
         "qwen3",
         "llama",
+        "mistral",
         "phi3",
         "qwen2_moe",
     ):
@@ -87,6 +88,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "storage-gemma3-cudagraph-tp1" in case_ids
     assert "storage-phi3-eager-tp1" in case_ids
     assert "storage-phi3-cudagraph-tp1" in case_ids
+    assert "storage-mistral-eager-tp1" in case_ids
+    assert "storage-mistral-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -117,6 +120,23 @@ def test_phi3_public_matrix_uses_the_production_checkpoint() -> None:
         "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM"
     )
     assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+
+
+def test_mistral_matrix_separates_production_and_graph_safe_fixtures() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-mistral-tp1-eager-graph"]
+    assert public.model_id == "mistralai/Mistral-7B-Instruct-v0.2"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "mistralai/Mistral-7B-Instruct-v0.2"
+    )
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "512"
+
+    for mode in ("eager", "cudagraph"):
+        storage = cases[f"storage-mistral-{mode}-tp1"]
+        assert storage.model_id == "openaccess-ai-collective/tiny-mistral"
+        assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.2"
+        assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
 
 
 def test_static_only_models_use_bounded_two_gpu_storage_cells():

--- a/tests/tools/README.md
+++ b/tests/tools/README.md
@@ -90,6 +90,22 @@ E2E_GPUS=0 E2E_MAX_MODEL_LEN=128 E2E_MAX_NUM_BATCHED_TOKENS=128 \
   bash tests/tools/run_tp_compare_vllm.sh phi3 cudagraph 1
 ```
 
+Mistral uses the official 7B checkpoint for public parity and a graph-safe small
+fixture for the full-hook value oracle. Keep the fixture's memory and token
+bounds: an extremely small Mistral can make vLLM derive excessive KV metadata,
+and attention heads below the target FlexAttention minimum cannot compile.
+
+```bash
+DMI_BLACKBOX_MODEL=mistralai/Mistral-7B-Instruct-v0.2 \
+  DMI_BLACKBOX_CUDAGRAPH=1 DMI_BLACKBOX_GPU_MEMORY_UTILIZATION=0.9 \
+  DMI_BLACKBOX_MAX_MODEL_LEN=512 CUDA_VISIBLE_DEVICES=0 \
+  pytest -q -s tests/test_vllm_blackbox.py
+
+E2E_GPUS=0 E2E_GPU_MEM_UTIL=0.2 E2E_MAX_MODEL_LEN=128 \
+  E2E_MAX_NUM_BATCHED_TOKENS=128 \
+  bash tests/tools/run_tp_compare_vllm.sh mistral cudagraph 1
+```
+
 Set `DMI_BLACKBOX_ARTIFACT_DIR` to retain each mode's generated cases and raw
 baseline/monitored JSON instead of relying on pytest's temporary directory.
 

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -117,13 +117,18 @@ def _storage_case(
     ref_max_len: int = 8192,
     model_subfolder: str | None = None,
     max_model_len: int = 512,
+    memory_utilization: float | None = None,
 ) -> MatrixCase:
     environment = {
         "DMX_HOOK_SELECTION": hook_selection,
         "E2E_REF_MAX_LEN": str(ref_max_len),
         "E2E_RING_PAYLOAD_MB": "512",
         "E2E_RING_PINNED_MB": "512",
-        "E2E_GPU_MEM_UTIL": "0.85" if tp_size == 2 else "0.6",
+        "E2E_GPU_MEM_UTIL": str(
+            memory_utilization
+            if memory_utilization is not None
+            else (0.85 if tp_size == 2 else 0.6)
+        ),
         "E2E_MAX_MODEL_LEN": str(max_model_len),
         "E2E_MAX_NUM_BATCHED_TOKENS": str(max_model_len),
     }
@@ -157,6 +162,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "tests/test_vllm_027_model_contracts.py",
             "tests/test_gemma3_p_inventory.py",
             "tests/test_model_artifacts.py",
+            "tests/test_mistral_p_contract.py",
             "tests/test_phi3_p_contract.py",
             "tests/test_vllm_storage_contracts.py",
             "tests/test_qwen2_p_inventory.py",
@@ -188,6 +194,14 @@ def build_cases(phase: str) -> list[MatrixCase]:
             tp_size=1,
             memory_utilization=0.75,
             model_arg="microsoft/Phi-3.5-mini-instruct",
+            max_model_len=512,
+        ),
+        _blackbox_case(
+            "mistral",
+            "mistralai/Mistral-7B-Instruct-v0.2",
+            tp_size=1,
+            memory_utilization=0.9,
+            model_arg="mistralai/Mistral-7B-Instruct-v0.2",
             max_model_len=512,
         ),
         _blackbox_case("gpt2", "gpt2", tp_size=1, memory_utilization=0.5),
@@ -224,6 +238,17 @@ def build_cases(phase: str) -> list[MatrixCase]:
                 ref_max_len=128,
                 model_subfolder="hf",
                 max_model_len=128,
+            )
+        )
+        storage.append(
+            _storage_case(
+                "mistral",
+                "openaccess-ai-collective/tiny-mistral",
+                mode,
+                1,
+                ref_max_len=128,
+                max_model_len=128,
+                memory_utilization=0.2,
             )
         )
         storage.append(

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -25,6 +25,7 @@ MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "mistral": "openaccess-ai-collective/tiny-mistral",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -26,6 +26,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "mistral": "openaccess-ai-collective/tiny-mistral",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -23,6 +23,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "mistral": "openaccess-ai-collective/tiny-mistral",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -22,6 +22,7 @@ _MODEL_ALIASES = {
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
+    "mistral": "openaccess-ai-collective/tiny-mistral",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 


### PR DESCRIPTION
## Summary

- remap MistralForCausalLM to a bounded DMI monitoring variant
- add public, compare, storage, and release-matrix coverage
- qualify a graph-safe small fixture and pin memory/token bounds
- add the agent-authored M01-M15/R01-R07 audit and update the model roadmap
- advance the vLLM integration gitlink to ProjectDMX/vllm-DMI#3

## Validation

- focused release cell: 1/1; 246/246 tests passed
- small-fixture public API eager + graph: 2/2 passed in 85.82 s
- small-fixture storage eager: 14,880/14,880 rows byte-identical
- small-fixture storage graph: 14,880/14,880 rows byte-identical
- official Mistral-7B-Instruct-v0.2 public eager + graph: 2/2 passed in 124.35 s
- no worker, teardown, residual-process, capture, or GPU-allocation failures

## Runtime dependencies

- vLLM 0.27.1 / upstream commit 6e448d0ea9bf3d88d898b65449ca6dc2aec170ac
- CUDA GPU for runtime cells and ClickHouse/native DMI backend for storage cells
- production checkpoint revision 63a8b081895390a26e140280378bc85ec8bce07a
- fixture revision 2a2db3d57a46dd87d62c12b50bb8c34cc1afe126

## Scope

TP1 BF16 V1 offline standard-HF eager/default-graph only. The audit explicitly excludes untested parallel, V2, serving, speculative, quantized, alternate-loader, and non-text cells.