### PR TITLE
Add OLMo 3 support for vLLM 0.27.1

### DIFF
--- a/docs/vllm-0.27.1-olmo3-audit.md
+++ b/docs/vllm-0.27.1-olmo3-audit.md
@@ -1,0 +1,81 @@
+# OLMo 3 model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only dense
+`Olmo3ForCausalLM` architecture in a bounded TP1 BF16 V1 offline cell. The
+runtime-qualified checkpoint is the official OLMo 3 7B Instruct model. OLMo 3
+is not treated as an OLMo 2 alias: vLLM 0.27.1 has a distinct post-norm
+implementation with Q/K normalization, a periodic sliding/full-attention
+schedule, and different RoPE behavior for the two attention kinds.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/olmo3.py`, `Olmo3ForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-olmo3`, commit `9f6a5c762bc5337aa08f38b31d70eb0020d60816` |
+| Production and storage checkpoint | `allenai/Olmo-3-7B-Instruct`, revision `6e5971d9eba42665f5bd5a0fcf047f299ce1dccc` |
+| Production shape | 7,298,011,136 BF16 parameters; hidden 4,096; intermediate 11,008; 32 layers; 32 query and KV heads; vocabulary 100,278; untied embeddings |
+| Attention schedule | Three 4,096-token sliding-attention layers followed by one full-attention layer, repeated eight times |
+| RoPE contract | sliding attention uses default RoPE at theta 500,000; full attention uses YaRN factor 8 with original context 8,192 |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph, all 389 declared hook families |
+| Excluded | other OLMo/OLMoE/hybrid architectures, TP>1, PP/DP/EP/SP, V2, serve/async, speculative, LoRA, quantization, prefix caching, pooling/task heads, attention weights/cache internals, and contexts beyond the bounded 128-token runtime cell |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01-M04 | independently adapted and runtime-verified | DMI follows the exact OLMo 3 post-norm arithmetic rather than a Llama/OLMo 2 template. Attention output is normalized before the first residual addition; MLP output is normalized before the second. Q/K hooks observe values after OLMo 3 Q/K RMSNorm and before type-specific RoPE. Upstream and monitored eager/graph execution on the official checkpoint close this path. |
+| M05-M09 | preserved but excluded from the support claim | The DMI class inherits OLMo 3's LoRA/PP interfaces, packed-module declarations, mapper, and intermediate-tensor behavior. The accepted runtime cell is deliberately limited to TP1 standard-HF BF16 offline generation; parallel, quantized, prefix-cache, speculative, serving, and alternate-task paths remain unclaimed. |
+| M10 | adapted-verified for official HF weights | The DMI wrapper preserves the upstream stacked QKV/gate-up mapper and `AutoWeightsLoader` method. The official three-shard checkpoint loaded in both upstream qualification modes, both public DMI modes, and four storage qualification runs. Untied `lm_head` construction is preserved. |
+| M11-M13 | verified for TP1 | Every layer exposes residual input, post-QK-norm/pre-RoPE Q/K, raw V, pre-output-projection Z, raw attention output, post-attention norm, completed mid-residual, MLP input, post-activation MLP width, raw MLP output, and post-feedforward norm. Five global families expose token IDs, embeddings, final residual, final norm, and logits. Thirty-two layers therefore expose 389 truthful families. |
+| M14 | fail-closed and bounded | DMI requires `model_type=olmo3`, SiLU, no attention bias, complete known layer types, a positive sliding window, and per-attention-type runtime RoPE parameters. Unknown layer types, missing schedule entries, and missing RoPE branches fail before model construction. |
+| M15 | verified with an ordered dense manifest | Hook specs follow the actual post-norm firing order. The manifest does not fabricate attention weights, KV-cache state, MoE routing, SSM state, or other OLMo-family internals absent from this implementation. |
+| R01-R03 | verified | Upstream resolves `Olmo3ForCausalLM` to `olmo3:Olmo3ForCausalLM`; DMI resolves it one-to-one to `olmo3_p:Olmo3PForCausalLM`. `Olmo3CompareForCausalLM` has a separate test-only registry entry. |
+| R04-R07 | verified | Official-wheel lazy registration, runtime remap, aliases, compare-worker registration, fail-closed schedule/RoPE checks, exact-tree instrumentation, manifest ordering, and concrete compare-backbone construction are locked by CPU contracts. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Upstream production qualification | The unmodified official 7B checkpoint loaded and generated successfully in eager and default CUDA-graph modes before DMI was enabled. |
+| Focused model and release contracts | The pre-public focused selections passed 26/26; the final aggregate focused sweep passed 321/321 in the pinned vLLM 0.27.1 / PyTorch 2.13.0+cu130 environment. They cover config rejection, disabled-forward delegation, post-norm ordering, Q/K normalization and RoPE boundaries, MLP post-activation placement, exact in-place identity, manifest inventory/order, concrete compare-backbone construction, registry, black-box, comparator, and matrix bounds. |
+| Production public eager+graph | 2/2 full 12-case API-only tests passed in 98.91 s. Baseline and monitored public outputs, request attribution, reverse-batch relations, generated metamorphic cases, and decision logprobs agreed in both modes. |
+| Production eager full-hook transport | 61,073/61,073 independent D2D reference rows were byte-identical to ClickHouse rows. One request stopped normally at EOS after 16 tokens, so 157 generated tokens multiplied by 389 families gives the exact retained row count. |
+| Production CUDA-graph full-hook transport | 61,073/61,073 independent D2D reference rows were byte-identical to ClickHouse rows, with the same deterministic EOS behavior. |
+| Reduced storage regression | Eager and CUDA graph each passed 3,112/3,112 before the full production cells were run. |
+| Lifecycle | Accepted runs flushed monitoring, shut down vLLM cleanly, removed only their capture-scoped ClickHouse rows, and left no residual GPU allocations. |
+
+The public oracle uses only vLLM's offline API and compares separate baseline
+and monitored processes. The storage oracle is independent: one execution
+contains both DMI ring producers and preallocated same-graph D2D copies, then
+compares every retained tensor and request/token range against ClickHouse byte
+for byte.
+
+## Fixture and implementation decisions
+
+Available tiny OLMo 3 fixtures were inspected but not used to qualify the
+production storage cell. One two-layer fixture covers sliding then full
+attention but does not preserve the production YaRN branch, while another
+contains YaRN metadata but only sliding-attention layers. Neither independently
+kills errors in the production combination of periodic schedule and
+attention-type-specific RoPE. The official 7B checkpoint therefore supplies
+both public and storage evidence; focused synthetic contracts separately reject
+missing schedule and RoPE branches.
+
+Disabled numerical-block hooks delegate directly to the exact upstream
+forward. When enabled, Q/K are observed after `_apply_qk_norm` but before RoPE;
+V is observed before attention, Z before the output projection, and MLP post
+after SiLU-and-multiply but before the down projection. The compare oracle
+constructs `Olmo3CompareModel` as the concrete backbone from initialization,
+which prevents the upstream compilation decorator from retaining an older
+model-wide forward.
+
+## Support decision
+
+`Olmo3ForCausalLM` is supported for the named
+`allenai/Olmo-3-7B-Instruct` TP1 BF16 V1 offline standard-HF
+eager/default-graph cell at the exact integration commit above. Other
+checkpoints that declare the same architecture remain runtime-unqualified, and
+every parallel, quantized, serving, speculative, alternate-task, or different
+OLMo-family path remains untested rather than implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -35,9 +35,9 @@ the registry source, but remains upstream-static evidence rather than DMI
 runtime support. Across the 41 representative checkpoints below:
 
 - all 41 resolve in vLLM 0.27.1;
-- 12 architectures have a DMI model remap on the current stacked expansion
+- 13 architectures have a DMI model remap on the current stacked expansion
   branch;
-- 29 are unmapped by DMI;
+- 28 are unmapped by DMI;
 - registry presence is upstream static evidence, not DMI runtime support.
 
 Between vLLM 0.25.1 and 0.27.1, the combined text/multimodal registry adds eight
@@ -140,6 +140,18 @@ logits scaling and adds the exact post-activation MLP boundary. Granite 4.1 8B
 and 30B share the statically audited dense path but remain runtime-unqualified;
 Granite MoE/hybrid/multimodal models, TP>1, prefix caching, quantization,
 serving, and speculative modes remain excluded.
+
+OLMo 3 is `supported` for the official `allenai/Olmo-3-7B-Instruct`
+checkpoint in the bounded TP1 BF16 V1 offline eager/default-graph cell at
+integration commit `9f6a5c762bc5`. The
+[`OLMo 3 audit`](vllm-0.27.1-olmo3-audit.md) records public API parity and
+byte-identical eager/graph storage on that same production checkpoint. Its
+389-family manifest follows OLMo 3's post-norm residual order and observes Q/K
+after Q/K normalization but before the layer-type-specific RoPE. Available tiny
+fixtures do not independently cover the production sliding/full schedule plus
+both default and YaRN RoPE branches, so they are not used to generalize the
+runtime verdict. Other checkpoints, TP>1, prefix caching, quantization, serving,
+speculative, and other OLMo-family architectures remain excluded.
 
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -151,6 +151,7 @@ _ARCH_REMAP = {
     "JambaForCausalLM": "JambaPForCausalLM",
     "Lfm2ForCausalLM": "Lfm2PForCausalLM",
     "MistralForCausalLM": "MistralPForCausalLM",
+    "Olmo3ForCausalLM": "Olmo3PForCausalLM",
     "Phi3ForCausalLM": "Phi3PForCausalLM",
     "Qwen2ForCausalLM": "Qwen2PForCausalLM",
     "Qwen2MoeForCausalLM": "Qwen2MoePForCausalLM",
@@ -180,6 +181,7 @@ _DMI_MODEL_VARIANTS = {
     "Qwen3PForCausalLM": "qwen3_p:Qwen3PForCausalLM",
     "LlamaPForCausalLM": "llama_p:LlamaPForCausalLM",
     "MistralPForCausalLM": "mistral_p:MistralPForCausalLM",
+    "Olmo3PForCausalLM": "olmo3_p:Olmo3PForCausalLM",
     "Phi3PForCausalLM": "phi3_p:Phi3PForCausalLM",
 }
 

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -42,6 +42,9 @@ _COMPARE_MODEL_VARIANTS = {
     "MistralCompareForCausalLM": (
         "mistral_compare:MistralCompareForCausalLM"
     ),
+    "Olmo3CompareForCausalLM": (
+        "olmo3_compare:Olmo3CompareForCausalLM"
+    ),
     "Phi3CompareForCausalLM": (
         "phi3_compare:Phi3CompareForCausalLM"
     ),
@@ -79,6 +82,7 @@ _ARCH_REMAP = {
     "Qwen3ForCausalLM": "Qwen3CompareForCausalLM",
     "LlamaForCausalLM": "LlamaCompareForCausalLM",
     "MistralForCausalLM": "MistralCompareForCausalLM",
+    "Olmo3ForCausalLM": "Olmo3CompareForCausalLM",
     "Phi3ForCausalLM": "Phi3CompareForCausalLM",
 }
 

--- a/tests/test_olmo3_p_contract.py
+++ b/tests/test_olmo3_p_contract.py
@@ -1,0 +1,465 @@
+"""CPU contracts for bounded OLMo 3 monitoring support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from integration.vllm_adapter import _ARCH_REMAP
+from monitoring.hook_points import HookPoint
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_MLP_POST,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+)
+from vllm.model_executor.models.olmo3 import (
+    Olmo3Attention,
+    Olmo3DecoderLayer,
+    Olmo3ForCausalLM,
+    Olmo3MLP,
+    Olmo3Model,
+)
+import vllm.model_executor.models.olmo3_compare as olmo3_compare
+from vllm.model_executor.models.olmo3_p import (
+    Olmo3PAttention,
+    Olmo3PDecoderLayer,
+    Olmo3PForCausalLM,
+    Olmo3PMLP,
+    Olmo3PModel,
+    _instrument_olmo3_model,
+    _require_supported_olmo3_config,
+)
+
+
+pytestmark = pytest.mark.framework_fork
+
+
+def _config(**overrides) -> SimpleNamespace:
+    values = {
+        "model_type": "olmo3",
+        "hidden_act": "silu",
+        "attention_bias": False,
+        "num_hidden_layers": 2,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "sliding_window": 4096,
+        "rope_parameters": {
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 500000.0,
+            },
+            "full_attention": {
+                "rope_type": "yarn",
+                "factor": 8.0,
+            },
+        },
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_olmo3_preserves_upstream_loader_and_class_contracts() -> None:
+    assert _ARCH_REMAP["Olmo3ForCausalLM"] == "Olmo3PForCausalLM"
+    assert issubclass(Olmo3PForCausalLM, Olmo3ForCausalLM)
+    assert issubclass(Olmo3PModel, Olmo3Model)
+    assert issubclass(Olmo3PDecoderLayer, Olmo3DecoderLayer)
+    assert issubclass(Olmo3PAttention, Olmo3Attention)
+    assert issubclass(Olmo3PMLP, Olmo3MLP)
+    assert (
+        Olmo3PForCausalLM.packed_modules_mapping
+        == Olmo3ForCausalLM.packed_modules_mapping
+    )
+    assert (
+        Olmo3PForCausalLM.hf_to_vllm_mapper
+        is Olmo3ForCausalLM.hf_to_vllm_mapper
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides, error, match",
+    [
+        ({"model_type": "olmo2"}, NotImplementedError, "model_type"),
+        ({"hidden_act": "gelu"}, NotImplementedError, "hidden_act"),
+        ({"attention_bias": True}, NotImplementedError, "attention_bias"),
+        ({"layer_types": ["full_attention"]}, ValueError, "layer_types"),
+        (
+            {"layer_types": ["linear_attention", "full_attention"]},
+            NotImplementedError,
+            "layer types",
+        ),
+        ({"sliding_window": 0}, NotImplementedError, "sliding_window"),
+        ({"rope_parameters": None}, NotImplementedError, "rope_parameters"),
+        (
+            {"rope_parameters": {"sliding_attention": {}}},
+            NotImplementedError,
+            "full_attention",
+        ),
+    ],
+)
+def test_olmo3_fails_closed_outside_audited_attention_contract(
+    overrides,
+    error,
+    match,
+) -> None:
+    with pytest.raises(error, match=match):
+        _require_supported_olmo3_config(_config(**overrides))
+
+
+def test_olmo3_accepts_mixed_sliding_and_full_attention() -> None:
+    _require_supported_olmo3_config(_config())
+
+
+def test_olmo3_disabled_layer_hooks_delegate_to_upstream(monkeypatch) -> None:
+    layer = Olmo3PDecoderLayer.__new__(Olmo3PDecoderLayer)
+    nn.Module.__init__(layer)
+    for name in (
+        "resid_pre",
+        "attn_out",
+        "ln1",
+        "resid_mid",
+        "mlp_in",
+        "mlp_out",
+        "ln2",
+    ):
+        hook = HookPoint()
+        hook.enabled = False
+        setattr(layer, f"hook_{name}", hook)
+    marker = torch.tensor([[17.0]])
+    observed = []
+
+    def upstream_forward(_self, positions, hidden_states):
+        observed.append((positions, hidden_states))
+        return marker
+
+    monkeypatch.setattr(Olmo3DecoderLayer, "forward", upstream_forward)
+    positions = torch.tensor([0])
+    hidden_states = torch.tensor([[1.0]])
+
+    result = layer(positions, hidden_states)
+
+    assert result is marker
+    assert observed == [(positions, hidden_states)]
+
+
+class _Scale(nn.Module):
+    def __init__(self, amount: float) -> None:
+        super().__init__()
+        self.amount = amount
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        return value * self.amount
+
+
+class _Attention(nn.Module):
+    def forward(self, _positions, hidden_states):
+        return hidden_states + 3
+
+
+class _Add(nn.Module):
+    def __init__(self, amount: float) -> None:
+        super().__init__()
+        self.amount = amount
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        return value + self.amount
+
+
+def test_olmo3_hooks_follow_post_norm_execution_order() -> None:
+    layer = Olmo3PDecoderLayer.__new__(Olmo3PDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.self_attn = _Attention()
+    layer.post_attention_layernorm = _Scale(2)
+    layer.mlp = _Add(5)
+    layer.post_feedforward_layernorm = _Scale(2)
+    captured: dict[str, torch.Tensor] = {}
+    for name in (
+        "resid_pre",
+        "attn_out",
+        "ln1",
+        "resid_mid",
+        "mlp_in",
+        "mlp_out",
+        "ln2",
+    ):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key,
+                output.clone(),
+            )
+        )
+        setattr(layer, f"hook_{name}", hook)
+
+    output = layer(torch.tensor([0]), torch.tensor([[1.0]]))
+
+    assert captured["resid_pre"].item() == 1.0
+    assert captured["attn_out"].item() == 4.0
+    assert captured["ln1"].item() == 8.0
+    assert captured["resid_mid"].item() == 9.0
+    assert captured["mlp_in"].item() == 9.0
+    assert captured["mlp_out"].item() == 14.0
+    assert captured["ln2"].item() == 28.0
+    assert output.item() == 37.0
+
+
+class _Projection(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+
+    def forward(self, _value: torch.Tensor):
+        return self.output, None
+
+
+class _Rotary(nn.Module):
+    def forward(self, _positions, q, k):
+        return q + 100, k + 100
+
+
+class _AttentionKernel(nn.Module):
+    def forward(self, q, _k, _v):
+        return q
+
+
+class _Activation(nn.Module):
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        return value[:, :2] * 3
+
+
+def test_olmo3_attention_hooks_bind_post_qk_norm_pre_rope_values() -> None:
+    attention = Olmo3PAttention.__new__(Olmo3PAttention)
+    nn.Module.__init__(attention)
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.num_heads = 2
+    attention.num_kv_heads = 1
+    attention.head_dim = 2
+    qkv = torch.arange(8, dtype=torch.float32).reshape(1, 8)
+    attention.qkv_proj = _Projection(qkv)
+    attention._apply_qk_norm = lambda q, k: (q + 10, k + 20)
+    attention.rotary_emb = _Rotary()
+    attention.attn = _AttentionKernel()
+    attention.o_proj = _Projection(torch.full((1, 4), 99.0))
+    captured: dict[str, torch.Tensor] = {}
+    for name in ("q", "k", "v", "z"):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key,
+                output.clone(),
+            )
+        )
+        setattr(attention, f"hook_{name}", hook)
+
+    output = attention(torch.tensor([0]), torch.zeros(1, 4))
+
+    assert output.tolist() == [[99.0, 99.0, 99.0, 99.0]]
+    assert torch.equal(captured["q"], (qkv[:, :4] + 10).view(1, 2, 2))
+    assert torch.equal(captured["k"], (qkv[:, 4:6] + 20).view(1, 1, 2))
+    assert torch.equal(captured["v"], qkv[:, 6:].view(1, 1, 2))
+    assert torch.equal(captured["z"], qkv[:, :4] + 110)
+
+
+def test_olmo3_mlp_post_hook_binds_pre_down_projection_activation() -> None:
+    mlp = Olmo3PMLP.__new__(Olmo3PMLP)
+    nn.Module.__init__(mlp)
+    gate_up = torch.tensor([[1.0, 2.0, 7.0, 11.0]])
+    mlp.gate_up_proj = _Projection(gate_up)
+    mlp.act_fn = _Activation()
+    mlp.down_proj = _Projection(torch.tensor([[19.0, 23.0]]))
+    captured: list[torch.Tensor] = []
+    mlp.hook_post = HookPoint()
+    mlp.hook_post.register_forward_hook(
+        lambda _module, _args, output: captured.append(output.clone())
+    )
+
+    output = mlp(torch.zeros(1, 2))
+
+    assert output.tolist() == [[19.0, 23.0]]
+    assert len(captured) == 1
+    assert captured[0].tolist() == [[3.0, 6.0]]
+
+
+def test_olmo3_instruments_the_upstream_tree_in_place() -> None:
+    model = Olmo3Model.__new__(Olmo3Model)
+    nn.Module.__init__(model)
+    model.config = _config()
+    model.start_layer = 0
+    model.end_layer = 1
+    layer = Olmo3DecoderLayer.__new__(Olmo3DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.self_attn = Olmo3Attention.__new__(Olmo3Attention)
+    nn.Module.__init__(layer.self_attn)
+    layer.mlp = Olmo3MLP.__new__(Olmo3MLP)
+    nn.Module.__init__(layer.mlp)
+    model.layers = nn.ModuleList([layer])
+    model.config.num_hidden_layers = 1
+    model.config.layer_types = ["full_attention"]
+    identities = (id(model), id(layer), id(layer.self_attn), id(layer.mlp))
+
+    result = _instrument_olmo3_model(model)
+
+    assert (id(result), id(layer), id(layer.self_attn), id(layer.mlp)) == identities
+    assert isinstance(result, Olmo3PModel)
+    assert isinstance(layer, Olmo3PDecoderLayer)
+    assert isinstance(layer.self_attn, Olmo3PAttention)
+    assert isinstance(layer.mlp, Olmo3PMLP)
+
+
+def _fake_hooked_model() -> Olmo3PForCausalLM:
+    subject = Olmo3PForCausalLM.__new__(Olmo3PForCausalLM)
+    nn.Module.__init__(subject)
+    attention = SimpleNamespace(
+        **{f"hook_{name}": HookPoint() for name in ("q", "k", "v", "z")}
+    )
+    mlp = SimpleNamespace(hook_post=HookPoint())
+    layer = SimpleNamespace(
+        self_attn=attention,
+        mlp=mlp,
+        **{
+            f"hook_{name}": HookPoint()
+            for name in (
+                "resid_pre",
+                "attn_out",
+                "ln1",
+                "resid_mid",
+                "mlp_in",
+                "mlp_out",
+                "ln2",
+            )
+        },
+    )
+    subject.config = _config(num_hidden_layers=1, layer_types=["full_attention"])
+    subject.model = SimpleNamespace(
+        start_layer=0,
+        end_layer=1,
+        layers=[layer],
+        hook_embed=HookPoint(),
+        hook_resid_final=HookPoint(),
+        hook_final_ln=HookPoint(),
+    )
+    subject.hook_token_ids = HookPoint()
+    subject.hook_final_logits = HookPoint()
+    return subject
+
+
+def test_olmo3_manifest_is_truthful_and_in_firing_order() -> None:
+    specs = _fake_hooked_model().get_hook_specs()
+
+    assert [spec.hook_type for spec in specs] == [
+        HOOK_TYPE_TOKEN_IDS,
+        HOOK_TYPE_EMBED,
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_Q,
+        HOOK_TYPE_K,
+        HOOK_TYPE_V,
+        HOOK_TYPE_Z,
+        HOOK_TYPE_ATTN_OUT,
+        HOOK_TYPE_LN1,
+        HOOK_TYPE_RESID_MID,
+        HOOK_TYPE_MLP_IN,
+        HOOK_TYPE_MLP_POST,
+        HOOK_TYPE_MLP_OUT,
+        HOOK_TYPE_LN2,
+        HOOK_TYPE_RESID_FINAL,
+        HOOK_TYPE_FINAL_LN,
+        HOOK_TYPE_FINAL_LOGITS,
+    ]
+    assert all(spec.module is not None for spec in specs)
+
+
+def test_olmo3_model_wide_manifest_has_no_runtime_modules() -> None:
+    specs = _fake_hooked_model().get_hook_specs(model_wide=True)
+
+    assert len(specs) == 17
+    assert all(spec.module is None for spec in specs)
+
+
+def test_olmo3_compare_uses_the_constructed_mlp_width(monkeypatch) -> None:
+    layer = SimpleNamespace(
+        mlp=SimpleNamespace(
+            down_proj=SimpleNamespace(input_size_per_partition=256)
+        ),
+        self_attn=SimpleNamespace(),
+    )
+    model = SimpleNamespace(start_layer=0, end_layer=1, layers=[layer])
+    subject = SimpleNamespace(
+        config=SimpleNamespace(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            intermediate_size=128,
+            vocab_size=65_536,
+        ),
+        model=model,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+    )
+    monkeypatch.setattr(
+        olmo3_compare,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        olmo3_compare.torch,
+        "empty",
+        lambda *shape, **_kwargs: shape,
+    )
+
+    olmo3_compare.Olmo3CompareForCausalLM.allocate_compare_buffers(
+        subject,
+        8,
+        vllm_config,
+    )
+
+    assert layer.mlp._buf_mlp_post == (8, 256)
+
+
+def test_olmo3_compare_constructs_concrete_compiled_backbone(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_init(
+        self,
+        *,
+        vllm_config,
+        prefix,
+        model_type=Olmo3PModel,
+    ) -> None:
+        nn.Module.__init__(self)
+        observed.update(
+            vllm_config=vllm_config,
+            prefix=prefix,
+            model_type=model_type,
+        )
+
+    monkeypatch.setattr(Olmo3PForCausalLM, "__init__", fake_init)
+    config = object()
+
+    olmo3_compare.Olmo3CompareForCausalLM(
+        vllm_config=config,
+        prefix="model",
+    )
+
+    assert observed == {
+        "vllm_config": config,
+        "prefix": "model",
+        "model_type": olmo3_compare.Olmo3CompareModel,
+    }

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -44,6 +44,7 @@ MODEL_ALIASES = {
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
     "mistral": "openaccess-ai-collective/tiny-mistral",
+    "olmo3": "allenai/Olmo-3-7B-Instruct",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 MODEL_ARG = os.environ.get("DMI_BLACKBOX_MODEL", "qwen2")

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -81,6 +81,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
         "qwen3",
         "llama",
         "mistral",
+        "olmo3",
         "phi3",
         "qwen2_moe",
     ):
@@ -102,6 +103,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "storage-jamba-cudagraph-tp1" in case_ids
     assert "storage-lfm2-eager-tp1" in case_ids
     assert "storage-lfm2-cudagraph-tp1" in case_ids
+    assert "storage-olmo3-eager-tp1" in case_ids
+    assert "storage-olmo3-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -218,6 +221,27 @@ def test_granite_matrix_uses_the_qualified_41_production_checkpoint() -> None:
         assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.6"
         assert storage.environment["E2E_REF_MAX_LEN"] == "128"
         assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+
+
+def test_olmo3_matrix_uses_the_branch_complete_production_checkpoint() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-olmo3-tp1-eager-graph"]
+    assert public.model_id == "allenai/Olmo-3-7B-Instruct"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "allenai/Olmo-3-7B-Instruct"
+    )
+    assert public.environment["DMI_BLACKBOX_GPU_MEMORY_UTILIZATION"] == "0.85"
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "128"
+
+    for mode in ("eager", "cudagraph"):
+        storage = cases[f"storage-olmo3-{mode}-tp1"]
+        assert storage.model_id == "allenai/Olmo-3-7B-Instruct"
+        assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.9"
+        assert storage.environment["E2E_REF_MAX_LEN"] == "128"
+        assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+        assert storage.environment["E2E_RING_PAYLOAD_MB"] == "1024"
+        assert storage.environment["E2E_RING_PINNED_MB"] == "1024"
 
 
 def test_static_only_models_use_bounded_two_gpu_storage_cells():

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -118,12 +118,13 @@ def _storage_case(
     model_subfolder: str | None = None,
     max_model_len: int = 512,
     memory_utilization: float | None = None,
+    ring_mb: int = 512,
 ) -> MatrixCase:
     environment = {
         "DMX_HOOK_SELECTION": hook_selection,
         "E2E_REF_MAX_LEN": str(ref_max_len),
-        "E2E_RING_PAYLOAD_MB": "512",
-        "E2E_RING_PINNED_MB": "512",
+        "E2E_RING_PAYLOAD_MB": str(ring_mb),
+        "E2E_RING_PINNED_MB": str(ring_mb),
         "E2E_GPU_MEM_UTIL": str(
             memory_utilization
             if memory_utilization is not None
@@ -164,6 +165,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "tests/test_granite_p_contract.py",
             "tests/test_jamba_p_contract.py",
             "tests/test_lfm2_p_contract.py",
+            "tests/test_olmo3_p_contract.py",
             "tests/test_conv_hook_contract.py",
             "tests/test_gemma3_p_inventory.py",
             "tests/test_model_artifacts.py",
@@ -186,6 +188,14 @@ def build_cases(phase: str) -> list[MatrixCase]:
         environment={},
     )
     public = [
+        _blackbox_case(
+            "olmo3",
+            "allenai/Olmo-3-7B-Instruct",
+            tp_size=1,
+            memory_utilization=0.85,
+            model_arg="allenai/Olmo-3-7B-Instruct",
+            max_model_len=128,
+        ),
         _blackbox_case(
             "granite",
             "ibm-granite/granite-4.1-3b",
@@ -267,6 +277,18 @@ def build_cases(phase: str) -> list[MatrixCase]:
     ]
     storage: list[MatrixCase] = []
     for mode in ("eager", "cudagraph"):
+        storage.append(
+            _storage_case(
+                "olmo3",
+                "allenai/Olmo-3-7B-Instruct",
+                mode,
+                1,
+                ref_max_len=128,
+                max_model_len=128,
+                memory_utilization=0.9,
+                ring_mb=1024,
+            )
+        )
         storage.append(
             _storage_case(
                 "granite",

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -30,6 +30,7 @@ MODEL_ALIASES = {
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
     "mistral": "openaccess-ai-collective/tiny-mistral",
+    "olmo3": "allenai/Olmo-3-7B-Instruct",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -31,6 +31,7 @@ _MODEL_ALIASES = {
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
     "mistral": "openaccess-ai-collective/tiny-mistral",
+    "olmo3": "allenai/Olmo-3-7B-Instruct",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -28,6 +28,7 @@ _MODEL_ALIASES = {
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
     "mistral": "openaccess-ai-collective/tiny-mistral",
+    "olmo3": "allenai/Olmo-3-7B-Instruct",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -27,6 +27,7 @@ _MODEL_ALIASES = {
     "qwen3": "Qwen/Qwen3-0.6B",
     "llama": "meta-llama/Llama-3.1-8B-Instruct",
     "mistral": "openaccess-ai-collective/tiny-mistral",
+    "olmo3": "allenai/Olmo-3-7B-Instruct",
     "phi3": "optimum-intel-internal-testing/tiny-random-Phi3ForCausalLM",
 }
 


### PR DESCRIPTION
## Summary

- remap Olmo3ForCausalLM to a dedicated OLMo 3 DMI implementation
- add production/test aliases, compare-worker registration, and lazy model registration coverage
- add focused contracts for post-norm order, post-QK-norm/pre-RoPE observation, MLP boundaries, fail-closed config handling, manifest order, and compare-buffer construction
- add OLMo 3 to the public and storage release matrix using the official 7B checkpoint
- document the exact TP1 BF16 V1 offline support cell and update model coverage to 13 mapped / 28 unmapped architectures

This PR is stacked on the Granite root PR. The support claim is limited to allenai/Olmo-3-7B-Instruct, TP1, BF16, standard Hugging Face weights, V1 offline LLM, eager and default CUDA Graph. Other OLMo families and parallel, quantized, serving, speculative, prefix-cache, and alternate-task paths remain excluded.

## Validation

- focused contracts: 321/321 passed
- official-checkpoint API-only black-box: 2/2 eager/graph passed in 98.91 seconds
- monitored-versus-upstream smoke: zero output mismatches in eager and graph
- reduced storage value oracle: 3,112/3,112 rows in each mode
- production storage value oracle: 61,073/61,073 rows in each mode
- source compile and diff checks passed

The complete cross-model 42-case clean-commit matrix remains pending because the fixed second physical GPU is occupied by an unrelated job; no unrelated GPU process was interrupted. Model-specific public and storage release gates are complete.
