### PR TITLE
Add Falcon-H1 support for vLLM 0.27

### DIFF
--- a/docs/vllm-0.27.1-falcon-h1-audit.md
+++ b/docs/vllm-0.27.1-falcon-h1-audit.md
@@ -1,0 +1,78 @@
+# Falcon-H1 model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only `FalconH1ForCausalLM`
+architecture in a bounded TP1 BF16 V1 offline cell. Falcon-H1 is a parallel
+hybrid architecture: every decoder layer evaluates both attention and Mamba2,
+merges the scaled branch outputs with the residual, and then evaluates its MLP.
+The verdict does not extend to other Falcon architectures or untested runtime
+cells.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/falcon_h1.py`, `FalconH1ForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-falcon-h1`, commit `e69be397855221bdfa395f51394a1f7ebeec68cb` |
+| Production checkpoint | `tiiuae/Falcon-H1-0.5B-Instruct`, revision `8f2587ca06bff78d8fa1adfccbe8c24d5f86b368` |
+| Focused fixture | `tiiuae/Falcon-H1-Tiny-90M-Instruct`, revision `e6389502a0b12cd8da894b395ba5bf7436873b16` |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph, canonical attention/MLP/residual hooks plus SSM branch input/output hooks |
+| Excluded | TP>1, PP/DP/EP/SP, V2, serve/async, speculative, LoRA, quantization, prefix caching, remote-code variants, and internal Mamba convolution/state/B/C/dt tensors |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01-M04 | independently adapted and runtime-verified | The target implementation has distinct attention, Mamba2, parallel-hybrid, MLP, model, and causal-LM classes. DMI preserves the exact branch order, residual order, and upstream arithmetic expression order while adding bounded observations. Representative eager/graph public differential tests close the numerical path. |
+| M05-M09 | preserved but excluded from the support claim | The DMI causal-LM class inherits upstream hybrid/state interfaces and state dtype, shape, and copy calculators. PP, TP>1, prefix caching, speculative execution, and quantized paths were not run and remain unclaimed. |
+| M10 | adapted-verified for standard HF weights | The DMI subclass inherits Falcon-H1's packed QKV/gate-up mapping, HF-to-vLLM name mapper, embedding declarations, and weight loader. Both the official Tiny checkpoint and the official 0.5B checkpoint loaded. The 0.5B fixture closes untied embeddings and non-unit embedding, key, attention, SSM, MLP, and LM-head scaling branches that Tiny does not exercise. |
+| M11-M13 | verified for TP1 | Each parallel-hybrid layer exposes `resid_pre`, `ln1`, Q/K/V/Z, scaled `attn_out`, scaled `ssm_in`, scaled `ssm_out`, `resid_mid`, `ln2`, `mlp_in`, `mlp_post`, and `mlp_out`. Five model-wide hooks cover token IDs, scaled embeddings, final residual, final norm, and logits. The 24-layer fixture exposes 341 hook families. Independent compare buffers and ClickHouse transport were byte-identical in eager and graph runs. |
+| M14 | bounded | Only `FalconH1ForCausalLM` is remapped. `FalconForCausalLM`, Falcon Mamba, task heads, remote-code models, and unrelated hybrid implementations do not inherit this verdict. |
+| M15 | verified with an explicit hybrid manifest | Every exercised layer contains both attention and Mamba2; it is not an alternating-layer model. Attention hooks describe only the attention branch. `ssm_in` and `ssm_out` describe hidden-width Mamba branch boundaries. DMI deliberately does not claim internal recurrent state, convolution, z/x/B/C/dt, or cache tensors. |
+| R01-R03 | verified | Upstream resolves `FalconH1ForCausalLM` to `falcon_h1:FalconH1ForCausalLM`; DMI resolves it one-to-one to `falcon_h1_p:FalconH1PForCausalLM`. The compare architecture has its own test-only registry entry. |
+| R04-R07 | verified | The 0.27.1 out-of-tree lazy-registration surface loads the DMI variant without eagerly loading CUDA. Constructor prefix keywords, registry remap, hybrid/state inheritance, hook inventory, and release-matrix bounds are locked by CPU contracts. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Upstream fixture qualification | Unmodified Tiny eager and default CUDA graph both loaded and generated successfully before DMI was enabled. |
+| Focused model and release contracts | Final focused sweep passed 257/257. The suite includes non-unit branch-scale semantics, exact `make_layers(prefix=...)` construction, native SSM ABI/shape/selection, storage-name derivation, registry, black-box, and release-matrix contracts. |
+| Tiny public eager+graph | 2/2 full 12-case API-only tests passed in 159.40 s. |
+| Tiny eager full-hook transport | 54,560/54,560 independent D2D reference rows were byte-identical to ClickHouse rows. |
+| Tiny CUDA-graph full-hook transport | 54,560/54,560 independent D2D reference rows were byte-identical to ClickHouse rows. |
+| Production eager+graph | 2/2 full 12-case API-only tests passed in 92.05 s. The public decision-logprob oracle accepted only bounded low-margin branch changes; there was no unexplained decision drift. |
+| Upstream graph stability | Two independent production baseline graph runs produced identical normalized public JSON hashes. A token-only DMI graph run also matched that hash exactly after upstream arithmetic expression order was restored. |
+| Lifecycle | Accepted runs exited cleanly without residual vLLM workers, captures, or GPU allocations. |
+
+The storage oracle compares independently copied and transported values from the
+same execution, including exact request/token ranges. The public oracle is a
+separate baseline-versus-monitored process comparison. The comparator's short
+hook names are derived from the native hook-definition table, so the new SSM
+family cannot silently diverge between reference files and ClickHouse names.
+
+## Fixture qualification and compiler regression
+
+The official Tiny checkpoint is an appropriate runtime fixture: it uses the
+target architecture, 24 parallel hybrid layers, 64-dimensional attention heads,
+Mamba2 state and convolution, BF16 weights, and a bounded 182 MB checkpoint.
+Its release cells pin `gpu_memory_utilization=0.2`, `max_model_len=128`, and
+`max_num_batched_tokens=128`.
+
+Tiny alone was insufficient for the final numerical verdict because its branch
+and MLP multipliers are all `1.0`. The production checkpoint uses non-unit
+embedding, key, attention-output, SSM-input/output, MLP, and LM-head scales.
+An early DMI implementation materialized scaled branch values before the merge;
+that was eager-equivalent but changed BF16 compiler fusion and failed the
+production CUDA-graph public oracle. The accepted implementation computes hook
+observations separately when enabled and preserves upstream expression order for
+the model output. A non-unit focused contract and production graph cell prevent
+an all-one tiny fixture from masking this class of regression again.
+
+## Support decision
+
+`FalconH1ForCausalLM` is supported for the named TP1 BF16 V1 offline standard-HF
+eager/default-graph cell at the exact commits above. The supported capability is
+the canonical attention/MLP/residual inventory plus hidden-width SSM branch
+input/output boundaries. Internal Mamba state and every excluded execution mode
+remain untested rather than implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -35,8 +35,9 @@ the registry source, but remains upstream-static evidence rather than DMI
 runtime support. Across the 41 representative checkpoints below:
 
 - all 41 resolve in vLLM 0.27.1;
-- 5 architectures have a DMI model remap today;
-- 36 are unmapped by DMI;
+- 9 architectures have a DMI model remap on the current stacked expansion
+  branch;
+- 32 are unmapped by DMI;
 - registry presence is upstream static evidence, not DMI runtime support.
 
 Between vLLM 0.25.1 and 0.27.1, the combined text/multimodal registry adds eight
@@ -101,6 +102,14 @@ eager/graph full-hook transport on a qualified small fixture. Configurations
 that enable Llama-4 attention scaling or adaptive conditional RMS normalization,
 alternate loaders, TP>1, quantization, serving, speculative, and non-text
 variants remain excluded.
+
+Falcon-H1 is `supported` for the bounded TP1 BF16 V1 offline
+eager/default-graph cell at integration commit `e69be3978552`. The
+[`Falcon-H1 audit`](vllm-0.27.1-falcon-h1-audit.md) records public validation on
+the official 0.5B checkpoint, byte-identical eager/graph full-hook transport on
+the official Tiny checkpoint, and the bounded SSM branch capability manifest.
+Internal Mamba state, TP>1, prefix caching, quantization, serving, speculative,
+and non-text variants remain excluded.
 
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -144,6 +144,7 @@ _LLAMA_COMPAT_ARCHES = {
 }
 
 _ARCH_REMAP = {
+    "FalconH1ForCausalLM": "FalconH1PForCausalLM",
     "Gemma3ForCausalLM": "Gemma3PForCausalLM",
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
     "MistralForCausalLM": "MistralPForCausalLM",
@@ -165,6 +166,7 @@ _ARCH_REMAP = {
 # Lazy strings are important here: importing model implementations eagerly in
 # the parent process can initialize CUDA before vLLM forks its workers.
 _DMI_MODEL_VARIANTS = {
+    "FalconH1PForCausalLM": "falcon_h1_p:FalconH1PForCausalLM",
     "Gemma3PForCausalLM": "gemma3_p:Gemma3PForCausalLM",
     "GPT2PLMHeadModel": "gpt2_p:GPT2PLMHeadModel",
     "Qwen2PForCausalLM": "qwen2_p:Qwen2PForCausalLM",

--- a/monitoring/csrc/ring/tensor_meta.h
+++ b/monitoring/csrc/ring/tensor_meta.h
@@ -51,11 +51,18 @@ enum HookType : int {
     HOOK_TYPE_ROUTER_LOGITS= 21,
     HOOK_TYPE_TOPK_IDS     = 22,
     HOOK_TYPE_TOPK_WEIGHTS = 23,
-    HOOK_TYPE_COUNT        = 24,
+    HOOK_TYPE_SSM_IN       = 24,
+    HOOK_TYPE_SSM_OUT      = 25,
+    HOOK_TYPE_COUNT        = 26,
 };
 
 // Hook group — which sub-block produces this tensor.
-enum HookGroup : int { GROUP_ATTN = 0, GROUP_MLP = 1, GROUP_OTHER = 2 };
+enum HookGroup : int {
+    GROUP_ATTN = 0,
+    GROUP_MLP = 1,
+    GROUP_OTHER = 2,
+    GROUP_SSM = 3,
+};
 
 // Shape class — determines the shape formula in _compute_hook_shape:
 //   SHAPE_HIDDEN   : [batch, q_len, hidden_dim]
@@ -83,7 +90,7 @@ struct HookDef {
     const char* act_name;    // ClickHouse act_name (p2p_thread uses this)
     const char* short_name;  // Python selection preset name
     bool        per_layer;   // true = "blocks.<L>.<act_name>", false = global
-    int         group;       // HookGroup: GROUP_ATTN / GROUP_MLP / GROUP_OTHER
+    int         group;       // HookGroup enum value
     bool        tp_sharded;  // true = tensor is TP-sharded (pre-all-reduce)
     int         shape_class; // ShapeClass: determines shape formula
     int         pp_stage;    // PpStage: PP_ANY / PP_FIRST / PP_LAST
@@ -114,6 +121,8 @@ static constexpr HookDef HOOK_DEFS[] = {
     {HOOK_TYPE_ROUTER_LOGITS,"mlp.hook_router_logits",  "router_logits",true,  GROUP_OTHER, false, SHAPE_ROUTER_LOGITS, PP_ANY },
     {HOOK_TYPE_TOPK_IDS,    "mlp.hook_topk_ids",        "topk_ids",     true,  GROUP_OTHER, false, SHAPE_TOPK_IDS, PP_ANY },
     {HOOK_TYPE_TOPK_WEIGHTS,"mlp.hook_topk_weights",    "topk_weights", true,  GROUP_OTHER, false, SHAPE_TOPK_WEIGHTS, PP_ANY },
+    {HOOK_TYPE_SSM_IN,      "ssm.hook_in",              "ssm_in",       true,  GROUP_SSM,   false, SHAPE_HIDDEN, PP_ANY },
+    {HOOK_TYPE_SSM_OUT,     "ssm.hook_out",             "ssm_out",      true,  GROUP_SSM,   false, SHAPE_HIDDEN, PP_ANY },
 };
 static constexpr int HOOK_DEFS_COUNT = sizeof(HOOK_DEFS) / sizeof(HOOK_DEFS[0]);
 

--- a/monitoring/ring_transport.py
+++ b/monitoring/ring_transport.py
@@ -57,10 +57,11 @@ from ._native_engine import _load_extension as _load_ext
 _ext = _load_ext()
 # (id, act_name, short_name, per_layer, group, tp_sharded, shape_class, pp_stage)
 # group/shape_class/pp_stage are int enums matching the C++ definitions.
-_HOOK_DEFS = _ext.HOOK_DEFS
+HOOK_DEFINITIONS = tuple(_ext.HOOK_DEFS)
+_HOOK_DEFS = HOOK_DEFINITIONS
 
 # C++ enum mirrors -- keep in sync with tensor_meta.h
-GROUP_ATTN, GROUP_MLP, GROUP_OTHER = 0, 1, 2
+GROUP_ATTN, GROUP_MLP, GROUP_OTHER, GROUP_SSM = 0, 1, 2, 3
 SHAPE_HIDDEN, SHAPE_QKV_Q, SHAPE_QKV_KV, SHAPE_QKV_Z = 0, 1, 2, 3
 SHAPE_ATTN_WT, SHAPE_MLP_POST, SHAPE_TOKEN_IDS, SHAPE_LOGITS = 4, 5, 6, 7
 PP_ANY, PP_FIRST, PP_LAST = 0, 1, 2
@@ -96,6 +97,9 @@ _ATTN_SUFFIXES: Tuple[str, ...] = tuple(
 )
 _MLP_SUFFIXES: Tuple[str, ...] = tuple(
     _act for _id, _act, _short, _pl, _grp, _tp, _sc, _pp in _HOOK_DEFS if _grp == GROUP_MLP
+)
+_SSM_SUFFIXES: Tuple[str, ...] = tuple(
+    _act for _id, _act, _short, _pl, _grp, _tp, _sc, _pp in _HOOK_DEFS if _grp == GROUP_SSM
 )
 
 # Auto-derive property sets from HOOK_DEFS columns.

--- a/tests/compare_disk_vs_ch.py
+++ b/tests/compare_disk_vs_ch.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import torch
 
+from monitoring.ring_transport import HOOK_DEFINITIONS
+
 
 _DTYPE_MAP = {
     "torch.bfloat16": torch.bfloat16, "torch.float": torch.float32,
@@ -19,31 +21,20 @@ _DTYPE_MAP = {
     "torch.bool": torch.bool,
 }
 
-# Map short hook name → ClickHouse act_name (must match tensor_meta.h + p2p make_act_name).
+# Derive storage names from the native ABI table so newly registered hook
+# families cannot silently diverge between reference files and ClickHouse.
 _BUF_TO_CH_ACT = {
-    "resid_pre": "blocks.hook_resid_pre",
-    "ln1": "blocks.hook_ln1",
-    "q": "blocks.attn.hook_q",
-    "k": "blocks.attn.hook_k",
-    "v": "blocks.attn.hook_v",
-    "z": "blocks.attn.hook_z",
-    "attn_scores": "blocks.attn.hook_attn_scores",
-    "pattern": "blocks.attn.hook_pattern",
-    "attn_out": "blocks.hook_attn_out",
-    "resid_mid": "blocks.hook_resid_mid",
-    "ln2": "blocks.hook_ln2",
-    "mlp_in": "blocks.hook_mlp_in",
-    "mlp_out": "blocks.hook_mlp_out",
-    "mlp_post": "blocks.hook_mlp_post",
-    "embed": "hook_embed",
-    "pos_embed": "hook_pos_embed",
-    "resid_final": "hook_resid_final",
-    "final_ln": "hook_final_ln",
-    "final_logits": "final_logits",
-    "token_ids": "token_ids",
-    "router_logits": "blocks.mlp.hook_router_logits",
-    "topk_ids": "blocks.mlp.hook_topk_ids",
-    "topk_weights": "blocks.mlp.hook_topk_weights",
+    short_name: f"blocks.{act_name}" if per_layer else act_name
+    for (
+        _hook_type,
+        act_name,
+        short_name,
+        per_layer,
+        _group,
+        _tp_sharded,
+        _shape_class,
+        _pp_stage,
+    ) in HOOK_DEFINITIONS
 }
 
 _PT_RE = re.compile(

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -18,6 +18,9 @@ from monitoring.ring_transport import HOOK_TYPE_TO_SHORT_NAME, HookSpec
 
 
 _COMPARE_MODEL_VARIANTS = {
+    "FalconH1CompareForCausalLM": (
+        "falcon_h1_compare:FalconH1CompareForCausalLM"
+    ),
     "Gemma3CompareForCausalLM": (
         "gemma3_compare:Gemma3CompareForCausalLM"
     ),
@@ -57,6 +60,7 @@ _register_compare_model_variants()
 
 
 _ARCH_REMAP = {
+    "FalconH1ForCausalLM": "FalconH1CompareForCausalLM",
     "Gemma3ForCausalLM": "Gemma3CompareForCausalLM",
     "GPT2LMHeadModel": "GPT2CompareForCausalLM",
     "Qwen2MoeForCausalLM": "Qwen2MoeCompareForCausalLM",

--- a/tests/test_falcon_h1_p_contract.py
+++ b/tests/test_falcon_h1_p_contract.py
@@ -1,0 +1,379 @@
+"""CPU contracts for Falcon-H1 hybrid DMI support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+import integration.vllm_adapter  # noqa: F401
+from integration.vllm_adapter import _ARCH_REMAP
+from monitoring.hook_points import HookPoint
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_MLP_POST,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_SSM_IN,
+    HOOK_TYPE_SSM_OUT,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+)
+from vllm.config import CompilationMode
+from vllm.model_executor.models.falcon_h1 import FalconH1ForCausalLM
+from vllm.model_executor.models.falcon_h1_p import (
+    FalconH1PAttentionDecoderLayer,
+    FalconH1PForCausalLM,
+    FalconH1PModel,
+    FalconH1PParallelHybrid,
+)
+import vllm.model_executor.models.falcon_h1_p as falcon_h1_p
+
+
+class _FakeAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        for name in ("q", "k", "v", "z"):
+            setattr(self, f"hook_{name}", HookPoint())
+
+
+class _FakeMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hook_post = HookPoint()
+
+
+class _FakeLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = _FakeAttention()
+        self.feed_forward = _FakeMLP()
+        for name in (
+            "resid_pre",
+            "ln1",
+            "attn_out",
+            "ssm_in",
+            "ssm_out",
+            "resid_mid",
+            "ln2",
+            "mlp_in",
+            "mlp_out",
+        ):
+            setattr(self, f"hook_{name}", HookPoint())
+
+
+class _FakeModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_FakeLayer(), _FakeLayer()])
+        self.start_layer = 0
+        self.end_layer = len(self.layers)
+        self.hook_embed = HookPoint()
+        self.hook_resid_final = HookPoint()
+        self.hook_final_ln = HookPoint()
+
+
+def _fake_model() -> FalconH1PForCausalLM:
+    model = FalconH1PForCausalLM.__new__(FalconH1PForCausalLM)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(num_hidden_layers=2)
+    model.model = _FakeModel()
+    model.hook_token_ids = HookPoint()
+    model.hook_final_logits = HookPoint()
+    return model
+
+
+def test_falcon_h1_preserves_hybrid_and_weight_loader_contracts() -> None:
+    assert _ARCH_REMAP["FalconH1ForCausalLM"] == "FalconH1PForCausalLM"
+    assert issubclass(FalconH1PForCausalLM, FalconH1ForCausalLM)
+    assert (
+        FalconH1PForCausalLM.packed_modules_mapping
+        == FalconH1ForCausalLM.packed_modules_mapping
+    )
+    assert (
+        FalconH1PForCausalLM.hf_to_vllm_mapper
+        is FalconH1ForCausalLM.hf_to_vllm_mapper
+    )
+    assert (
+        FalconH1PForCausalLM.get_mamba_state_shape_from_config.__func__
+        is FalconH1ForCausalLM.get_mamba_state_shape_from_config.__func__
+    )
+    assert (
+        FalconH1PForCausalLM.get_mamba_state_copy_func.__func__
+        is FalconH1ForCausalLM.get_mamba_state_copy_func.__func__
+    )
+
+
+def test_falcon_h1_model_factory_accepts_make_layers_prefix_keyword(
+    monkeypatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    class _FactoryLayer(nn.Module):
+        def __init__(
+            self,
+            config,
+            layer_idx,
+            model_config,
+            cache_config,
+            *,
+            quant_config,
+            prefix,
+        ) -> None:
+            super().__init__()
+            observed.update(
+                layer_idx=layer_idx,
+                prefix=prefix,
+                quant_config=quant_config,
+            )
+
+    def _make_layers(num_layers, layer_fn, *, prefix):
+        layer = layer_fn(prefix=f"{prefix}.0")
+        return 0, num_layers, nn.ModuleList([layer])
+
+    rank = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(falcon_h1_p, "get_pp_group", lambda: rank)
+    monkeypatch.setattr(falcon_h1_p, "make_layers", _make_layers)
+    monkeypatch.setattr(
+        falcon_h1_p,
+        "VocabParallelEmbedding",
+        lambda *_args, **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        falcon_h1_p,
+        "RMSNorm",
+        lambda *_args, **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        falcon_h1_p,
+        "make_empty_intermediate_tensors_factory",
+        lambda *_args, **_kwargs: object(),
+    )
+    config = SimpleNamespace(
+        vocab_size=32,
+        hidden_size=8,
+        embedding_multiplier=1.0,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=config),
+        cache_config=object(),
+        quant_config="quant",
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+    model = FalconH1PModel(
+        vllm_config=vllm_config,
+        prefix="model",
+        layer_type=_FactoryLayer,
+    )
+
+    assert len(model.layers) == 1
+    assert observed == {
+        "layer_idx": 0,
+        "prefix": "model.layers.0",
+        "quant_config": "quant",
+    }
+
+
+def test_falcon_h1_inventory_declares_each_hybrid_layer_capability() -> None:
+    specs = _fake_model().get_hook_specs()
+    per_layer = {
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_LN1,
+        HOOK_TYPE_Q,
+        HOOK_TYPE_K,
+        HOOK_TYPE_V,
+        HOOK_TYPE_Z,
+        HOOK_TYPE_ATTN_OUT,
+        HOOK_TYPE_SSM_IN,
+        HOOK_TYPE_SSM_OUT,
+        HOOK_TYPE_RESID_MID,
+        HOOK_TYPE_LN2,
+        HOOK_TYPE_MLP_IN,
+        HOOK_TYPE_MLP_POST,
+        HOOK_TYPE_MLP_OUT,
+    }
+
+    assert {spec.hook_type for spec in specs if spec.layer_no == 0} == per_layer
+    assert {spec.hook_type for spec in specs if spec.layer_no == 1} == per_layer
+    assert {spec.hook_type for spec in specs if spec.layer_no == -1} == {
+        HOOK_TYPE_TOKEN_IDS,
+        HOOK_TYPE_EMBED,
+        HOOK_TYPE_RESID_FINAL,
+        HOOK_TYPE_FINAL_LN,
+        HOOK_TYPE_FINAL_LOGITS,
+    }
+    assert len(specs) == 33
+    assert all(spec.module is not None for spec in specs)
+
+
+def test_falcon_h1_model_wide_inventory_is_module_free() -> None:
+    specs = _fake_model().get_hook_specs(model_wide=True)
+
+    assert len(specs) == 33
+    assert all(spec.module is None for spec in specs)
+    assert all(
+        spec.dim0_is_actual_tokens
+        for spec in specs
+        if spec.hook_type != HOOK_TYPE_FINAL_LOGITS
+    )
+
+
+class _Projection(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+
+    def forward(self, _value: torch.Tensor):
+        return self.output, None
+
+
+class _Rotary(nn.Module):
+    def __init__(self, events: list[tuple[str, torch.Tensor]]) -> None:
+        super().__init__()
+        self.events = events
+
+    def forward(self, _positions, q, k):
+        self.events.extend(
+            [("rotary_q", q.clone()), ("rotary_k", k.clone())]
+        )
+        return q + 100, k + 200
+
+
+class _AttentionKernel(nn.Module):
+    def __init__(self, events: list[tuple[str, torch.Tensor]]) -> None:
+        super().__init__()
+        self.events = events
+
+    def forward(self, q, k, v):
+        self.events.extend(
+            [
+                ("kernel_q", q.clone()),
+                ("kernel_k", k.clone()),
+                ("kernel_v", v.clone()),
+            ]
+        )
+        return q
+
+
+def test_falcon_h1_attention_hooks_scaled_k_before_rope() -> None:
+    attention = FalconH1PAttentionDecoderLayer.__new__(
+        FalconH1PAttentionDecoderLayer
+    )
+    nn.Module.__init__(attention)
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.num_heads = 2
+    attention.num_kv_heads = 1
+    attention.head_dim = 2
+    attention.key_multiplier = 10
+    qkv = torch.arange(8, dtype=torch.float32).reshape(1, 8)
+    attention.qkv_proj = _Projection(qkv)
+    events: list[tuple[str, torch.Tensor]] = []
+    attention.rotary_emb = _Rotary(events)
+    attention.attn = _AttentionKernel(events)
+    attention.o_proj = _Projection(torch.full((1, 4), 999.0))
+    captured: dict[str, torch.Tensor] = {}
+    for name in ("q", "k", "v", "z"):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key, output.clone()
+            )
+        )
+        setattr(attention, f"hook_{name}", hook)
+
+    output = attention.self_attention(
+        torch.tensor([0]), torch.zeros(1, 4)
+    )
+
+    assert output.tolist() == [[999.0, 999.0, 999.0, 999.0]]
+    assert torch.equal(captured["q"].flatten(), qkv[:, :4].flatten())
+    assert torch.equal(captured["k"].flatten(), qkv[:, 4:6].flatten() * 10)
+    assert torch.equal(captured["v"].flatten(), qkv[:, 6:].flatten())
+    assert torch.equal(events[0][1], captured["q"].flatten(-2, -1))
+    assert torch.equal(events[1][1], captured["k"].flatten(-2, -1))
+    assert torch.equal(events[4][1], captured["v"].flatten(-2, -1))
+    assert torch.equal(captured["z"], events[2][1])
+
+
+class _Scale(nn.Module):
+    def __init__(self, value: float) -> None:
+        super().__init__()
+        self.value = value
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * self.value
+
+
+class _Branch(nn.Module):
+    def __init__(self, amount: float) -> None:
+        super().__init__()
+        self.amount = amount
+
+    def forward(self, *, hidden_states: torch.Tensor, **kwargs):
+        return hidden_states + self.amount, kwargs.get("residual")
+
+
+class _Add(nn.Module):
+    def __init__(self, amount: float) -> None:
+        super().__init__()
+        self.amount = amount
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor + self.amount
+
+
+def test_falcon_h1_ssm_hooks_bound_scaled_branch_contribution() -> None:
+    layer = FalconH1PParallelHybrid.__new__(FalconH1PParallelHybrid)
+    nn.Module.__init__(layer)
+    layer.input_layernorm = _Scale(2)
+    layer.pre_ff_layernorm = _Scale(13)
+    layer.self_attn = _Branch(1)
+    layer.mamba = _Branch(2)
+    layer.feed_forward = _Add(3)
+    layer.attention_in_multiplier = 3
+    layer.attn_out_multiplier = 5
+    layer.ssm_in_multiplier = 7
+    layer.ssm_out_multiplier = 11
+    captured: dict[str, torch.Tensor] = {}
+    for name in (
+        "resid_pre",
+        "ln1",
+        "attn_out",
+        "ssm_in",
+        "ssm_out",
+        "resid_mid",
+        "ln2",
+        "mlp_in",
+        "mlp_out",
+    ):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key, output.clone()
+            )
+        )
+        setattr(layer, f"hook_{name}", hook)
+
+    output = layer(torch.tensor([0]), torch.tensor([[1.0]]))
+
+    assert captured["ssm_in"].item() == 14
+    assert captured["ssm_out"].item() == 176
+    assert captured["attn_out"].item() == 35
+    assert captured["resid_mid"].item() == 212
+    assert output.item() == 2971

--- a/tests/test_ssm_hook_contract.py
+++ b/tests/test_ssm_hook_contract.py
@@ -1,0 +1,67 @@
+"""CPU contracts for architecture-neutral SSM branch hook types."""
+
+from __future__ import annotations
+
+import torch
+
+import integration.vllm_adapter  # noqa: F401
+import monitoring.ring_transport as ring
+from monitoring.selection import resolve_hook_selection
+from tests.compare_disk_vs_ch import _BUF_TO_CH_ACT
+
+
+def _model_shape() -> ring.ModelShapeConfig:
+    return ring.ModelShapeConfig(
+        hidden_dim=64,
+        num_heads=4,
+        num_kv_heads=2,
+        head_dim=16,
+        dtype=torch.bfloat16,
+        vocab_size=128,
+        intermediate_dim=96,
+    )
+
+
+def test_ssm_hooks_are_native_hidden_shape_branch_boundaries() -> None:
+    definitions = {row[2]: row for row in ring._HOOK_DEFS}
+
+    for short_name, hook_type in (
+        ("ssm_in", ring.HOOK_TYPE_SSM_IN),
+        ("ssm_out", ring.HOOK_TYPE_SSM_OUT),
+    ):
+        definition = definitions[short_name]
+        assert definition[0] == hook_type
+        assert definition[3] is True
+        assert definition[4] == ring.GROUP_SSM
+        assert definition[5] is False
+        assert definition[6] == ring.SHAPE_HIDDEN
+        assert definition[7] == ring.PP_ANY
+
+
+def test_ssm_storage_names_are_derived_from_native_definitions() -> None:
+    assert _BUF_TO_CH_ACT["ssm_in"] == "blocks.ssm.hook_in"
+    assert _BUF_TO_CH_ACT["ssm_out"] == "blocks.ssm.hook_out"
+
+
+def test_ssm_hooks_use_full_hidden_rows_in_both_layouts() -> None:
+    config = _model_shape()
+
+    for hook_type in (ring.HOOK_TYPE_SSM_IN, ring.HOOK_TYPE_SSM_OUT):
+        assert ring._compute_hook_shape(hook_type, config, 0, 7, 0) == [
+            7,
+            64,
+        ]
+        assert ring._compute_hook_shape(hook_type, config, 3, 7, 0) == [
+            3,
+            7,
+            64,
+        ]
+
+
+def test_vllm_full_selects_ssm_hooks_without_reclassifying_attention() -> None:
+    selected = resolve_hook_selection("vllm-full")
+
+    assert ring.HOOK_TYPE_SSM_IN in selected
+    assert ring.HOOK_TYPE_SSM_OUT in selected
+    assert ring._SSM_SUFFIXES == ("ssm.hook_in", "ssm.hook_out")
+    assert set(ring._SSM_SUFFIXES).isdisjoint(ring._ATTN_SUFFIXES)

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -33,6 +33,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 RUNNER = PROJECT_ROOT / "tests/tools/smoke_vllm_model.py"
 CASES = PROJECT_ROOT / "tests/blackbox/cases/transparency.json"
 MODEL_ALIASES = {
+    "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",
     "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -71,6 +71,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
 
     assert "focused-cpu-contracts" in case_ids
     for model in (
+        "falcon_h1",
         "gemma3",
         "gpt2",
         "qwen2",
@@ -90,6 +91,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "storage-phi3-cudagraph-tp1" in case_ids
     assert "storage-mistral-eager-tp1" in case_ids
     assert "storage-mistral-cudagraph-tp1" in case_ids
+    assert "storage-falcon_h1-eager-tp1" in case_ids
+    assert "storage-falcon_h1-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -135,6 +138,23 @@ def test_mistral_matrix_separates_production_and_graph_safe_fixtures() -> None:
     for mode in ("eager", "cudagraph"):
         storage = cases[f"storage-mistral-{mode}-tp1"]
         assert storage.model_id == "openaccess-ai-collective/tiny-mistral"
+        assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.2"
+        assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+
+
+def test_falcon_h1_matrix_separates_production_and_hybrid_fixture() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-falcon_h1-tp1-eager-graph"]
+    assert public.model_id == "tiiuae/Falcon-H1-0.5B-Instruct"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "tiiuae/Falcon-H1-0.5B-Instruct"
+    )
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "512"
+
+    for mode in ("eager", "cudagraph"):
+        storage = cases[f"storage-falcon_h1-{mode}-tp1"]
+        assert storage.model_id == "tiiuae/Falcon-H1-Tiny-90M-Instruct"
         assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.2"
         assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
 

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -160,6 +160,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "-q",
             "tests/test_vllm_version_compat.py",
             "tests/test_vllm_027_model_contracts.py",
+            "tests/test_falcon_h1_p_contract.py",
             "tests/test_gemma3_p_inventory.py",
             "tests/test_model_artifacts.py",
             "tests/test_mistral_p_contract.py",
@@ -174,12 +175,21 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "tests/test_gpu_idle_check.py",
             "tests/test_blackbox_case_generation.py",
             "tests/test_process_group.py",
+            "tests/test_ssm_hook_contract.py",
             "tests/test_vllm_compare_runner.py",
             "tests/test_vllm_release_matrix.py",
         ),
         environment={},
     )
     public = [
+        _blackbox_case(
+            "falcon_h1",
+            "tiiuae/Falcon-H1-0.5B-Instruct",
+            tp_size=1,
+            memory_utilization=0.5,
+            model_arg="tiiuae/Falcon-H1-0.5B-Instruct",
+            max_model_len=512,
+        ),
         _blackbox_case(
             "gemma3",
             "shibatch/tinygemma3-2m",
@@ -229,6 +239,17 @@ def build_cases(phase: str) -> list[MatrixCase]:
     ]
     storage: list[MatrixCase] = []
     for mode in ("eager", "cudagraph"):
+        storage.append(
+            _storage_case(
+                "falcon_h1",
+                "tiiuae/Falcon-H1-Tiny-90M-Instruct",
+                mode,
+                1,
+                ref_max_len=128,
+                max_model_len=128,
+                memory_utilization=0.2,
+            )
+        )
         storage.append(
             _storage_case(
                 "gemma3",

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -19,6 +19,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 
 MODEL_ALIASES = {
+    "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",
     "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -21,6 +21,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -17,6 +17,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",
     "qwen2": "Qwen/Qwen2.5-0.5B-Instruct",

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -17,6 +17,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",
     "qwen2_moe": "Qwen/Qwen1.5-MoE-A2.7B-Chat",


### PR DESCRIPTION
## Summary

- add TP1 BF16 V1 offline support for `FalconH1ForCausalLM` on vLLM 0.27.1
- add native architecture-neutral SSM input/output hook types and a separate SSM selection group
- remap Falcon-H1 to the DMI integration variant and register its compare worker
- derive reference-to-ClickHouse activation names from the native hook ABI table
- add Falcon-H1 model, non-unit scaling, SSM ABI, storage-name, black-box, and release-matrix contracts
- document the bounded capability manifest, production compiler regression, evidence, and exclusions

Integration dependency: https://github.com/ProjectDMX/vllm-DMI/pull/4

## Validation

- focused contracts: 257/257 passed
- official `tiiuae/Falcon-H1-0.5B-Instruct` public API eager and CUDA graph: 2/2 passed in 92.05 s
- official `tiiuae/Falcon-H1-Tiny-90M-Instruct` public API eager and CUDA graph: 2/2 passed
- Tiny eager full-hook transport: 54,560/54,560 byte-identical rows
- Tiny CUDA-graph full-hook transport: 54,560/54,560 byte-identical rows
- two independent production upstream CUDA-graph baselines produced identical normalized public outputs
- native monitoring extension rebuilt successfully against the pinned environment

## Supported cell

TP1, BF16, vLLM V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph. The hook inventory covers canonical attention/MLP/residual tensors plus scaled hidden-width SSM branch input/output boundaries.

TP>1, PP/DP/EP/SP, V2, serving, speculative execution, LoRA, quantization, prefix caching, remote-code variants, and internal Mamba convolution/recurrent/B/C/dt/cache tensors remain unclaimed.