### PR TITLE
Add ERNIE 4.5 support for vLLM 0.27.1

### DIFF
--- a/docs/vllm-0.27.1-ernie45-audit.md
+++ b/docs/vllm-0.27.1-ernie45-audit.md
@@ -1,0 +1,73 @@
+# ERNIE 4.5 dense model support audit for vLLM 0.27.1
+
+This agent-authored record supports the text-only dense
+`Ernie4_5ForCausalLM` architecture in a bounded TP1 BF16 V1 offline cell. The
+runtime-qualified checkpoint is Baidu's official 0.3B pretraining model. The
+upstream implementation is a deliberately thin Llama subclass, but its
+post-construction rotary and output-projection changes are part of the model
+contract and are replayed explicitly by both DMI variants.
+
+## Frozen identity and cell
+
+| Field | Value |
+| --- | --- |
+| Upstream vLLM | `v0.27.1` / `6e448d0ea9bf3d88d898b65449ca6dc2aec170ac` |
+| Upstream implementation | `vllm/model_executor/models/ernie45.py`, `Ernie4_5ForCausalLM` |
+| DMI integration | branch `dmi-v0.27.1-ernie45`, commit `6f2cf03f68e411e89732f74ec8ef3d588735d2a7` |
+| Production and storage checkpoint | `baidu/ERNIE-4.5-0.3B-PT`, revision `b565cf6caebdb7a1eadf00100857b1ed5e044f12` |
+| Production shape | 360,748,032 BF16 parameters; hidden 1,024; intermediate 3,072; 18 layers; 16 query heads; 2 KV heads; head dimension 128; vocabulary 103,424; tied embeddings |
+| Block contract | bias-free causal Llama block with SiLU gated MLP; output projection has no bias and returns its bias separately; non-NeoX rotary layout |
+| RoPE contract | default RoPE, theta 500,000 |
+| Claimed cell | TP1, BF16, V1 offline `LLM`, standard Hugging Face weights, eager and default CUDA graph, all 203 declared hook families, bounded 128-token runtime |
+| Excluded | Other ERNIE sizes, ERNIE MoE/VL architectures, biased or untied configurations, alternate activation/layer schedules/RoPE, TP>1, PP/DP/EP/SP, V2, serve/async, speculative, Eagle, LoRA, quantization, pooling/task heads, attention weights/cache internals, and contexts beyond the bounded runtime cell |
+
+## M/R checklist
+
+| IDs | Verdict | Evidence and rationale |
+| --- | --- | --- |
+| M01-M04 | independently adapted and runtime-verified | DMI reuses the audited hooked Llama computation while preserving ERNIE's explicit head dimension, non-NeoX rotary layout, bias-free output projection, causal attention, SiLU MLP, and residual order. Separate upstream and monitored eager/graph executions on the frozen checkpoint close the runtime path. |
+| M05-M09 | preserved but excluded from the support claim | The monitored class preserves the upstream Llama loader, packed-module declarations, mapper, embedding interface, compilation dynamic dimensions, and inherited intermediate/parallel/speculative interfaces. Those broader execution modes remain outside this verdict. |
+| M10 | adapted-verified for official HF weights | The official safetensors checkpoint loaded in upstream qualification, public baseline/monitored, and storage runs. Tied embeddings and the inherited Llama weight mapper/loader are unchanged. |
+| M11-M13 | verified for TP1 | Each layer exposes completed residual input, normalized attention input, pre-RoPE Q/K/V, pre-output-projection Z, raw attention output, completed mid-residual, normalized MLP input, post-activation MLP width, and raw MLP output. Five global families expose token IDs, embeddings, final residual, final norm, and logits. Eighteen layers therefore expose 203 truthful families. |
+| M14 | fail-closed and bounded | Construction requires `model_type=ernie4_5`, SiLU, causal bias-free blocks, tied embeddings, no mixed/sliding layer schedule, unit logits scaling, an explicit positive head dimension, and exact default RoPE theta 500,000. Semantically different known branches fail before model construction. |
+| M15 | verified with an ordered dense manifest | Hook specs retain the inherited Llama firing order and do not claim attention weights, KV-cache state, gates, experts, recurrent state, or other unavailable internals. |
+| R01-R03 | verified | Upstream resolves `Ernie4_5ForCausalLM` to `ernie45:Ernie4_5ForCausalLM`; DMI remaps it one-to-one to `ernie45_p:Ernie4_5PForCausalLM`. `Ernie4_5CompareForCausalLM` has a separate test-only registry entry. |
+| R04-R07 | verified | Runtime remap, lazy registration, compare-worker registration, config rejection, upstream post-init replay, hook inventory, public aliases, and bounded release cells are locked by focused contracts. |
+
+## Runtime evidence
+
+| Gate | Result |
+| --- | --- |
+| Upstream production qualification | The unmodified official 0.3B checkpoint loaded and generated successfully in eager and default CUDA-graph modes before DMI was enabled. |
+| Focused model and release contracts | The initial ERNIE-focused selection passed 46/46. The final cross-model focused sweep passed 363/363 in the pinned vLLM 0.27.1 environment. It covers remap/registry behavior, fail-closed configuration branches, exact upstream post-init replay, manifest inventory/order, aliases, storage runners, and release-matrix bounds. |
+| Production public eager+graph | 2/2 full API-only tests passed in 84.06 s. Separate baseline and monitored processes had zero strict and zero ambiguity mismatches across tokens, text, finish reasons, request attribution, reverse-batch relations, generated metamorphic cases, and public decision logprobs. |
+| Reduced eager full-hook transport | 1,624/1,624 independent same-graph D2D reference rows were byte-identical to ClickHouse rows. |
+| Reduced CUDA-graph full-hook transport | 1,624/1,624 independent same-graph D2D reference rows were byte-identical to ClickHouse rows. |
+| Production eager full-hook transport | 16,240/16,240 independent same-graph D2D reference rows were byte-identical to ClickHouse rows. The eight requests reached EOS after nine generated tokens each, below the configured 20-token ceiling. |
+| Production CUDA-graph full-hook transport | 16,240/16,240 independent same-graph D2D reference rows were byte-identical to ClickHouse rows, with the same deterministic EOS behavior. |
+| Lifecycle | Accepted runs flushed monitoring, shut down vLLM cleanly, removed only capture-scoped ClickHouse rows, and left no residual GPU allocation. |
+
+The public oracle uses only vLLM's offline API and compares separate baseline
+and monitored processes. The storage oracle is independent: one execution
+contains both DMI ring producers and preallocated same-graph D2D copies, then
+compares every retained tensor and request/token range against ClickHouse byte
+for byte.
+
+## Implementation decision
+
+Both DMI classes inherit the existing Llama monitoring implementation because
+the upstream ERNIE class inherits the same Llama implementation without a new
+forward. Inheritance alone is not the compatibility argument: after base model
+construction, DMI explicitly repeats upstream's `is_neox_style=False`, removes
+the attention output-projection bias, and enables `skip_bias_add`. Focused tests
+lock those assignments so a future upstream subclass change cannot silently
+fall through the alias.
+
+## Support decision
+
+`Ernie4_5ForCausalLM` is supported for the named
+`baidu/ERNIE-4.5-0.3B-PT` TP1 BF16 V1 offline standard-HF
+eager/default-graph cell at the exact integration commit above. Other ERNIE
+checkpoints and every MoE, multimodal, parallel, quantized, serving,
+speculative, alternate-task, or different configuration path remain untested
+rather than implicitly supported.

--- a/docs/vllm-model-coverage-roadmap.md
+++ b/docs/vllm-model-coverage-roadmap.md
@@ -35,9 +35,9 @@ the registry source, but remains upstream-static evidence rather than DMI
 runtime support. Across the 41 representative checkpoints below:
 
 - all 41 resolve in vLLM 0.27.1;
-- 14 architectures have a DMI model remap on the current stacked expansion
+- 15 architectures have a DMI model remap on the current stacked expansion
   branch;
-- 27 are unmapped by DMI;
+- 26 are unmapped by DMI;
 - registry presence is upstream static evidence, not DMI runtime support.
 
 Between vLLM 0.25.1 and 0.27.1, the combined text/multimodal registry adds eight
@@ -164,6 +164,17 @@ post-activation boundary. The verdict covers vLLM's Python xIELU fallback;
 Apertus v1.1/70B and other config branches, the optional fused xIELU extension,
 TP>1, prefix caching, quantization, serving, and speculative modes remain
 excluded.
+
+ERNIE 4.5 dense is `supported` for the official
+`baidu/ERNIE-4.5-0.3B-PT` checkpoint in the bounded TP1 BF16 V1 offline
+eager/default-graph cell at integration commit `6f2cf03f68e4`. The
+[`ERNIE 4.5 audit`](vllm-0.27.1-ernie45-audit.md) records strict public API
+parity and byte-identical eager/graph storage on that same production
+checkpoint. Its 203-family manifest follows the inherited dense Llama block,
+while the monitored and compare variants explicitly replay ERNIE's non-NeoX
+rotary and bias-free output-projection post-init changes. Other ERNIE sizes,
+ERNIE MoE/VL, alternate configuration branches, TP>1, prefix caching,
+quantization, serving, and speculative modes remain excluded.
 
 For each row, use an upstream tiny/random fixture for fast focused tests when
 available, then require one real-checkpoint baseline/monitored run before moving

--- a/integration/vllm_adapter.py
+++ b/integration/vllm_adapter.py
@@ -145,6 +145,7 @@ _LLAMA_COMPAT_ARCHES = {
 
 _ARCH_REMAP = {
     "ApertusForCausalLM": "ApertusPForCausalLM",
+    "Ernie4_5ForCausalLM": "Ernie4_5PForCausalLM",
     "FalconH1ForCausalLM": "FalconH1PForCausalLM",
     "Gemma3ForCausalLM": "Gemma3PForCausalLM",
     "GPT2LMHeadModel": "GPT2PLMHeadModel",
@@ -172,6 +173,7 @@ _ARCH_REMAP = {
 # the parent process can initialize CUDA before vLLM forks its workers.
 _DMI_MODEL_VARIANTS = {
     "ApertusPForCausalLM": "apertus_p:ApertusPForCausalLM",
+    "Ernie4_5PForCausalLM": "ernie45_p:Ernie4_5PForCausalLM",
     "FalconH1PForCausalLM": "falcon_h1_p:FalconH1PForCausalLM",
     "Gemma3PForCausalLM": "gemma3_p:Gemma3PForCausalLM",
     "GPT2PLMHeadModel": "gpt2_p:GPT2PLMHeadModel",

--- a/tests/compare_worker.py
+++ b/tests/compare_worker.py
@@ -21,6 +21,9 @@ _COMPARE_MODEL_VARIANTS = {
     "ApertusCompareForCausalLM": (
         "apertus_compare:ApertusCompareForCausalLM"
     ),
+    "Ernie4_5CompareForCausalLM": (
+        "ernie45_compare:Ernie4_5CompareForCausalLM"
+    ),
     "FalconH1CompareForCausalLM": (
         "falcon_h1_compare:FalconH1CompareForCausalLM"
     ),
@@ -76,6 +79,7 @@ _register_compare_model_variants()
 
 _ARCH_REMAP = {
     "ApertusForCausalLM": "ApertusCompareForCausalLM",
+    "Ernie4_5ForCausalLM": "Ernie4_5CompareForCausalLM",
     "FalconH1ForCausalLM": "FalconH1CompareForCausalLM",
     "Gemma3ForCausalLM": "Gemma3CompareForCausalLM",
     "GPT2LMHeadModel": "GPT2CompareForCausalLM",

--- a/tests/test_ernie45_p_contract.py
+++ b/tests/test_ernie45_p_contract.py
@@ -1,0 +1,209 @@
+"""CPU contracts for bounded ERNIE 4.5 dense monitoring support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from integration.vllm_adapter import _ARCH_REMAP
+from monitoring.hook_points import HookPoint
+from monitoring.ring_transport import (
+    HOOK_TYPE_ATTN_OUT,
+    HOOK_TYPE_EMBED,
+    HOOK_TYPE_FINAL_LN,
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_K,
+    HOOK_TYPE_LN1,
+    HOOK_TYPE_LN2,
+    HOOK_TYPE_MLP_IN,
+    HOOK_TYPE_MLP_OUT,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_FINAL,
+    HOOK_TYPE_RESID_MID,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_TOKEN_IDS,
+    HOOK_TYPE_V,
+    HOOK_TYPE_Z,
+)
+from vllm.model_executor.models.ernie45 import Ernie4_5ForCausalLM
+from vllm.model_executor.models.ernie45_compare import (
+    Ernie4_5CompareForCausalLM,
+)
+from vllm.model_executor.models.ernie45_p import (
+    Ernie4_5PForCausalLM,
+    _apply_ernie45_attention_contract,
+    _require_supported_ernie45_config,
+)
+from vllm.model_executor.models.llama_compare import LlamaCompareForCausalLM
+from vllm.model_executor.models.llama_p import LlamaPForCausalLM
+
+
+pytestmark = pytest.mark.framework_fork
+
+
+def _config(**overrides) -> SimpleNamespace:
+    values = {
+        "model_type": "ernie4_5",
+        "hidden_act": "silu",
+        "use_bias": False,
+        "is_causal": True,
+        "layer_types": None,
+        "tie_word_embeddings": True,
+        "logit_scale": None,
+        "head_dim": 128,
+        "rope_parameters": {
+            "rope_type": "default",
+            "rope_theta": 500_000.0,
+        },
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _vllm_config(**overrides) -> SimpleNamespace:
+    return SimpleNamespace(model_config=SimpleNamespace(hf_config=_config(**overrides)))
+
+
+def test_ernie45_preserves_upstream_llama_class_contracts() -> None:
+    assert _ARCH_REMAP["Ernie4_5ForCausalLM"] == "Ernie4_5PForCausalLM"
+    assert issubclass(Ernie4_5ForCausalLM, nn.Module)
+    assert issubclass(Ernie4_5PForCausalLM, LlamaPForCausalLM)
+    assert issubclass(Ernie4_5CompareForCausalLM, LlamaCompareForCausalLM)
+    assert (
+        Ernie4_5PForCausalLM.packed_modules_mapping
+        == Ernie4_5ForCausalLM.packed_modules_mapping
+    )
+    assert (
+        vars(Ernie4_5PForCausalLM.hf_to_vllm_mapper)
+        == vars(Ernie4_5ForCausalLM.hf_to_vllm_mapper)
+    )
+    assert (
+        Ernie4_5PForCausalLM.embedding_modules
+        == Ernie4_5ForCausalLM.embedding_modules
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"model_type": "llama"}, "model_type"),
+        ({"hidden_act": "gelu"}, "SiLU"),
+        ({"use_bias": True}, "bias-free"),
+        ({"is_causal": False}, "causal"),
+        ({"layer_types": ["sliding_attention"]}, "schedules"),
+        ({"tie_word_embeddings": False}, "tied"),
+        ({"logit_scale": 0.5}, "logit scale"),
+        ({"head_dim": None}, "head_dim"),
+        ({"rope_parameters": None}, "rope_parameters"),
+        (
+            {
+                "rope_parameters": {
+                    "rope_type": "yarn",
+                    "rope_theta": 500_000.0,
+                }
+            },
+            "default RoPE",
+        ),
+        (
+            {
+                "rope_parameters": {
+                    "rope_type": "default",
+                    "rope_theta": 10_000.0,
+                }
+            },
+            "theta 500000",
+        ),
+    ],
+)
+def test_ernie45_fails_closed_outside_the_audited_contract(
+    overrides,
+    match,
+) -> None:
+    with pytest.raises(NotImplementedError, match=match):
+        _require_supported_ernie45_config(_vllm_config(**overrides))
+
+
+def test_ernie45_accepts_the_official_03b_config_contract() -> None:
+    _require_supported_ernie45_config(_vllm_config())
+
+
+def test_ernie45_replays_non_neox_rope_and_bias_free_output_projection() -> None:
+    rotary = SimpleNamespace(is_neox_style=True)
+    output_projection = SimpleNamespace(
+        bias=torch.tensor([1.0]),
+        skip_bias_add=False,
+    )
+    model = SimpleNamespace(
+        layers=[
+            SimpleNamespace(
+                self_attn=SimpleNamespace(
+                    rotary_emb=rotary,
+                    o_proj=output_projection,
+                )
+            )
+        ]
+    )
+
+    _apply_ernie45_attention_contract(model)
+
+    assert rotary.is_neox_style is False
+    assert output_projection.bias is None
+    assert output_projection.skip_bias_add is True
+
+
+def test_ernie45_model_wide_manifest_has_203_truthful_families() -> None:
+    subject = Ernie4_5PForCausalLM.__new__(Ernie4_5PForCausalLM)
+    nn.Module.__init__(subject)
+    subject.model = SimpleNamespace(layers=[None] * 18)
+    specs = subject.get_hook_specs(model_wide=True)
+    layer_types = [
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_LN1,
+        HOOK_TYPE_Q,
+        HOOK_TYPE_K,
+        HOOK_TYPE_V,
+        HOOK_TYPE_Z,
+        HOOK_TYPE_ATTN_OUT,
+        HOOK_TYPE_RESID_MID,
+        HOOK_TYPE_LN2,
+        HOOK_TYPE_MLP_IN,
+        HOOK_TYPE_MLP_OUT,
+    ]
+
+    assert [spec.hook_type for spec in specs] == [
+        HOOK_TYPE_TOKEN_IDS,
+        HOOK_TYPE_EMBED,
+        *(layer_types * 18),
+        HOOK_TYPE_RESID_FINAL,
+        HOOK_TYPE_FINAL_LN,
+        HOOK_TYPE_FINAL_LOGITS,
+    ]
+    assert len(specs) == 203
+    assert all(spec.module is None for spec in specs)
+
+
+def test_ernie45_global_hook_points_keep_llama_dtypes_and_token_axes() -> None:
+    subject = Ernie4_5PForCausalLM.__new__(Ernie4_5PForCausalLM)
+    nn.Module.__init__(subject)
+    subject.model = SimpleNamespace(
+        start_layer=0,
+        end_layer=0,
+        layers=[],
+        hook_embed=HookPoint(),
+        hook_resid_final=HookPoint(),
+        hook_final_ln=HookPoint(),
+    )
+    subject.hook_token_ids = HookPoint()
+    subject.hook_final_logits = HookPoint()
+
+    specs = subject.get_hook_specs()
+
+    assert specs[0].dtype == torch.int32
+    assert specs[0].dim0_is_actual_tokens is True
+    assert specs[1].dim0_is_actual_tokens is True
+    assert specs[-3].dim0_is_actual_tokens is True
+    assert specs[-2].dim0_is_actual_tokens is True
+    assert specs[-1].dim0_is_actual_tokens is False

--- a/tests/test_vllm_blackbox.py
+++ b/tests/test_vllm_blackbox.py
@@ -34,6 +34,7 @@ RUNNER = PROJECT_ROOT / "tests/tools/smoke_vllm_model.py"
 CASES = PROJECT_ROOT / "tests/blackbox/cases/transparency.json"
 MODEL_ALIASES = {
     "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
+    "ernie45": "baidu/ERNIE-4.5-0.3B-PT",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/test_vllm_release_matrix.py
+++ b/tests/test_vllm_release_matrix.py
@@ -72,6 +72,7 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "focused-cpu-contracts" in case_ids
     for model in (
         "apertus",
+        "ernie45",
         "falcon_h1",
         "gemma3",
         "gpt2",
@@ -108,6 +109,8 @@ def test_all_matrix_covers_existing_architectures_and_storage_modes():
     assert "storage-olmo3-cudagraph-tp1" in case_ids
     assert "storage-apertus-eager-tp1" in case_ids
     assert "storage-apertus-cudagraph-tp1" in case_ids
+    assert "storage-ernie45-eager-tp1" in case_ids
+    assert "storage-ernie45-cudagraph-tp1" in case_ids
 
 
 def test_gemma3_matrix_resolves_the_fixture_subfolder() -> None:
@@ -262,6 +265,25 @@ def test_apertus_matrix_uses_the_qualified_8b_production_checkpoint() -> None:
         storage = cases[f"storage-apertus-{mode}-tp1"]
         assert storage.model_id == "swiss-ai/Apertus-8B-Instruct-2509"
         assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.93"
+        assert storage.environment["E2E_REF_MAX_LEN"] == "128"
+        assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
+
+
+def test_ernie45_matrix_uses_the_qualified_03b_checkpoint() -> None:
+    cases = {case.case_id: case for case in build_cases("all")}
+
+    public = cases["public-ernie45-tp1-eager-graph"]
+    assert public.model_id == "baidu/ERNIE-4.5-0.3B-PT"
+    assert public.environment["DMI_BLACKBOX_MODEL"] == (
+        "baidu/ERNIE-4.5-0.3B-PT"
+    )
+    assert public.environment["DMI_BLACKBOX_GPU_MEMORY_UTILIZATION"] == "0.3"
+    assert public.environment["DMI_BLACKBOX_MAX_MODEL_LEN"] == "128"
+
+    for mode in ("eager", "cudagraph"):
+        storage = cases[f"storage-ernie45-{mode}-tp1"]
+        assert storage.model_id == "baidu/ERNIE-4.5-0.3B-PT"
+        assert storage.environment["E2E_GPU_MEM_UTIL"] == "0.3"
         assert storage.environment["E2E_REF_MAX_LEN"] == "128"
         assert storage.environment["E2E_MAX_MODEL_LEN"] == "128"
 

--- a/tests/tools/run_vllm_release_matrix.py
+++ b/tests/tools/run_vllm_release_matrix.py
@@ -162,6 +162,7 @@ def build_cases(phase: str) -> list[MatrixCase]:
             "tests/test_vllm_version_compat.py",
             "tests/test_vllm_027_model_contracts.py",
             "tests/test_apertus_p_contract.py",
+            "tests/test_ernie45_p_contract.py",
             "tests/test_falcon_h1_p_contract.py",
             "tests/test_granite_p_contract.py",
             "tests/test_jamba_p_contract.py",
@@ -189,6 +190,14 @@ def build_cases(phase: str) -> list[MatrixCase]:
         environment={},
     )
     public = [
+        _blackbox_case(
+            "ernie45",
+            "baidu/ERNIE-4.5-0.3B-PT",
+            tp_size=1,
+            memory_utilization=0.3,
+            model_arg="baidu/ERNIE-4.5-0.3B-PT",
+            max_model_len=128,
+        ),
         _blackbox_case(
             "apertus",
             "swiss-ai/Apertus-8B-Instruct-2509",
@@ -286,6 +295,17 @@ def build_cases(phase: str) -> list[MatrixCase]:
     ]
     storage: list[MatrixCase] = []
     for mode in ("eager", "cudagraph"):
+        storage.append(
+            _storage_case(
+                "ernie45",
+                "baidu/ERNIE-4.5-0.3B-PT",
+                mode,
+                1,
+                ref_max_len=128,
+                max_model_len=128,
+                memory_utilization=0.3,
+            )
+        )
         storage.append(
             _storage_case(
                 "apertus",

--- a/tests/tools/smoke_vllm_model.py
+++ b/tests/tools/smoke_vllm_model.py
@@ -20,6 +20,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 MODEL_ALIASES = {
     "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
+    "ernie45": "baidu/ERNIE-4.5-0.3B-PT",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_compare_runner.py
+++ b/tests/vllm_compare_runner.py
@@ -22,6 +22,7 @@ import torch
 
 _MODEL_ALIASES = {
     "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
+    "ernie45": "baidu/ERNIE-4.5-0.3B-PT",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_monitored_runner.py
+++ b/tests/vllm_monitored_runner.py
@@ -18,6 +18,7 @@ import torch
 
 _MODEL_ALIASES = {
     "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
+    "ernie45": "baidu/ERNIE-4.5-0.3B-PT",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",

--- a/tests/vllm_ref_runner.py
+++ b/tests/vllm_ref_runner.py
@@ -18,6 +18,7 @@ import torch
 
 _MODEL_ALIASES = {
     "apertus": "swiss-ai/Apertus-8B-Instruct-2509",
+    "ernie45": "baidu/ERNIE-4.5-0.3B-PT",
     "falcon_h1": "tiiuae/Falcon-H1-Tiny-90M-Instruct",
     "gemma3": "shibatch/tinygemma3-2m",
     "gpt2": "gpt2",


### PR DESCRIPTION
Adds bounded dense ERNIE 4.5 support on top of the Apertus stack.

Scope:
- architecture and compare-worker remaps for Ernie4_5ForCausalLM
- official checkpoint aliases across public and storage runners
- fail-closed CPU contracts for the audited model configuration and upstream post-init adjustments
- official-checkpoint public/storage cells in the release matrix
- frozen compatibility audit and updated model coverage roadmap
- integration submodule commit 6f2cf03f68e4 from ProjectDMX/vllm-DMI#10

Validation:
- official baidu/ERNIE-4.5-0.3B-PT upstream eager and CUDA graph qualification
- full API-only baseline/monitored eager+graph: 2/2 passed in 84.06 s, zero strict and ambiguity mismatches
- reduced full-hook transport: eager and graph each 1,624/1,624 byte-identical rows
- production full-hook transport: eager and graph each 16,240/16,240 byte-identical rows
- final focused cross-model sweep: 363 passed

Supported cell is TP1 BF16 V1 offline, standard HF weights, eager/default CUDA graph, 203 hook families, max model length 128. The full current-supported two-GPU release matrix remains pending until physical GPUs 0 and 2 are both idle; existing external GPU jobs were not disturbed.