### PR TITLE
Add Apertus support for vLLM 0.27.1

### DIFF
--- a/docs/vllm-0.27.1-apertus-audit.md
+++ b/docs/vllm-0.27.1-apertus-audit.md
@@ -1,0 +1,80 @@
+# Apertus model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only dense
+`ApertusForCausalLM` architecture in a bounded TP1 BF16 V1 offline cell. The
+runtime-qualified checkpoint is the official Apertus 8B Instruct model. The
+implementation is treated as its own contract rather than a Llama alias:
+Apertus uses xIELU, per-head Q/K RMSNorm, fused pre-norm residual arithmetic,
+and Llama-3-scaled RoPE with a model-specific theta.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/apertus.py`, `ApertusForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-apertus`, commit `3d5e5fb6b87febb0ed0b18ba58f2a417916ce186` |
+| Production and storage checkpoint | `swiss-ai/Apertus-8B-Instruct-2509`, revision `b946d40447b2b597999b9c86d44bee0b452c919f` |
+| Production shape | 8,053,338,240 BF16 parameters; hidden 4,096; intermediate 21,504; 32 layers; 32 query heads; 8 KV heads; vocabulary 131,072; untied embeddings |
+| Block contract | bias-free fused pre-norm residual blocks; per-head Q/K RMSNorm; xIELU MLP with a single up projection |
+| RoPE contract | Llama-3 scaling factor 8, high-frequency factor 4, low-frequency factor 1, original context 8,192, theta 12,000,000 |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph, Python xIELU fallback, all 389 declared hook families, bounded 128-token runtime |
+| Excluded | Apertus v1.1 and 70B configurations, optional fused xIELU extension, tied-embedding/default-RoPE branches, TP>1, PP/DP/EP/SP, V2, serve/async, speculative, Eagle, LoRA, quantization, prefix caching, pooling/task heads, attention weights/cache internals, and contexts beyond the bounded runtime cell |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01-M04 | independently adapted and runtime-verified | DMI follows the exact upstream xIELU, Q/K normalization, RoPE, fused add-RMSNorm, attention, and residual order. Q/K are observed after per-head RMSNorm and before RoPE; V is raw; Z precedes the output projection. Upstream and monitored eager/graph execution on the frozen checkpoint close the path. |
+| M05-M09 | preserved but excluded from the support claim | The monitored class preserves the upstream loader, mapper, packed-module declarations, embedding interface, intermediate-tensor behavior, and inherited LoRA/Eagle/PP interfaces. The accepted cell deliberately excludes parallel, speculative, adapter, quantized, prefix-cache, serving, and alternate-task paths. |
+| M10 | adapted-verified for official HF weights | The monitored wrapper preserves upstream `WeightsMapper`, packed QKV declarations, and `AutoWeightsLoader`. The official four-shard checkpoint loaded in upstream qualification, public baseline/monitored, and storage runs. The checkpoint's untied `lm_head` path is preserved. |
+| M11-M13 | verified for TP1 | Every layer exposes completed residual input, normalized attention input, post-QK-norm/pre-RoPE Q/K, raw V, pre-output-projection Z, raw attention output, completed mid-residual, normalized MLP input, post-xIELU MLP width, and raw MLP output. Five global families expose token IDs, embeddings, final residual, final norm, and logits. Thirty-two layers therefore expose 389 truthful families. |
+| M14 | fail-closed and bounded | Construction requires `model_type=apertus`, xIELU, pre-norm, Q/K normalization, causal bias-free blocks, untied embeddings, no mixed/sliding layer schedule, unit logits scaling, and the exact audited Llama-3 RoPE fields. Semantically different known configuration branches fail before model construction; same-contract size variants remain outside the runtime verdict. |
+| M15 | verified with an ordered dense manifest | Hook specs follow the fused pre-norm firing order. The manifest does not invent attention weights, KV-cache state, gates, experts, recurrent state, or other families absent from this implementation. |
+| R01-R03 | verified | Upstream resolves `ApertusForCausalLM` to `apertus:ApertusForCausalLM`; DMI remaps it one-to-one to `apertus_p:ApertusPForCausalLM`. `ApertusCompareForCausalLM` has a separate test-only registry entry. |
+| R04-R07 | verified | Runtime remap, public aliases, compare-worker registration, fail-closed config checks, exact hook placement, manifest order, concrete compiled backbone construction, and matrix resource bounds are locked by focused contracts. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Upstream production qualification | The unmodified official 8B checkpoint loaded and generated successfully in eager and default CUDA-graph modes before DMI was enabled. |
+| Focused model and release contracts | Apertus contract plus release-matrix selections passed 45/45; the final cross-model focused sweep passed 346/346 in the pinned vLLM 0.27.1 / PyTorch 2.13.0+cu130 environment. They cover remap/registry, config rejection, fused pre-norm order, Q/K normalization and RoPE boundaries, xIELU placement, manifest inventory/order, model-wide specs, concrete compare construction, request/lifecycle behavior, and bounded release cells. |
+| Production public eager+graph | 2/2 full 12-case API-only tests passed in 112.33 s. Separate baseline and monitored processes agreed exactly on tokens, text, finish reasons, request attribution, reverse-batch relations, generated metamorphic cases, and public decision logprobs in both modes. |
+| Public-oracle mutation found during qualification | The first CUDA-graph attempt correctly rejected token, finish-reason, and decision-logprob drift. A second independent upstream baseline was stable. The cause was an extra `hidden_states + residual` node inserted only to observe pre-norm state; capture now reads the completed residual returned by fused add-RMSNorm. The final full eager/graph rerun has zero strict and zero ambiguity mismatches. |
+| Production eager full-hook transport | 62,240/62,240 independent same-graph D2D reference rows were byte-identical to ClickHouse rows. Eight requests generated 20 tokens each; 160 generated tokens multiplied by 389 families gives the exact retained row count. |
+| Production CUDA-graph full-hook transport | 62,240/62,240 independent same-graph D2D reference rows were byte-identical to ClickHouse rows, including the corrected fused residual capture. |
+| Reduced storage regression | Eager and CUDA graph each passed 3,112/3,112 after the fused-residual correction. |
+| Lifecycle | Accepted runs flushed monitoring, shut down vLLM cleanly, removed only capture-scoped ClickHouse rows, and left no residual GPU allocation. |
+
+The public oracle uses only vLLM's offline API and compares separate baseline
+and monitored processes. The storage oracle is independent: one execution
+contains both DMI ring producers and preallocated same-graph D2D copies, then
+compares every retained tensor and request/token range against ClickHouse byte
+for byte.
+
+## Fixture and implementation decisions
+
+An available tiny Apertus fixture follows the original 8B-style Llama-3 RoPE
+branch, but it is not used to generalize production storage. All public and
+storage evidence comes from the frozen official 8B checkpoint. Newer Apertus
+v1.1 small configs use materially different tied-embedding and RoPE branches,
+so they are explicitly outside this verdict rather than inherited by name.
+
+The optional CUDA-fused xIELU package was not installed. This cell therefore
+qualifies vLLM's official Python xIELU fallback in both eager and default graph
+modes. Disabled numerical-block hooks delegate to the exact upstream forward.
+When enabled, `resid_pre` and `resid_final` read the completed residuals returned
+by their fused add-RMSNorm operations instead of adding second CUDA nodes; the
+compare oracle copies the same authoritative tensors. The compare model is constructed as a concrete
+backbone so the upstream compilation decorator cannot retain an older
+model-wide forward.
+
+## Support decision
+
+`ApertusForCausalLM` is supported for the named
+`swiss-ai/Apertus-8B-Instruct-2509` TP1 BF16 V1 offline standard-HF
+eager/default-graph cell at the exact integration commit above. Other Apertus
+checkpoints and every parallel, quantized, serving, speculative, optional
+fused-xIELU, alternate-task, or different configuration path remain untested
+rather than implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -35,9 +35,9 @@ the registry source, but remains upstream-static evidence rather than DMI
 runtime support. Across the 41 representative checkpoints below:
 
 - all 41 resolve in vLLM 0.27.1;
-- 13 architectures have a DMI model remap on the current stacked expansion
+- 14 architectures have a DMI model remap on the current stacked expansion
   branch;
-- 28 are unmapped by DMI;
+- 27 are unmapped by DMI;
 - registry presence is upstream static evidence, not DMI runtime support.
 
 Between vLLM 0.25.1 and 0.27.1, the combined text/multimodal registry adds eight
@@ -152,6 +152,18 @@ fixtures do not independently cover the production sliding/full schedule plus
 both default and YaRN RoPE branches, so they are not used to generalize the
 runtime verdict. Other checkpoints, TP>1, prefix caching, quantization, serving,
 speculative, and other OLMo-family architectures remain excluded.
+
+Apertus is `supported` for the official
+`swiss-ai/Apertus-8B-Instruct-2509` checkpoint in the bounded TP1 BF16 V1
+offline eager/default-graph cell at integration commit `3d5e5fb6b87f`. The
+[`Apertus audit`](vllm-0.27.1-apertus-audit.md) records strict public API parity
+and byte-identical eager/graph storage on that same production checkpoint. Its
+389-family manifest follows fused pre-norm residual arithmetic, observes Q/K
+after per-head normalization and before RoPE, and exposes the xIELU
+post-activation boundary. The verdict covers vLLM's Python xIELU fallback;
+Apertus v1.1/70B and other config branches, the optional fused xIELU extension,
+TP>1, prefix caching, quantization, serving, and speculative modes remain
+excluded.
 
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -144,6 +144,7 @@ _LLAMA_COMPAT_ARCHES = {
 }
 
 _ARCH_REMAP = {
+    "ApertusForCausalLM": "ApertusPForCausalLM",
     "FalconH1ForCausalLM": "FalconH1PForCausalLM",
     "Gemma3ForCausalLM": "Gemma3PForCausalLM",
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
@@ -170,6 +171,7 @@ _ARCH_REMAP = {
 # Lazy strings are important here: importing model implementations eagerly in
 # the parent process can initialize CUDA before vLLM forks its workers.
 _DMI_MODEL_VARIANTS = {
+    "ApertusPForCausalLM": "apertus_p:ApertusPForCausalLM",
     "FalconH1PForCausalLM": "falcon_h1_p:FalconH1PForCausalLM",
     "Gemma3PForCausalLM": "gemma3_p:Gemma3PForCausalLM",
     "GPT2PLMHeadModel": "gpt2_p:GPT2PLMHeadModel",

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -18,6 +18,9 @@ from monitoring.ring_transport import HOOK_TYPE_TO_SHORT_NAME, HookSpec
 
 
 _COMPARE_MODEL_VARIANTS = {
+    "ApertusCompareForCausalLM": (
+        "apertus_compare:ApertusCompareForCausalLM"
+    ),
     "FalconH1CompareForCausalLM": (
         "falcon_h1_compare:FalconH1CompareForCausalLM"
     ),
@@ -72,6 +75,7 @@ _register_compare_model_variants()
 
 
 _ARCH_REMAP = {
+    "ApertusForCausalLM": "ApertusCompareForCausalLM",
     "FalconH1ForCausalLM": "FalconH1CompareForCausalLM",
     "Gemma3ForCausalLM": "Gemma3CompareForCausalLM",
     "GPT2LMHeadModel": "GPT2CompareForCausalLM",

--- a/tests/test_apertus_p_contract.py
+++ b/tests/test_apertus_p_contract.py
@@ -1,0 +1,539 @@
+"""CPU contracts for bounded Apertus monitoring support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from integration.vllm_adapter import _ARCH_REMAP
+from monitoring.hook_points import HookPoint
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_MLP_POST,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+)
+from vllm.model_executor.models.apertus import (
+    ApertusAttention,
+    ApertusDecoderLayer,
+    ApertusForCausalLM,
+    ApertusMLP,
+    ApertusModel,
+)
+import vllm.model_executor.models.apertus_compare as apertus_compare
+from vllm.model_executor.models.apertus_p import (
+    ApertusPAttention,
+    ApertusPDecoderLayer,
+    ApertusPForCausalLM,
+    ApertusPMLP,
+    ApertusPModel,
+    _require_supported_apertus_config,
+)
+
+
+pytestmark = pytest.mark.framework_fork
+
+
+def _config(**overrides) -> SimpleNamespace:
+    values = {
+        "model_type": "apertus",
+        "hidden_act": "xielu",
+        "post_norm": False,
+        "qk_norm": True,
+        "attention_bias": False,
+        "mlp_bias": False,
+        "is_causal": True,
+        "layer_types": None,
+        "logit_scale": None,
+        "tie_word_embeddings": False,
+        "num_hidden_layers": 2,
+        "rope_parameters": {
+            "factor": 8.0,
+            "high_freq_factor": 4.0,
+            "low_freq_factor": 1.0,
+            "original_max_position_embeddings": 8192,
+            "rope_type": "llama3",
+            "rope_theta": 12_000_000,
+        },
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_apertus_preserves_upstream_loader_and_class_contracts() -> None:
+    assert _ARCH_REMAP["ApertusForCausalLM"] == "ApertusPForCausalLM"
+    assert issubclass(ApertusPForCausalLM, ApertusForCausalLM)
+    assert issubclass(ApertusPModel, ApertusModel)
+    assert issubclass(ApertusPDecoderLayer, ApertusDecoderLayer)
+    assert issubclass(ApertusPAttention, ApertusAttention)
+    assert issubclass(ApertusPMLP, ApertusMLP)
+    assert (
+        ApertusPForCausalLM.packed_modules_mapping
+        == ApertusForCausalLM.packed_modules_mapping
+    )
+    assert (
+        ApertusPForCausalLM.hf_to_vllm_mapper
+        is ApertusForCausalLM.hf_to_vllm_mapper
+    )
+    assert ApertusPForCausalLM.embedding_modules == (
+        ApertusForCausalLM.embedding_modules
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"model_type": "llama"}, "model_type"),
+        ({"hidden_act": "silu"}, "hidden_act"),
+        ({"post_norm": True}, "post_norm"),
+        ({"qk_norm": False}, "qk_norm"),
+        ({"attention_bias": True}, "bias-free"),
+        ({"mlp_bias": True}, "bias-free"),
+        ({"is_causal": False}, "causal"),
+        ({"layer_types": ["sliding_attention"] * 2}, "schedules"),
+        ({"logit_scale": 0.5}, "logit scale"),
+        ({"tie_word_embeddings": True}, "untied"),
+        ({"rope_parameters": None}, "rope_parameters"),
+        (
+            {
+                "rope_parameters": {
+                    "factor": 8.0,
+                    "high_freq_factor": 4.0,
+                    "low_freq_factor": 1.0,
+                    "original_max_position_embeddings": 8192,
+                    "rope_type": "default",
+                    "rope_theta": 12_000_000,
+                }
+            },
+            "rope_type",
+        ),
+    ],
+)
+def test_apertus_fails_closed_outside_audited_8b_contract(
+    overrides,
+    match,
+) -> None:
+    with pytest.raises(NotImplementedError, match=match):
+        _require_supported_apertus_config(_config(**overrides))
+
+
+def test_apertus_accepts_the_official_8b_config_contract() -> None:
+    _require_supported_apertus_config(_config())
+
+
+def test_apertus_disabled_layer_hooks_delegate_to_upstream(monkeypatch) -> None:
+    layer = ApertusPDecoderLayer.__new__(ApertusPDecoderLayer)
+    nn.Module.__init__(layer)
+    for name in (
+        "resid_pre",
+        "ln1",
+        "attn_out",
+        "resid_mid",
+        "ln2",
+        "mlp_in",
+        "mlp_out",
+    ):
+        hook = HookPoint()
+        hook.enabled = False
+        setattr(layer, f"hook_{name}", hook)
+    marker = (torch.tensor([[17.0]]), torch.tensor([[19.0]]))
+    observed = []
+
+    def upstream_forward(_self, positions, hidden_states, residual):
+        observed.append((positions, hidden_states, residual))
+        return marker
+
+    monkeypatch.setattr(ApertusDecoderLayer, "forward", upstream_forward)
+    positions = torch.tensor([0])
+    hidden_states = torch.tensor([[1.0]])
+    residual = torch.tensor([[2.0]])
+
+    result = layer(positions, hidden_states, residual)
+
+    assert result is marker
+    assert observed == [(positions, hidden_states, residual)]
+
+
+class _FusedNorm(nn.Module):
+    def forward(self, value: torch.Tensor, residual: torch.Tensor | None = None):
+        if residual is None:
+            return value * 2
+        completed = value + residual
+        return completed * 2, completed
+
+
+class _Attention(nn.Module):
+    def forward(self, *, positions, hidden_states):
+        return hidden_states + 3
+
+
+class _Add(nn.Module):
+    def forward(self, value: torch.Tensor):
+        return value + 5
+
+
+def test_apertus_hooks_follow_fused_prenorm_execution_order() -> None:
+    layer = ApertusPDecoderLayer.__new__(ApertusPDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.attention_layernorm = _FusedNorm()
+    layer.self_attn = _Attention()
+    layer.feedforward_layernorm = _FusedNorm()
+    layer.mlp = _Add()
+    captured: dict[str, torch.Tensor] = {}
+    for name in (
+        "resid_pre",
+        "ln1",
+        "attn_out",
+        "resid_mid",
+        "ln2",
+        "mlp_in",
+        "mlp_out",
+    ):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key, output.clone()
+            )
+        )
+        setattr(layer, f"hook_{name}", hook)
+
+    hidden_states, residual = layer(
+        torch.tensor([0]), torch.tensor([[1.0]]), None
+    )
+
+    assert {name: value.item() for name, value in captured.items()} == {
+        "resid_pre": 1.0,
+        "ln1": 2.0,
+        "attn_out": 5.0,
+        "resid_mid": 6.0,
+        "ln2": 12.0,
+        "mlp_in": 12.0,
+        "mlp_out": 17.0,
+    }
+    assert hidden_states.item() == 17.0
+    assert residual.item() == 6.0
+
+
+def test_apertus_resid_pre_uses_completed_fused_norm_residual() -> None:
+    layer = ApertusPDecoderLayer.__new__(ApertusPDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.attention_layernorm = _FusedNorm()
+    layer.self_attn = _Attention()
+    layer.feedforward_layernorm = _FusedNorm()
+    layer.mlp = _Add()
+    captured: list[torch.Tensor] = []
+    for name in (
+        "resid_pre",
+        "ln1",
+        "attn_out",
+        "resid_mid",
+        "ln2",
+        "mlp_in",
+        "mlp_out",
+    ):
+        hook = HookPoint()
+        hook.enabled = name == "resid_pre"
+        if name == "resid_pre":
+            hook.register_forward_hook(
+                lambda _module, _args, output: captured.append(output.clone())
+            )
+        setattr(layer, f"hook_{name}", hook)
+
+    layer(
+        torch.tensor([0]),
+        torch.tensor([[2.0]]),
+        torch.tensor([[3.0]]),
+    )
+
+    assert len(captured) == 1
+    assert captured[0].item() == 5.0
+
+
+class _FinalLayer(nn.Module):
+    def forward(self, _positions, _hidden_states, _residual):
+        return torch.tensor([[2.0]]), torch.tensor([[3.0]])
+
+
+class _FinalNorm(nn.Module):
+    def forward(self, value, residual):
+        return value * 10, value + residual
+
+
+def test_apertus_resid_final_uses_completed_fused_norm_residual(
+    monkeypatch,
+) -> None:
+    import vllm.model_executor.models.apertus_p as apertus_p
+
+    model = ApertusPModel.__new__(ApertusPModel)
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([_FinalLayer()])
+    model.start_layer = 0
+    model.end_layer = 1
+    model.norm = _FinalNorm()
+    model.hook_embed = HookPoint()
+    model.hook_embed.enabled = False
+    model.hook_final_ln = HookPoint()
+    model.hook_final_ln.enabled = False
+    model.hook_resid_final = HookPoint()
+    captured: list[torch.Tensor] = []
+    model.hook_resid_final.register_forward_hook(
+        lambda _module, _args, output: captured.append(output.clone())
+    )
+    model._maybe_add_hidden_state = lambda values, *_args: values
+    monkeypatch.setattr(
+        apertus_p,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    output = model.forward(
+        None,
+        torch.tensor([0]),
+        None,
+        inputs_embeds=torch.tensor([[1.0]]),
+    )
+
+    assert output.item() == 20.0
+    assert len(captured) == 1
+    assert captured[0].item() == 5.0
+
+
+class _Projection(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+
+    def forward(self, _value: torch.Tensor):
+        return self.output, None
+
+
+class _Norm(nn.Module):
+    def __init__(self, amount: float) -> None:
+        super().__init__()
+        self.amount = amount
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        return value + self.amount
+
+
+class _Rotary(nn.Module):
+    def forward(self, _positions, q, k):
+        return q + 100, k + 100
+
+
+class _AttentionKernel(nn.Module):
+    def forward(self, q, _k, _v):
+        return q
+
+
+def test_apertus_attention_hooks_bind_post_qk_norm_pre_rope_values() -> None:
+    attention = ApertusPAttention.__new__(ApertusPAttention)
+    nn.Module.__init__(attention)
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.num_heads = 2
+    attention.num_kv_heads = 1
+    attention.head_dim = 2
+    qkv = torch.arange(8, dtype=torch.float32).reshape(1, 8)
+    attention.qkv_proj = _Projection(qkv)
+    attention.q_norm = _Norm(10)
+    attention.k_norm = _Norm(20)
+    attention.rotary_emb = _Rotary()
+    attention.attn = _AttentionKernel()
+    attention.o_proj = _Projection(torch.full((1, 4), 99.0))
+    captured: dict[str, torch.Tensor] = {}
+    for name in ("q", "k", "v", "z"):
+        hook = HookPoint()
+        hook.register_forward_hook(
+            lambda _module, _args, output, key=name: captured.setdefault(
+                key, output.clone()
+            )
+        )
+        setattr(attention, f"hook_{name}", hook)
+
+    output = attention(torch.tensor([0]), torch.zeros(1, 4))
+
+    assert output.tolist() == [[99.0, 99.0, 99.0, 99.0]]
+    assert torch.equal(captured["q"], (qkv[:, :4].view(1, 2, 2) + 10))
+    assert torch.equal(captured["k"], (qkv[:, 4:6].view(1, 1, 2) + 20))
+    assert torch.equal(captured["v"], qkv[:, 6:].view(1, 1, 2))
+    assert torch.equal(captured["z"], qkv[:, :4] + 110)
+
+
+def test_apertus_mlp_post_hook_binds_xielu_before_down_projection() -> None:
+    mlp = ApertusPMLP.__new__(ApertusPMLP)
+    nn.Module.__init__(mlp)
+    mlp.up_proj = _Projection(torch.tensor([[1.0, 2.0]]))
+    mlp.act_fn = _Norm(10)
+    mlp.down_proj = _Projection(torch.tensor([[19.0, 23.0]]))
+    captured: list[torch.Tensor] = []
+    mlp.hook_post = HookPoint()
+    mlp.hook_post.register_forward_hook(
+        lambda _module, _args, output: captured.append(output.clone())
+    )
+
+    output = mlp(torch.zeros(1, 2))
+
+    assert output.tolist() == [[19.0, 23.0]]
+    assert len(captured) == 1
+    assert captured[0].tolist() == [[11.0, 12.0]]
+
+
+def _fake_hooked_model() -> ApertusPForCausalLM:
+    subject = ApertusPForCausalLM.__new__(ApertusPForCausalLM)
+    nn.Module.__init__(subject)
+    attention = SimpleNamespace(
+        **{f"hook_{name}": HookPoint() for name in ("q", "k", "v", "z")}
+    )
+    mlp = SimpleNamespace(hook_post=HookPoint())
+    layer = SimpleNamespace(
+        self_attn=attention,
+        mlp=mlp,
+        **{
+            f"hook_{name}": HookPoint()
+            for name in (
+                "resid_pre",
+                "ln1",
+                "attn_out",
+                "resid_mid",
+                "ln2",
+                "mlp_in",
+                "mlp_out",
+            )
+        },
+    )
+    subject.config = _config(num_hidden_layers=1)
+    subject.model = SimpleNamespace(
+        start_layer=0,
+        end_layer=1,
+        layers=[layer],
+        hook_embed=HookPoint(),
+        hook_resid_final=HookPoint(),
+        hook_final_ln=HookPoint(),
+    )
+    subject.hook_token_ids = HookPoint()
+    subject.hook_final_logits = HookPoint()
+    return subject
+
+
+def test_apertus_manifest_is_truthful_and_in_firing_order() -> None:
+    specs = _fake_hooked_model().get_hook_specs()
+
+    assert [spec.hook_type for spec in specs] == [
+        HOOK_TYPE_TOKEN_IDS,
+        HOOK_TYPE_EMBED,
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_LN1,
+        HOOK_TYPE_Q,
+        HOOK_TYPE_K,
+        HOOK_TYPE_V,
+        HOOK_TYPE_Z,
+        HOOK_TYPE_ATTN_OUT,
+        HOOK_TYPE_RESID_MID,
+        HOOK_TYPE_LN2,
+        HOOK_TYPE_MLP_IN,
+        HOOK_TYPE_MLP_POST,
+        HOOK_TYPE_MLP_OUT,
+        HOOK_TYPE_RESID_FINAL,
+        HOOK_TYPE_FINAL_LN,
+        HOOK_TYPE_FINAL_LOGITS,
+    ]
+    assert all(spec.module is not None for spec in specs)
+
+
+def test_apertus_model_wide_manifest_has_no_runtime_modules() -> None:
+    specs = _fake_hooked_model().get_hook_specs(model_wide=True)
+
+    assert len(specs) == 17
+    assert all(spec.module is None for spec in specs)
+
+
+def test_apertus_compare_uses_the_constructed_mlp_width(monkeypatch) -> None:
+    layer = SimpleNamespace(
+        mlp=SimpleNamespace(down_proj=SimpleNamespace(input_size_per_partition=256)),
+        self_attn=SimpleNamespace(),
+    )
+    subject = SimpleNamespace(
+        config=SimpleNamespace(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            intermediate_size=128,
+            vocab_size=65_536,
+            head_dim=None,
+        ),
+        model=SimpleNamespace(start_layer=0, end_layer=1, layers=[layer]),
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+    )
+    monkeypatch.setattr(
+        apertus_compare,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        apertus_compare.torch,
+        "empty",
+        lambda *shape, **_kwargs: shape,
+    )
+
+    apertus_compare.ApertusCompareForCausalLM.allocate_compare_buffers(
+        subject,
+        8,
+        vllm_config,
+    )
+
+    assert layer.mlp._buf_mlp_post == (8, 256)
+
+
+def test_apertus_compare_constructs_concrete_model_and_layer(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_init(
+        self,
+        *,
+        vllm_config,
+        prefix,
+        model_type=ApertusPModel,
+        layer_type=ApertusPDecoderLayer,
+    ) -> None:
+        nn.Module.__init__(self)
+        observed.update(
+            vllm_config=vllm_config,
+            prefix=prefix,
+            model_type=model_type,
+            layer_type=layer_type,
+        )
+
+    monkeypatch.setattr(ApertusPForCausalLM, "__init__", fake_init)
+    config = object()
+
+    apertus_compare.ApertusCompareForCausalLM(
+        vllm_config=config,
+        prefix="model",
+    )
+
+    assert observed == {
+        "vllm_config": config,
+        "prefix": "model",
+        "model_type": apertus_compare.ApertusCompareModel,
+        "layer_type": apertus_compare.ApertusCompareDecoderLayer,
+    }

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -33,6 +33,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 RUNNER = PROJECT_ROOT / "tests/tools/smoke_vllm_model.py"
 CASES = PROJECT_ROOT / "tests/blackbox/cases/transparency.json"
 MODEL_ALIASES = {
+    "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -71,6 +71,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
 
     assert "focused-cpu-contracts" in case_ids
     for model in (
+        "apertus",
         "falcon_h1",
         "gemma3",
         "gpt2",
@@ -105,6 +106,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "storage-lfm2-cudagraph-tp1" in case_ids
     assert "storage-olmo3-eager-tp1" in case_ids
     assert "storage-olmo3-cudagraph-tp1" in case_ids
+    assert "storage-apertus-eager-tp1" in case_ids
+    assert "storage-apertus-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -242,6 +245,25 @@ def test_olmo3_matrix_uses_the_branch_complete_production_checkpoint() -> None:
         assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
         assert storage.environment["E2E_RING_PAYLOAD_MB"] == "1024"
         assert storage.environment["E2E_RING_PINNED_MB"] == "1024"
+
+
+def test_apertus_matrix_uses_the_qualified_8b_production_checkpoint() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-apertus-tp1-eager-graph"]
+    assert public.model_id == "swiss-ai/Apertus-8B-Instruct-2509"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "swiss-ai/Apertus-8B-Instruct-2509"
+    )
+    assert public.environment["DMI_BLACKBOX_GPU_MEMORY_UTILIZATION"] == "0.9"
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "128"
+
+    for mode in ("eager", "cudagraph"):
+        storage = cases[f"storage-apertus-{mode}-tp1"]
+        assert storage.model_id == "swiss-ai/Apertus-8B-Instruct-2509"
+        assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.93"
+        assert storage.environment["E2E_REF_MAX_LEN"] == "128"
+        assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
 
 
 def test_static_only_models_use_bounded_two_gpu_storage_cells():

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -161,6 +161,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "-q",
             "tests/test_vllm_version_compat.py",
             "tests/test_vllm_027_model_contracts.py",
+            "tests/test_apertus_p_contract.py",
             "tests/test_falcon_h1_p_contract.py",
             "tests/test_granite_p_contract.py",
             "tests/test_jamba_p_contract.py",
@@ -188,6 +189,14 @@ def build_cases(phase: str) -> list[MatrixCase]:
         environment={},
     )
     public = [
+        _blackbox_case(
+            "apertus",
+            "swiss-ai/Apertus-8B-Instruct-2509",
+            tp_size=1,
+            memory_utilization=0.9,
+            model_arg="swiss-ai/Apertus-8B-Instruct-2509",
+            max_model_len=128,
+        ),
         _blackbox_case(
             "olmo3",
             "allenai/Olmo-3-7B-Instruct",
@@ -277,6 +286,17 @@ def build_cases(phase: str) -> list[MatrixCase]:
     ]
     storage: list[MatrixCase] = []
     for mode in ("eager", "cudagraph"):
+        storage.append(
+            _storage_case(
+                "apertus",
+                "swiss-ai/Apertus-8B-Instruct-2509",
+                mode,
+                1,
+                ref_max_len=128,
+                max_model_len=128,
+                memory_utilization=0.93,
+            )
+        )
         storage.append(
             _storage_case(
                 "olmo3",

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -19,6 +19,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 
 MODEL_ALIASES = {
+    "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -21,6 +21,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -17,6 +17,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -17,6 +17,7 @@ import torch
 
 
 _MODEL_ALIASES = {
+    "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",


### PR DESCRIPTION
## Summary

- remap `ApertusForCausalLM` to the bounded monitored variant from ProjectDMX/vllm-DMI#9
- add public/compare runner aliases and the production checkpoint to the release matrix
- add focused fail-closed, fused-residual, Q/K normalization, xIELU, manifest, registry, and compare-construction contracts
- publish the exact Apertus support audit and update vLLM 0.27.1 model coverage to 14 mapped / 27 unmapped representative architectures

## Qualified cell

- vLLM `v0.27.1` at `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac`
- integration commit `3d5e5fb6b87febb0ed0b18ba58f2a417916ce186`
- checkpoint `swiss-ai/Apertus-8B-Instruct-2509` at `b946d40447b2b597999b9c86d44bee0b452c919f`
- TP1 BF16 V1 offline `LLM`, eager/default graph, max model length 128
- standard Hugging Face weights, Python xIELU fallback, all 389 declared hook families

The audit deliberately excludes Apertus v1.1/70B and other checkpoint/config branches, fused xIELU, TP>1, PP/DP/EP/SP, V2, serving, speculative/Eagle, LoRA, quantization, prefix caching, and alternate tasks.

## Validation

- unmodified upstream official checkpoint: eager and CUDA graph passed
- public API black box: 2/2 eager+graph tests passed in 112.33 s with exact tokens, completion metadata, attribution, generated/metamorphic cases, and decision logprobs
- reduced full-hook storage: eager 3,112/3,112; graph 3,112/3,112 byte-identical rows
- production full-hook storage: eager 62,240/62,240; graph 62,240/62,240 byte-identical rows
- focused Apertus and matrix contracts: 45/45
- final cross-model focused suite: 346/346
- Python compile and both worktree diff checks passed
- `dmi-port-vllm` skill updated with the observed compiled-path regression rule and validated successfully

The API-only oracle caught a real CUDA-graph transparency defect during qualification: a mathematically equivalent monitoring-only residual add changed public generation. An independent baseline replica was stable, the hook was moved to the authoritative residual returned by fused add-RMSNorm, and every public/storage result above was rerun on the final implementation.

## Dependency and pending matrix

This stacked PR depends on ProjectDMX/vllm-DMI#9 and is based on the OLMo 3 support branch. The full current-supported cross-model GPU matrix remains pending until two designated physical GPUs are simultaneously idle; unrelated jobs currently occupy the other cards and were not interrupted.
