### PR TITLE
[Core] Add framework-neutral record offload runtime

### DIFF
--- a/docs/integration-api-v1.md
+++ b/docs/integration-api-v1.md
@@ -327,10 +327,18 @@ and a zero-byte task.
 A nonempty producer descriptor must contain a `PayloadSlice`; an empty
 producer descriptor is permitted.
 
+After device-to-host transfer, the native ring pairs each descriptor with its
+owned contiguous CPU payload as a backend-neutral record envelope. A native
+`RecordSink` receives that envelope before any backend-specific row
+materialization. `ClickHouseRecordSink` is the current adapter; another native
+sink can be passed to `RingEngine.create_record()` without changing the
+producer, drain, or descriptor consumer.
+
 `MonitoringEngine.flush_and_wait()` is a checked, non-closing completion
-operation. Success means the ring, descriptor consumer, host queues, and
-ClickHouse sink completed within one timeout. A timeout raises `TimeoutError`;
-asynchronous failures propagate unchanged.
+operation. Success means the ring, descriptor consumer, and configured record
+sink reached that sink's durability boundary within one timeout. The current
+ClickHouse adapter waits for acknowledged inserts. A timeout raises
+`TimeoutError`; asynchronous failures propagate unchanged.
 
 ### `deactivate_ring_transport`
 

--- a/docs/integration-api-v1.md
+++ b/docs/integration-api-v1.md
@@ -253,6 +253,85 @@ old payload tensor. Treat the attached model as terminal too. A later CUDA
 forward—especially after another engine becomes active—can combine stale hook
 bindings with the new global engine.
 
+### Generic record runtime
+
+The generic record path is opt-in and independent of the legacy inference
+path. It is selected only by constructing a schema-driven stage with
+`StageConfig.clickhouse_records()` and then calling
+`MonitoringEngine.create_record_runtime()`.
+The returned `RecordRuntime` owns descriptor association for that record ring.
+
+`RecordCellType` supports `STRING`, `INT32`, `INT64`, `FLOAT64`,
+`INT64_ARRAY`, and `TENSOR`. A `RecordColumn` declares one logical column.
+A tensor column additionally names its dtype, shape, and bytes columns.
+`RecordLayout` declares one named table layout, its ordered columns, primary
+key, and ordering key. `RecordSchema` contains the layouts and index
+granularity.
+
+`RecordCell` is the accepted encoded-cell union. `PayloadSlice` describes how
+one cell is materialized from its associated producer payload.
+`RecordDescriptor` contains a layout name, encoded rows, and an optional
+producer output ID. `RecordFormat` supplies the immutable schema and converts
+integration metadata into descriptors.
+
+At record-runtime startup, the runtime schema must exactly match the schema
+retained by the host stage. Layout declaration order is irrelevant, but layout
+names, target tables, ordered logical columns and types, tensor physical-column
+names, keys, and index granularity must match. Each live ClickHouse table is
+also checked for its ordered physical columns and types, primary key,
+`ORDER BY`, and effective index granularity before the stage becomes ready.
+
+`TransportType` supports `IDENTITY`, `PREFIX_STRIP`, `CHUNKED`,
+`SEQ_PREFIX_PACK`, and `SEGMENTED_PACK`. `OutputStorage` selects tensor,
+floating-scalar, or integer-scalar materialization. `RecordType` describes the
+integration-owned row granularity. A `TransportSpec` declares one physical
+output, and `HookOutput` carries its source tensor and any device-side producer
+metadata.
+
+`HookSpecV1` declares one generic hook and its ordered outputs. `HookRuntime`
+decides eligibility and associates metadata before each producer launch.
+`HookPointV1` checks eligibility before preprocessing, dispatches each output
+in declaration order, and returns `None`.
+
+`ProducerPlanBuilder` records physical outputs during capture and builds an
+immutable `ProducerPlan`. Each `ProducerPlanEntry` retains the output ID,
+shapes, dtype, transport, storage, reservation bound, and task count required
+for replay.
+
+```python
+runtime = engine.create_record_runtime(record_format)
+
+runtime.bind_hook(
+    hook,
+    hook_runtime=hook_runtime,
+    gate_tensor=None,
+    gate_value=0,
+)
+
+runtime.emit_output(entry, metadata, output)
+runtime.prepare_replay(plan, metadata)
+
+engine.flush_and_wait(timeout_s=600.0)
+```
+
+The public operations are `create_record_runtime()`, `bind_hook()`,
+`emit_output()`, `prepare_replay()`, and `flush_and_wait()`.
+
+`RecordRuntime.bind_hook()` assigns stable output IDs and binds the hook to the
+record ring. `RecordRuntime.emit_output()` reserves and publishes one eager
+descriptor before its producer. `RecordRuntime.prepare_replay()` publishes
+fresh descriptors for an existing physical plan. Every producer occurrence
+has exactly one descriptor; a gated-off occurrence uses an empty descriptor
+and a zero-byte task.
+
+A nonempty producer descriptor must contain a `PayloadSlice`; an empty
+producer descriptor is permitted.
+
+`MonitoringEngine.flush_and_wait()` is a checked, non-closing completion
+operation. Success means the ring, descriptor consumer, host queues, and
+ClickHouse sink completed within one timeout. A timeout raises `TimeoutError`;
+asynchronous failures propagate unchanged.
+
 ### `deactivate_ring_transport`
 
 ```python

--- a/native/Makefile
+++ b/native/Makefile
@@ -11,12 +11,14 @@ SRCS := csrc/bindings.cpp \
         csrc/clickhouse_client.cpp \
         csrc/ring/drain_thread.cpp \
         csrc/ring/p2p_thread.cpp \
+        csrc/ring/record_consumer.cpp \
         csrc/ring/ring_torch_op.cpp
 HOST_SRCS := csrc/bindings.cpp csrc/clickhouse_client.cpp
 HEADERS := csrc/dmx_host_utils.h \
-           csrc/clickhouse_client.h csrc/dmx_host_engine.h \
+           csrc/clickhouse_client.h csrc/dmx_host_engine.h csrc/record_schema.h \
            csrc/ring/ring_config.h csrc/ring/ring_state.h csrc/ring/ring_alloc.h \
            csrc/ring/task_entry.h csrc/ring/drain_task.h csrc/ring/drain_thread.h \
+           csrc/ring/record_descriptor.h csrc/ring/record_consumer.h \
            csrc/ring/p2p_thread.h csrc/ring/pinned_staging.h \
            csrc/ring/ring_engine.h csrc/ring/ring_engine_py.h \
            csrc/ring/ring_torch_op.h csrc/ring/tensor_meta.h

--- a/native/Makefile
+++ b/native/Makefile
@@ -8,6 +8,7 @@ LTO ?= 0
 TARGET := _native_backend
 HOST_TARGET := _host_backend
 SRCS := csrc/bindings.cpp \
+        csrc/clickhouse_record_sink.cpp \
         csrc/clickhouse_client.cpp \
         csrc/ring/drain_thread.cpp \
         csrc/ring/p2p_thread.cpp \
@@ -15,10 +16,12 @@ SRCS := csrc/bindings.cpp \
         csrc/ring/ring_torch_op.cpp
 HOST_SRCS := csrc/bindings.cpp csrc/clickhouse_client.cpp
 HEADERS := csrc/dmx_host_utils.h \
-           csrc/clickhouse_client.h csrc/dmx_host_engine.h csrc/record_schema.h \
+           csrc/clickhouse_client.h csrc/clickhouse_record_sink.h \
+           csrc/dmx_host_engine.h csrc/record_schema.h \
            csrc/ring/ring_config.h csrc/ring/ring_state.h csrc/ring/ring_alloc.h \
            csrc/ring/task_entry.h csrc/ring/drain_task.h csrc/ring/drain_thread.h \
            csrc/ring/record_descriptor.h csrc/ring/record_consumer.h \
+           csrc/ring/record_sink.h \
            csrc/ring/p2p_thread.h csrc/ring/pinned_staging.h \
            csrc/ring/ring_engine.h csrc/ring/ring_engine_py.h \
            csrc/ring/ring_torch_op.h csrc/ring/tensor_meta.h

--- a/native/csrc/batching_queue.hpp
+++ b/native/csrc/batching_queue.hpp
@@ -431,6 +431,32 @@ class WatermarkBatchingQueue
     return closed_;
   }
 
+  // Enter a nonterminal flush rendezvous.  While active, all buffered items
+  // are immediately eligible for dequeue and an open, empty queue returns an
+  // empty batch so each worker can acknowledge that all preceding work has
+  // completed.  The engine serializes submission with this operation.
+  void begin_flush() {
+    {
+      std::unique_lock<std::mutex> lk(mu_);
+      if (closed_) {
+        throw QueueClosedError("cannot begin flush on a closed queue");
+      }
+      if (flush_active_) {
+        throw std::logic_error("flush is already active");
+      }
+      flush_active_ = true;
+    }
+    cv_can_dequeue_.notify_all();
+  }
+
+  void end_flush() {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (!flush_active_) {
+      throw std::logic_error("no active flush to end");
+    }
+    flush_active_ = false;
+  }
+
   std::size_t size() const {
     std::unique_lock<std::mutex> lk(mu_);
     return static_cast<std::size_t>(buffered_items_);
@@ -704,8 +730,8 @@ class WatermarkBatchingQueue
   // Contract:
   // - Returns a NON-empty batch when items are available and batching triggers are met
   //   (min_batch_items/min_batch_size/max_linger) or high-watermark forces a flush.
-  // - Returns an empty vector ONLY when the queue is closed AND empty (drained). This is
-  //   intended as a shutdown sentinel for worker loops.
+  // - Returns an empty vector when the queue is closed and empty (terminal),
+  //   or when an active nonterminal flush reaches an open, empty queue.
   // - If block=false and a batch is not ready, throws QueueEmptyError.
   // - If timeout is provided and expires, throws QueueEmptyError.
   std::vector<ItemT> dequeue_batch(bool block = true, std::optional<Duration> timeout = std::nullopt) {
@@ -802,6 +828,10 @@ class WatermarkBatchingQueue
             auto& prof_opt = prof_storage_();
             if (prof_opt) prof_opt->dequeue_returned_empty_on_close += 1;
           }
+          finish_total();
+          return {};
+        }
+        if (flush_active_) {
           finish_total();
           return {};
         }
@@ -1011,7 +1041,7 @@ class WatermarkBatchingQueue
   }
 
   bool dequeue_allowed_(Tick now, Count cnt, const SizeT& size) const {
-    if (closed_) return true;
+    if (closed_ || flush_active_) return true;
     std::optional<Tick> oldest = q_.empty() ? std::nullopt : std::optional<Tick>(q_.front().enq_at);
     if (flush_triggers_met_(now, cnt, size, oldest)) return true;
     if (high_watermark_reached_(cnt, size)) return true;
@@ -1152,6 +1182,7 @@ class WatermarkBatchingQueue
   Count buffered_items_ = 0;
   SizeT buffered_size_ = SizeT{0};
   bool closed_ = false;
+  bool flush_active_ = false;
 };
 
 }  // namespace dmx_host

--- a/native/csrc/bindings.cpp
+++ b/native/csrc/bindings.cpp
@@ -7,6 +7,7 @@
 #endif
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <type_traits>
@@ -15,6 +16,7 @@ namespace py = pybind11;
 #include "clickhouse_client.h"
 #include "dmx_host_engine.h"
 #ifndef DMI_HOST_ONLY
+#include "clickhouse_record_sink.h"
 #include "ring/ring_engine_py.h"
 #include "ring/ring_torch_op.h"
 #include "ring/tensor_meta.h"
@@ -117,6 +119,24 @@ bool IsPayloadSlice(const py::handle& value) {
          py::hasattr(value, "storage") &&
          py::hasattr(value, "dtype") &&
          py::hasattr(value, "shape");
+}
+
+std::shared_ptr<dmx_host::ClickHouseRecordSink> MakeClickHouseRecordSink(
+    std::shared_ptr<dmx_host::DMXHostEngine> host) {
+  if (!host) {
+    throw std::invalid_argument("ClickHouse record sink requires a host engine");
+  }
+  return std::make_shared<dmx_host::ClickHouseRecordSink>(
+      [host](dmx_host::GenericRecordRow row, uint64_t payload_bytes) {
+        host->submit_record(std::move(row), payload_bytes);
+      },
+      [host](ring::RecordSink::Duration timeout) {
+        const double timeout_s =
+            std::chrono::duration<double>(timeout).count();
+        return host->flush_and_wait(
+            dmx_host::DMXHostEngine::Duration(timeout_s));
+      },
+      [host] { host->raise_if_failed(); });
 }
 
 ring::RecordDescriptor CopyRecordDescriptor(
@@ -582,6 +602,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_readwrite("insert_queue_max_bytes",    &ring_py::RingConfig::insert_queue_max_bytes)
       .def_readwrite("insert_queue_max_items",    &ring_py::RingConfig::insert_queue_max_items);
 
+  // Native-only extension point.  No Python trampoline is registered: sink
+  // callbacks stay off the GIL-bound Python hot path.
+  py::class_<ring::RecordSink, std::shared_ptr<ring::RecordSink>>(
+      m, "RecordSink");
+  py::class_<dmx_host::ClickHouseRecordSink, ring::RecordSink,
+             std::shared_ptr<dmx_host::ClickHouseRecordSink>>(
+      m, "ClickHouseRecordSink")
+      .def(py::init([](std::shared_ptr<dmx_host::DMXHostEngine> host) {
+             return MakeClickHouseRecordSink(std::move(host));
+           }),
+           py::arg("host_engine"));
+
   py::class_<ring_py::RingEnginePy, std::shared_ptr<ring_py::RingEnginePy>>(m, "RingEngine")
       .def(py::init([](ring_py::RingConfig cfg, py::object host_engine_obj) {
              ring_py::SubmitFn submit_fn;
@@ -610,20 +642,21 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("config"), py::arg("host_engine") = py::none())
       .def_static(
           "create_record",
-          [](ring_py::RingConfig cfg, py::object host_engine_obj) {
-            ring_py::RecordSubmitFn submit_fn;
-            if (!host_engine_obj.is_none()) {
-              auto host = host_engine_obj.cast<
-                  std::shared_ptr<dmx_host::DMXHostEngine>>();
-              submit_fn = [host](dmx_host::GenericRecordRow row,
-                                 uint64_t payload_bytes) {
-                host->submit_record(std::move(row), payload_bytes);
-              };
+          [](ring_py::RingConfig cfg, py::object sink_or_host) {
+            std::shared_ptr<ring::RecordSink> sink;
+            if (!sink_or_host.is_none()) {
+              if (py::isinstance<ring::RecordSink>(sink_or_host)) {
+                sink = sink_or_host.cast<std::shared_ptr<ring::RecordSink>>();
+              } else {
+                auto host = sink_or_host.cast<
+                    std::shared_ptr<dmx_host::DMXHostEngine>>();
+                sink = MakeClickHouseRecordSink(std::move(host));
+              }
             }
             return std::make_shared<ring_py::RingEnginePy>(
-                std::move(cfg), std::move(submit_fn));
+                std::move(cfg), std::move(sink));
           },
-          py::arg("config"), py::arg("host_engine") = py::none())
+          py::arg("config"), py::arg("sink_or_host") = py::none())
       .def("init",  &ring_py::RingEnginePy::init,
            py::arg("stream_handle") = uint64_t{0})
       .def("start", &ring_py::RingEnginePy::start)

--- a/native/csrc/bindings.cpp
+++ b/native/csrc/bindings.cpp
@@ -8,6 +8,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <cmath>
+#include <limits>
+#include <type_traits>
 namespace py = pybind11;
 
 #include "clickhouse_client.h"
@@ -17,6 +19,185 @@ namespace py = pybind11;
 #include "ring/ring_torch_op.h"
 #include "ring/tensor_meta.h"
 #endif
+
+namespace {
+
+std::string EnumValueString(const py::handle& value) {
+  if (py::hasattr(value, "value")) {
+    return py::cast<std::string>(value.attr("value"));
+  }
+  return py::cast<std::string>(value);
+}
+
+dmx_host::RecordCellType ParseRecordCellType(const py::handle& value) {
+  const std::string name = EnumValueString(value);
+  if (name == "string") return dmx_host::RecordCellType::STRING;
+  if (name == "int32") return dmx_host::RecordCellType::INT32;
+  if (name == "int64") return dmx_host::RecordCellType::INT64;
+  if (name == "float64") return dmx_host::RecordCellType::FLOAT64;
+  if (name == "int64_array") return dmx_host::RecordCellType::INT64_ARRAY;
+  if (name == "tensor") return dmx_host::RecordCellType::TENSOR;
+  throw py::value_error("unsupported RecordCellType: " + name);
+}
+
+std::string OptionalStringAttr(const py::handle& object, const char* name) {
+  py::object value = object.attr(name);
+  return value.is_none() ? std::string{} : py::cast<std::string>(value);
+}
+
+dmx_host::RecordSchema CopyRecordSchema(const py::handle& schema_py) {
+  dmx_host::RecordSchema schema;
+  schema.index_granularity =
+      py::cast<int>(schema_py.attr("index_granularity"));
+  for (const py::handle layout_py : schema_py.attr("layouts")) {
+    dmx_host::RecordLayout layout;
+    layout.name = py::cast<std::string>(layout_py.attr("name"));
+    layout.table = py::cast<std::string>(layout_py.attr("table"));
+    layout.primary_key = py::cast<std::vector<std::string>>(
+        layout_py.attr("primary_key"));
+    layout.order_by = py::cast<std::vector<std::string>>(
+        layout_py.attr("order_by"));
+    for (const py::handle column_py : layout_py.attr("columns")) {
+      dmx_host::RecordColumn column;
+      column.name = py::cast<std::string>(column_py.attr("name"));
+      column.type = ParseRecordCellType(column_py.attr("type"));
+      column.dtype_column = OptionalStringAttr(column_py, "dtype_column");
+      column.shape_column = OptionalStringAttr(column_py, "shape_column");
+      column.bytes_column = OptionalStringAttr(column_py, "bytes_column");
+      layout.columns.push_back(std::move(column));
+    }
+    schema.layouts.push_back(std::move(layout));
+  }
+  dmx_host::ValidateRecordSchema(schema);
+  return schema;
+}
+
+dmx_host::RecordValue CopyLiteralRecordValue(
+    const py::handle& value, dmx_host::RecordCellType type) {
+  switch (type) {
+    case dmx_host::RecordCellType::STRING:
+      return py::cast<std::string>(value);
+    case dmx_host::RecordCellType::INT32: {
+      const int64_t parsed = py::cast<int64_t>(value);
+      if (parsed < std::numeric_limits<int32_t>::min() ||
+          parsed > std::numeric_limits<int32_t>::max()) {
+        throw py::value_error("record INT32 value is out of range");
+      }
+      return static_cast<int32_t>(parsed);
+    }
+    case dmx_host::RecordCellType::INT64:
+      return py::cast<int64_t>(value);
+    case dmx_host::RecordCellType::FLOAT64:
+      return py::cast<double>(value);
+    case dmx_host::RecordCellType::INT64_ARRAY:
+      return py::cast<std::vector<int64_t>>(value);
+    case dmx_host::RecordCellType::TENSOR:
+      return py::cast<at::Tensor>(value);
+  }
+  throw py::value_error("unsupported record cell type");
+}
+
+#ifndef DMI_HOST_ONLY
+ring::PayloadMaterialization ParsePayloadMaterialization(
+    const py::handle& slice_py, dmx_host::RecordCellType column_type) {
+  const int storage = py::cast<int>(slice_py.attr("storage"));
+  if (column_type == dmx_host::RecordCellType::TENSOR && storage == 0)
+    return ring::PayloadMaterialization::TENSOR;
+  if (column_type == dmx_host::RecordCellType::FLOAT64 && storage == 1)
+    return ring::PayloadMaterialization::FLOAT_SCALAR;
+  if (column_type == dmx_host::RecordCellType::INT64 && storage == 2)
+    return ring::PayloadMaterialization::INT_SCALAR;
+  throw py::type_error(
+      "PayloadSlice storage does not match its record column type");
+}
+
+bool IsPayloadSlice(const py::handle& value) {
+  return py::hasattr(value, "offset_bytes") &&
+         py::hasattr(value, "nbytes") &&
+         py::hasattr(value, "storage") &&
+         py::hasattr(value, "dtype") &&
+         py::hasattr(value, "shape");
+}
+
+ring::RecordDescriptor CopyRecordDescriptor(
+    const py::handle& descriptor_py,
+    const dmx_host::RecordSchema& schema) {
+  ring::RecordDescriptor descriptor;
+  descriptor.layout = py::cast<std::string>(descriptor_py.attr("layout"));
+  const auto& layout = dmx_host::FindRecordLayout(schema, descriptor.layout);
+
+  for (const py::handle row_py : descriptor_py.attr("rows")) {
+    const py::sequence row = py::reinterpret_borrow<py::sequence>(row_py);
+    if (static_cast<size_t>(py::len(row)) != layout.columns.size()) {
+      throw py::value_error(
+          "record descriptor row width does not match its layout");
+    }
+    ring::EncodedRecordRow encoded_row;
+    encoded_row.cells.reserve(layout.columns.size());
+    for (size_t i = 0; i < layout.columns.size(); ++i) {
+      py::handle value = row[i];
+      const auto column_type = layout.columns[i].type;
+      if (IsPayloadSlice(value)) {
+        ring::PayloadSlice slice;
+        slice.offset_bytes = py::cast<uint64_t>(value.attr("offset_bytes"));
+        py::object nbytes = value.attr("nbytes");
+        if (!nbytes.is_none()) {
+          slice.length_bytes = py::cast<uint64_t>(nbytes);
+        }
+        slice.materialization =
+            ParsePayloadMaterialization(value, column_type);
+        py::object dtype = value.attr("dtype");
+        if (dtype.is_none()) {
+          throw py::value_error("PayloadSlice dtype is required");
+        }
+        slice.dtype = static_cast<int32_t>(dtype.cast<at::ScalarType>());
+        slice.logical_shape = py::cast<std::vector<int64_t>>(
+            value.attr("shape"));
+        for (size_t dim = 0; dim < slice.logical_shape.size(); ++dim) {
+          if (slice.logical_shape[dim] == -1) {
+            if (slice.inferred_dynamic_dim >= 0) {
+              throw py::value_error(
+                  "PayloadSlice supports at most one dynamic dimension");
+            }
+            slice.inferred_dynamic_dim = static_cast<int32_t>(dim);
+          }
+        }
+        encoded_row.cells.emplace_back(std::move(slice));
+        continue;
+      }
+
+      dmx_host::RecordValue literal =
+          CopyLiteralRecordValue(value, column_type);
+      std::visit(
+          [&](auto&& item) {
+            using T = std::decay_t<decltype(item)>;
+            if constexpr (std::is_same_v<T, at::Tensor>) {
+              throw py::type_error(
+                  "record tensor columns require a PayloadSlice");
+            } else {
+              encoded_row.cells.emplace_back(std::forward<decltype(item)>(item));
+            }
+          },
+          std::move(literal));
+    }
+    descriptor.rows.push_back(std::move(encoded_row));
+  }
+  return descriptor;
+}
+
+std::vector<ring::RecordDescriptor> CopyRecordDescriptors(
+    const py::handle& descriptors_py,
+    const py::handle& schema_py) {
+  const auto schema = CopyRecordSchema(schema_py);
+  std::vector<ring::RecordDescriptor> descriptors;
+  for (const py::handle descriptor_py : descriptors_py) {
+    descriptors.push_back(CopyRecordDescriptor(descriptor_py, schema));
+  }
+  return descriptors;
+}
+#endif
+
+}  // namespace
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifndef DMI_HOST_ONLY
@@ -226,7 +407,42 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           },
           py::arg("clickhouse_config"),
           py::arg("parallelism") = 1,
-          py::arg("name") = "clickhouse_insert");
+          py::arg("name") = "clickhouse_insert")
+      .def_static(
+          "clickhouse_records",
+          [](const dmx_host::ClickHouseClientConfig& ch_cfg,
+             py::object schema_py, int parallelism, std::string name) {
+            if (parallelism <= 0) {
+              throw py::value_error("parallelism must be positive");
+            }
+            StageConfig cfg;
+            cfg.name = std::move(name);
+            cfg.parallelism = parallelism;
+            cfg.input_queue.min_batch_items.reset();
+            cfg.input_queue.min_batch_size = 16ULL * 1024 * 1024;
+            cfg.input_queue.max_linger = Duration(0.05);
+            cfg.input_queue.max_batch_items = 10000;
+            cfg.input_queue.high_watermark_items = 20000;
+            cfg.input_queue.high_watermark_size = 512ULL * 1024 * 1024;
+            cfg.process_fn = [](
+                std::vector<dmx_host::dmx_host_queue_item> batch,
+                QueueT* next_q) {
+              return dmx_host::ClickHouseRecordInsertStage::ProcessFn<QueueT>(
+                  std::move(batch), next_q);
+            };
+            dmx_host::ClickHouseRecordStageConfig stage_cfg;
+            stage_cfg.client = ch_cfg;
+            stage_cfg.schema = CopyRecordSchema(schema_py);
+            cfg.thread_init_config = std::move(stage_cfg);
+            cfg.thread_init =
+                &dmx_host::ClickHouseRecordInsertStage::ThreadInitAny;
+            cfg.thread_cleanup =
+                &dmx_host::ClickHouseRecordInsertStage::ThreadCleanupAny;
+            return cfg;
+          },
+          py::arg("clickhouse_config"), py::arg("schema"),
+          py::arg("parallelism") = 1,
+          py::arg("name") = "clickhouse_records");
 
   py::class_<DMXHostEngine, std::shared_ptr<DMXHostEngine>>(m, "DMXHostEngine")
       .def(py::init<StageConfig>(), py::arg("insert_stage"))
@@ -270,6 +486,49 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("failures", &DMXHostEngine::failures)
       .def("raise_if_failed", &DMXHostEngine::raise_if_failed)
+      .def("flush_and_wait",
+           [](DMXHostEngine& self, double timeout_s) {
+             if (!std::isfinite(timeout_s) || timeout_s <= 0.0) {
+               throw std::invalid_argument(
+                   "timeout_s must be finite and positive");
+             }
+             return self.flush_and_wait(DMXHostEngine::Duration(timeout_s));
+           },
+           py::arg("timeout_s") = 600.0,
+           py::call_guard<py::gil_scoped_release>())
+      .def("submit_record",
+           [](DMXHostEngine& self, const std::string& layout,
+              py::sequence cells, py::sequence cell_types,
+              uint64_t nbytes) {
+             if (py::len(cells) != py::len(cell_types)) {
+               throw py::value_error(
+                   "cells and cell_types must have the same length");
+             }
+             dmx_host::GenericRecordRow row;
+             row.layout = layout;
+             row.cells.reserve(static_cast<size_t>(py::len(cells)));
+             uint64_t accounted = nbytes;
+             for (py::ssize_t i = 0; i < py::len(cells); ++i) {
+               const auto type = ParseRecordCellType(cell_types[i]);
+               dmx_host::RecordValue value =
+                   CopyLiteralRecordValue(cells[i], type);
+               if (auto* tensor = std::get_if<at::Tensor>(&value)) {
+                 if (!tensor->device().is_cpu()) {
+                   throw py::value_error(
+                       "submit_record tensor cells must already be on CPU");
+                 }
+                 if (!tensor->is_contiguous()) *tensor = tensor->contiguous();
+                 if (nbytes == 0) {
+                   accounted += static_cast<uint64_t>(tensor->nbytes());
+                 }
+               }
+               row.cells.push_back(std::move(value));
+             }
+             py::gil_scoped_release release;
+             self.submit_record(std::move(row), accounted);
+           },
+           py::arg("layout"), py::arg("cells"), py::arg("cell_types"),
+           py::arg("nbytes") = uint64_t{0})
       // Submit a pre-formatted ClickHouseRow directly to the insert stage.
       // Called from the ring transport drain callback after format processing.
       .def("submit_direct",
@@ -296,6 +555,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("layer_no"), py::arg("start_token"), py::arg("end_token"),
            py::arg("tensor"),
            py::call_guard<py::gil_scoped_release>());
+
+  m.def(
+      "_validate_record_host_schema",
+      [](DMXHostEngine& host_engine, py::object schema) {
+        host_engine.validate_record_schema(CopyRecordSchema(schema));
+      },
+      py::arg("host_engine"), py::arg("schema"));
 
   // -------------------------------------------------------------------------
   // Ring offload engine
@@ -342,6 +608,22 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                  std::move(cfg), std::move(submit_fn));
            }),
            py::arg("config"), py::arg("host_engine") = py::none())
+      .def_static(
+          "create_record",
+          [](ring_py::RingConfig cfg, py::object host_engine_obj) {
+            ring_py::RecordSubmitFn submit_fn;
+            if (!host_engine_obj.is_none()) {
+              auto host = host_engine_obj.cast<
+                  std::shared_ptr<dmx_host::DMXHostEngine>>();
+              submit_fn = [host](dmx_host::GenericRecordRow row,
+                                 uint64_t payload_bytes) {
+                host->submit_record(std::move(row), payload_bytes);
+              };
+            }
+            return std::make_shared<ring_py::RingEnginePy>(
+                std::move(cfg), std::move(submit_fn));
+          },
+          py::arg("config"), py::arg("host_engine") = py::none())
       .def("init",  &ring_py::RingEnginePy::init,
            py::arg("stream_handle") = uint64_t{0})
       .def("start", &ring_py::RingEnginePy::start)
@@ -351,6 +633,52 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            &ring_py::RingEnginePy::prepare_step,
            py::arg("step_total_bytes"),
            py::arg("num_hooks"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("reserve_record",
+           &ring_py::RingEnginePy::reserve_record,
+           py::arg("reservation_bytes"), py::arg("num_tasks"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("push_record_descriptors",
+           [](ring_py::RingEnginePy& self, py::sequence descriptors,
+              py::object schema) {
+             auto encoded = CopyRecordDescriptors(descriptors, schema);
+             py::gil_scoped_release release;
+             self.push_record_descriptors(std::move(encoded));
+           },
+           py::arg("descriptors"), py::arg("schema"))
+      .def("submit_record_cpu_direct",
+           [](ring_py::RingEnginePy& self, at::Tensor cpu_tensor,
+              uint64_t tensor_bytes) {
+             if (!cpu_tensor.device().is_cpu()) {
+               throw py::value_error(
+                   "record CPU-direct tensor must already be on CPU");
+             }
+             at::Tensor contiguous = cpu_tensor.is_contiguous()
+                 ? std::move(cpu_tensor) : cpu_tensor.contiguous();
+             if (tensor_bytes != static_cast<uint64_t>(contiguous.nbytes())) {
+               throw py::value_error(
+                   "record CPU-direct byte count does not match tensor");
+             }
+             py::gil_scoped_release release;
+             self.submit_record_cpu_direct(
+                 std::move(contiguous), tensor_bytes);
+           },
+           py::arg("cpu_tensor"), py::arg("tensor_bytes"))
+      .def("flush_records_and_wait",
+           [](ring_py::RingEnginePy& self, double timeout_s) {
+             if (!std::isfinite(timeout_s) || timeout_s <= 0.0) {
+               throw std::invalid_argument(
+                   "timeout_s must be finite and positive");
+             }
+             const double milliseconds = std::ceil(timeout_s * 1000.0);
+             if (milliseconds >
+                 static_cast<double>(std::numeric_limits<int64_t>::max())) {
+               throw std::invalid_argument("timeout_s is too large");
+             }
+             return self.flush_records_and_wait(
+                 static_cast<uint64_t>(milliseconds));
+           },
+           py::arg("timeout_s") = 600.0,
            py::call_guard<py::gil_scoped_release>())
       .def("submit_cpu_direct",
            [](ring_py::RingEnginePy& self, at::Tensor cpu_tensor) {

--- a/native/csrc/bindings.cpp
+++ b/native/csrc/bindings.cpp
@@ -636,7 +636,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("reserve_record",
            &ring_py::RingEnginePy::reserve_record,
-           py::arg("reservation_bytes"), py::arg("num_tasks"),
+           py::arg("reservation_items"),
            py::call_guard<py::gil_scoped_release>())
       .def("push_record_descriptors",
            [](ring_py::RingEnginePy& self, py::sequence descriptors,

--- a/native/csrc/clickhouse_client.cpp
+++ b/native/csrc/clickhouse_client.cpp
@@ -9,10 +9,12 @@
 #include <charconv>
 #include <chrono>
 #include <mutex>
+#include <map>
 #include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 #include <clickhouse/columns/array.h>
@@ -99,6 +101,7 @@ thread_local std::string tl_db;
 thread_local std::string tl_table;
 thread_local int tl_worker_index = -1;
 thread_local std::shared_ptr<ClickHouseRuntimeMetrics> tl_runtime_metrics;
+thread_local std::optional<RecordSchema> tl_record_schema;
 
 std::mutex g_schema_mutex;
 std::set<std::string> g_schema_inited_dbs;
@@ -453,7 +456,555 @@ StagedRow StageOneRow(ClickHouseRow&& row) {
   return r;
 }
 
+bool IsSafeIdentifier(const std::string& value) {
+  if (value.empty()) return false;
+  const auto first = static_cast<unsigned char>(value.front());
+  if (!(std::isalpha(first) || value.front() == '_')) return false;
+  return std::all_of(value.begin() + 1, value.end(), [](unsigned char c) {
+    return std::isalnum(c) || c == '_';
+  });
+}
+
+const char* ClickHouseTypeName(RecordCellType type) {
+  switch (type) {
+    case RecordCellType::STRING: return "String";
+    case RecordCellType::INT32: return "Int32";
+    case RecordCellType::INT64: return "Int64";
+    case RecordCellType::FLOAT64: return "Float64";
+    case RecordCellType::INT64_ARRAY: return "Array(Int64)";
+    case RecordCellType::TENSOR: break;
+  }
+  throw std::invalid_argument("TENSOR expands to three physical columns");
+}
+
+std::vector<std::pair<std::string, std::string>> PhysicalColumns(
+    const RecordLayout& layout) {
+  std::vector<std::pair<std::string, std::string>> result;
+  for (const auto& column : layout.columns) {
+    if (column.type == RecordCellType::TENSOR) {
+      result.emplace_back(column.dtype_column, "String");
+      result.emplace_back(column.shape_column, "Array(Int64)");
+      result.emplace_back(column.bytes_column, "String");
+    } else {
+      result.emplace_back(column.name, ClickHouseTypeName(column.type));
+    }
+  }
+  return result;
+}
+
+std::string JoinQuotedIdentifiers(const std::vector<std::string>& names) {
+  std::ostringstream out;
+  for (std::size_t i = 0; i < names.size(); ++i) {
+    if (i != 0) out << ", ";
+    out << QuoteIdent(names[i]);
+  }
+  return out.str();
+}
+
+std::string RecordLayoutSignature(const RecordLayout& layout,
+                                  int index_granularity) {
+  std::ostringstream out;
+  for (const auto& [name, type] : PhysicalColumns(layout)) {
+    out << name << '\0' << type << '\0';
+  }
+  out << "pk\0";
+  for (const auto& name : layout.primary_key) out << name << '\0';
+  out << "order\0";
+  for (const auto& name : layout.order_by) out << name << '\0';
+  out << index_granularity;
+  return out.str();
+}
+
+void AppendIdentityField(std::string& identity, std::string_view value) {
+  identity.append(std::to_string(value.size()));
+  identity.push_back(':');
+  identity.append(value.data(), value.size());
+}
+
+std::string RecordSchemaIdentityImpl(const RecordSchema& schema) {
+  std::vector<const RecordLayout*> layouts;
+  layouts.reserve(schema.layouts.size());
+  for (const auto& layout : schema.layouts) layouts.push_back(&layout);
+  std::sort(layouts.begin(), layouts.end(), [](const auto* lhs, const auto* rhs) {
+    return lhs->name < rhs->name;
+  });
+
+  std::string identity = "dmi-record-schema-v1";
+  AppendIdentityField(identity, std::to_string(schema.index_granularity));
+  AppendIdentityField(identity, std::to_string(layouts.size()));
+  for (const auto* layout : layouts) {
+    AppendIdentityField(identity, layout->name);
+    AppendIdentityField(identity, layout->table);
+    AppendIdentityField(identity, std::to_string(layout->columns.size()));
+    for (const auto& column : layout->columns) {
+      AppendIdentityField(identity, column.name);
+      AppendIdentityField(
+          identity,
+          std::to_string(static_cast<unsigned int>(column.type)));
+      if (column.type == RecordCellType::TENSOR) {
+        AppendIdentityField(identity, column.dtype_column);
+        AppendIdentityField(identity, column.shape_column);
+        AppendIdentityField(identity, column.bytes_column);
+      }
+    }
+    AppendIdentityField(identity, std::to_string(layout->primary_key.size()));
+    for (const auto& name : layout->primary_key) {
+      AppendIdentityField(identity, name);
+    }
+    AppendIdentityField(identity, std::to_string(layout->order_by.size()));
+    for (const auto& name : layout->order_by) {
+      AppendIdentityField(identity, name);
+    }
+  }
+  return identity;
+}
+
+void ValidateRecordSchemaImpl(const RecordSchema& schema) {
+  if (schema.layouts.empty()) {
+    throw std::invalid_argument("RecordSchema must contain at least one layout");
+  }
+  if (schema.index_granularity <= 0) {
+    throw std::invalid_argument("RecordSchema index_granularity must be positive");
+  }
+
+  std::set<std::string> layout_names;
+  std::unordered_map<std::string, std::string> table_signatures;
+  for (const auto& layout : schema.layouts) {
+    if (!IsSafeIdentifier(layout.name)) {
+      throw std::invalid_argument("record layout name is not a safe identifier: " +
+                                  layout.name);
+    }
+    if (!layout_names.insert(layout.name).second) {
+      throw std::invalid_argument("duplicate record layout name: " + layout.name);
+    }
+    if (!IsSafeIdentifier(layout.table)) {
+      throw std::invalid_argument("record table is not a safe identifier: " +
+                                  layout.table);
+    }
+    if (layout.columns.empty()) {
+      throw std::invalid_argument("record layout has no columns: " + layout.name);
+    }
+    if (layout.primary_key.empty() || layout.order_by.empty()) {
+      throw std::invalid_argument(
+          "record layout requires non-empty primary_key and order_by: " +
+          layout.name);
+    }
+
+    std::set<std::string> logical_names;
+    std::set<std::string> physical_names;
+    for (const auto& column : layout.columns) {
+      if (!IsSafeIdentifier(column.name)) {
+        throw std::invalid_argument("record column is not a safe identifier: " +
+                                    column.name);
+      }
+      if (!logical_names.insert(column.name).second) {
+        throw std::invalid_argument("duplicate logical record column: " +
+                                    column.name);
+      }
+      if (column.type == RecordCellType::TENSOR) {
+        for (const auto* name : {&column.dtype_column, &column.shape_column,
+                                 &column.bytes_column}) {
+          if (!IsSafeIdentifier(*name)) {
+            throw std::invalid_argument(
+                "tensor physical column is not a safe identifier: " + *name);
+          }
+          if (!physical_names.insert(*name).second) {
+            throw std::invalid_argument("duplicate physical record column: " +
+                                        *name);
+          }
+        }
+      } else if (!physical_names.insert(column.name).second) {
+        throw std::invalid_argument("duplicate physical record column: " +
+                                    column.name);
+      }
+    }
+
+    for (const auto& key : layout.primary_key) {
+      if (!physical_names.count(key)) {
+        throw std::invalid_argument("primary-key column is not declared: " + key);
+      }
+    }
+    for (const auto& key : layout.order_by) {
+      if (!physical_names.count(key)) {
+        throw std::invalid_argument("ordering-key column is not declared: " + key);
+      }
+    }
+
+    const std::string signature =
+        RecordLayoutSignature(layout, schema.index_granularity);
+    const auto [it, inserted] =
+        table_signatures.emplace(layout.table, signature);
+    if (!inserted && it->second != signature) {
+      throw std::invalid_argument(
+          "record layouts targeting the same table must declare the same "
+          "physical schema and keys: " + layout.table);
+    }
+  }
+}
+
+const RecordLayout& FindRecordLayoutImpl(const RecordSchema& schema,
+                                         const std::string& name) {
+  const auto it = std::find_if(
+      schema.layouts.begin(), schema.layouts.end(),
+      [&](const RecordLayout& layout) { return layout.name == name; });
+  if (it == schema.layouts.end()) {
+    throw std::invalid_argument("unknown record layout: " + name);
+  }
+  return *it;
+}
+
+std::optional<std::vector<std::string>> ParseIdentifierKey(
+    std::string_view expression) {
+  std::vector<std::string> names;
+  std::size_t cursor = 0;
+  while (cursor < expression.size()) {
+    while (cursor < expression.size() &&
+           std::isspace(static_cast<unsigned char>(expression[cursor]))) {
+      ++cursor;
+    }
+    if (cursor == expression.size()) break;
+
+    std::string name;
+    if (expression[cursor] == '`') {
+      ++cursor;
+      bool closed = false;
+      while (cursor < expression.size()) {
+        const char character = expression[cursor++];
+        if (character != '`') {
+          name.push_back(character);
+          continue;
+        }
+        if (cursor < expression.size() && expression[cursor] == '`') {
+          name.push_back('`');
+          ++cursor;
+          continue;
+        }
+        closed = true;
+        break;
+      }
+      if (!closed) return std::nullopt;
+    } else {
+      const std::size_t begin = cursor;
+      while (cursor < expression.size()) {
+        const unsigned char character =
+            static_cast<unsigned char>(expression[cursor]);
+        if (!std::isalnum(character) && expression[cursor] != '_') break;
+        ++cursor;
+      }
+      if (cursor == begin) return std::nullopt;
+      name.assign(expression.substr(begin, cursor - begin));
+    }
+    if (!IsSafeIdentifier(name)) return std::nullopt;
+    names.push_back(std::move(name));
+
+    while (cursor < expression.size() &&
+           std::isspace(static_cast<unsigned char>(expression[cursor]))) {
+      ++cursor;
+    }
+    if (cursor == expression.size()) break;
+    if (expression[cursor] != ',') return std::nullopt;
+    ++cursor;
+    std::size_t next = cursor;
+    while (next < expression.size() &&
+           std::isspace(static_cast<unsigned char>(expression[next]))) {
+      ++next;
+    }
+    if (next == expression.size()) return std::nullopt;
+  }
+  return names;
+}
+
+std::optional<int> ParsePositiveIntegerSetting(
+    std::string_view text, std::string_view setting) {
+  std::size_t search_from = 0;
+  while (search_from < text.size()) {
+    const std::size_t found = text.find(setting, search_from);
+    if (found == std::string_view::npos) return std::nullopt;
+    const std::size_t after_name = found + setting.size();
+    const bool left_boundary =
+        found == 0 || (!std::isalnum(static_cast<unsigned char>(text[found - 1])) &&
+                       text[found - 1] != '_');
+    const bool right_boundary =
+        after_name == text.size() ||
+        (!std::isalnum(static_cast<unsigned char>(text[after_name])) &&
+         text[after_name] != '_');
+    if (!left_boundary || !right_boundary) {
+      search_from = after_name;
+      continue;
+    }
+
+    std::size_t cursor = after_name;
+    while (cursor < text.size() &&
+           std::isspace(static_cast<unsigned char>(text[cursor]))) {
+      ++cursor;
+    }
+    if (cursor == text.size() || text[cursor] != '=') {
+      search_from = after_name;
+      continue;
+    }
+    ++cursor;
+    while (cursor < text.size() &&
+           std::isspace(static_cast<unsigned char>(text[cursor]))) {
+      ++cursor;
+    }
+    const char* begin = text.data() + cursor;
+    const char* end = text.data() + text.size();
+    int parsed = 0;
+    const auto [ptr, error] = std::from_chars(begin, end, parsed);
+    const char* suffix = ptr;
+    while (suffix < end &&
+           std::isspace(static_cast<unsigned char>(*suffix))) {
+      ++suffix;
+    }
+    if (error == std::errc{} && ptr != begin && parsed > 0 &&
+        (suffix == end || *suffix == ',')) {
+      return parsed;
+    }
+    throw std::runtime_error(
+        "live ClickHouse table has an invalid index_granularity setting");
+  }
+  return std::nullopt;
+}
+
+int DefaultIndexGranularity(clickhouse::Client& client) {
+  std::optional<int> granularity;
+  client.Select(
+      "SELECT toString(value) FROM system.merge_tree_settings "
+      "WHERE name = 'index_granularity'",
+      [&](const clickhouse::Block& block) {
+        if (block.GetRowCount() == 0 || block.GetColumnCount() == 0) {
+          return;
+        }
+        if (block.GetColumnCount() != 1) {
+          throw std::runtime_error(
+              "ClickHouse merge-tree settings query returned an unexpected "
+              "column count");
+        }
+        const auto values =
+            block[0]->AsStrict<clickhouse::ColumnString>();
+        for (std::size_t i = 0; i < block.GetRowCount(); ++i) {
+          if (granularity) {
+            throw std::runtime_error(
+                "ClickHouse returned duplicate index_granularity settings");
+          }
+          const std::string value(values->At(i));
+          int parsed = 0;
+          const auto [ptr, error] = std::from_chars(
+              value.data(), value.data() + value.size(), parsed);
+          if (error != std::errc{} || ptr != value.data() + value.size() ||
+              parsed <= 0) {
+            throw std::runtime_error(
+                "ClickHouse returned an invalid default index_granularity");
+          }
+          granularity = parsed;
+        }
+      });
+  if (!granularity) {
+    throw std::runtime_error(
+        "ClickHouse did not return a default index_granularity");
+  }
+  return *granularity;
+}
+
+void ValidateLiveRecordTable(
+    clickhouse::Client& client, const std::string& database,
+    const RecordLayout& layout, int index_granularity) {
+  const std::string qualified_table =
+      QualifiedTableNameQuoted(database, layout.table);
+  std::vector<std::pair<std::string, std::string>> actual;
+  client.Select("DESCRIBE TABLE " + qualified_table,
+                [&](const clickhouse::Block& block) {
+    if (block.GetRowCount() == 0 || block.GetColumnCount() == 0) {
+      return;
+    }
+    if (block.GetColumnCount() < 2) {
+      throw std::runtime_error(
+          "ClickHouse DESCRIBE returned fewer than two columns");
+    }
+    const auto names = block[0]->AsStrict<clickhouse::ColumnString>();
+    const auto types = block[1]->AsStrict<clickhouse::ColumnString>();
+    for (std::size_t i = 0; i < block.GetRowCount(); ++i) {
+      actual.emplace_back(std::string(names->At(i)),
+                          std::string(types->At(i)));
+    }
+  });
+
+  const auto expected = PhysicalColumns(layout);
+  if (actual != expected) {
+    throw std::runtime_error(
+        "live ClickHouse columns/types do not match record layout '" +
+        layout.name + "'");
+  }
+
+  std::optional<std::string> primary_key;
+  std::optional<std::string> sorting_key;
+  std::optional<std::string> engine_full;
+  const std::string metadata_query =
+      "SELECT toString(primary_key), toString(sorting_key), "
+      "toString(engine_full) FROM system.tables "
+      "WHERE database = " +
+      QuoteStringLiteral(database) + " AND name = " +
+      QuoteStringLiteral(layout.table);
+  client.Select(metadata_query, [&](const clickhouse::Block& block) {
+    if (block.GetRowCount() == 0 || block.GetColumnCount() == 0) {
+      return;
+    }
+    if (block.GetColumnCount() != 3) {
+      throw std::runtime_error(
+          "ClickHouse table metadata query returned an unexpected column "
+          "count");
+    }
+    const auto primary =
+        block[0]->AsStrict<clickhouse::ColumnString>();
+    const auto sorting =
+        block[1]->AsStrict<clickhouse::ColumnString>();
+    const auto engine =
+        block[2]->AsStrict<clickhouse::ColumnString>();
+    for (std::size_t i = 0; i < block.GetRowCount(); ++i) {
+      if (primary_key) {
+        throw std::runtime_error(
+            "ClickHouse returned duplicate live-table metadata rows");
+      }
+      primary_key = std::string(primary->At(i));
+      sorting_key = std::string(sorting->At(i));
+      engine_full = std::string(engine->At(i));
+    }
+  });
+  if (!primary_key || !sorting_key || !engine_full) {
+    throw std::runtime_error(
+        "ClickHouse did not return metadata for record table '" +
+        layout.table + "'");
+  }
+
+  const auto parsed_primary_key = ParseIdentifierKey(*primary_key);
+  if (!parsed_primary_key || *parsed_primary_key != layout.primary_key) {
+    throw std::runtime_error(
+        "live ClickHouse primary key does not match record layout '" +
+        layout.name + "'");
+  }
+  const auto parsed_sorting_key = ParseIdentifierKey(*sorting_key);
+  if (!parsed_sorting_key || *parsed_sorting_key != layout.order_by) {
+    throw std::runtime_error(
+        "live ClickHouse ORDER BY does not match record layout '" +
+        layout.name + "'");
+  }
+  const auto explicit_granularity =
+      ParsePositiveIntegerSetting(*engine_full, "index_granularity");
+  const int live_granularity = explicit_granularity
+      ? *explicit_granularity
+      : DefaultIndexGranularity(client);
+  if (live_granularity != index_granularity) {
+    throw std::runtime_error(
+        "live ClickHouse index_granularity does not match record schema");
+  }
+}
+
+void InitializeAndValidateRecordTables(
+    const ClickHouseClientConfig& cfg, const RecordSchema& schema,
+    const clickhouse::ClientOptions& opts) {
+  auto client = std::make_unique<clickhouse::Client>(opts);
+  std::set<std::string> visited_tables;
+  for (const auto& layout : schema.layouts) {
+    if (!visited_tables.insert(layout.table).second) continue;
+
+    const std::string fq_table =
+        QualifiedTableNameQuoted(cfg.database, layout.table);
+    const auto physical_columns = PhysicalColumns(layout);
+
+    std::ostringstream ddl;
+    ddl << "CREATE TABLE IF NOT EXISTS " << fq_table << " (";
+    for (std::size_t i = 0; i < physical_columns.size(); ++i) {
+      if (i != 0) ddl << ", ";
+      ddl << QuoteIdent(physical_columns[i].first) << " "
+          << physical_columns[i].second;
+    }
+    ddl << ") ENGINE = MergeTree PRIMARY KEY ("
+        << JoinQuotedIdentifiers(layout.primary_key) << ") ORDER BY ("
+        << JoinQuotedIdentifiers(layout.order_by)
+        << ") SETTINGS index_granularity = " << schema.index_granularity;
+
+    client->Execute(ddl.str());
+    ValidateLiveRecordTable(
+        *client, cfg.database, layout, schema.index_granularity);
+  }
+}
+
+using StagedRecordValue =
+    std::variant<std::string, int32_t, int64_t, double,
+                 std::vector<int64_t>, EncodedTensor>;
+
+struct StagedRecordRow {
+  std::vector<StagedRecordValue> cells;
+};
+
+StagedRecordRow StageGenericRecordRow(GenericRecordRow&& row,
+                                      const RecordLayout& layout) {
+  if (row.cells.size() != layout.columns.size()) {
+    throw std::invalid_argument(
+        "generic record cell count does not match layout '" + layout.name +
+        "'");
+  }
+
+  StagedRecordRow staged;
+  staged.cells.reserve(row.cells.size());
+  for (std::size_t i = 0; i < row.cells.size(); ++i) {
+    auto& value = row.cells[i];
+    const auto type = layout.columns[i].type;
+    switch (type) {
+      case RecordCellType::STRING:
+        if (!std::holds_alternative<std::string>(value))
+          throw std::invalid_argument("record STRING cell has wrong value type");
+        staged.cells.emplace_back(
+            std::move(std::get<std::string>(value)));
+        break;
+      case RecordCellType::INT32:
+        if (!std::holds_alternative<int32_t>(value))
+          throw std::invalid_argument("record INT32 cell has wrong value type");
+        staged.cells.emplace_back(std::get<int32_t>(value));
+        break;
+      case RecordCellType::INT64:
+        if (!std::holds_alternative<int64_t>(value))
+          throw std::invalid_argument("record INT64 cell has wrong value type");
+        staged.cells.emplace_back(std::get<int64_t>(value));
+        break;
+      case RecordCellType::FLOAT64:
+        if (!std::holds_alternative<double>(value))
+          throw std::invalid_argument("record FLOAT64 cell has wrong value type");
+        staged.cells.emplace_back(std::get<double>(value));
+        break;
+      case RecordCellType::INT64_ARRAY:
+        if (!std::holds_alternative<std::vector<int64_t>>(value))
+          throw std::invalid_argument(
+              "record INT64_ARRAY cell has wrong value type");
+        staged.cells.emplace_back(
+            std::move(std::get<std::vector<int64_t>>(value)));
+        break;
+      case RecordCellType::TENSOR:
+        if (!std::holds_alternative<at::Tensor>(value))
+          throw std::invalid_argument("record TENSOR cell has wrong value type");
+        staged.cells.emplace_back(
+            EncodeTensorToColumns(std::get<at::Tensor>(value)));
+        break;
+    }
+  }
+  return staged;
+}
+
 }  // namespace
+
+void ValidateRecordSchema(const RecordSchema& schema) {
+  ValidateRecordSchemaImpl(schema);
+}
+
+std::string RecordSchemaIdentity(const RecordSchema& schema) {
+  ValidateRecordSchemaImpl(schema);
+  return RecordSchemaIdentityImpl(schema);
+}
+
+const RecordLayout& FindRecordLayout(const RecordSchema& schema,
+                                     const std::string& name) {
+  return FindRecordLayoutImpl(schema, name);
+}
 
 // ===================== Stage API =====================
 
@@ -557,6 +1108,7 @@ void ClickHouseInsertStage::ThreadCleanup() noexcept {
   if (!tl_inited || tl_cleaned) return;
   tl_cleaned = true;
   try { tl_client.reset(); } catch (...) {}
+  tl_record_schema.reset();
   tl_runtime_metrics.reset();
   tl_worker_index = -1;
 }
@@ -573,7 +1125,12 @@ void ClickHouseInsertStage::InsertBatch(std::vector<dmx_host_queue_item>&& batch
   std::vector<StagedRow> rows;
   rows.reserve(batch.size());
   for (auto& row : batch) {
-    rows.emplace_back(StageOneRow(std::move(row.core)));
+    if (!std::holds_alternative<ClickHouseRow>(row.row)) {
+      throw std::invalid_argument(
+          "fixed ClickHouse insert stage received a generic record row");
+    }
+    rows.emplace_back(
+        StageOneRow(std::move(std::get<ClickHouseRow>(row.row))));
   }
 
   const std::string fq_table = QualifiedTableNameQuoted(tl_db, tl_table);
@@ -647,9 +1204,244 @@ void ClickHouseInsertStage::InsertBatch(std::vector<dmx_host_queue_item>&& batch
   tl_runtime_metrics->EndInsert(tl_worker_index, row_count, logical_bytes, seconds);
 }
 
+void ClickHouseRecordInsertStage::ThreadInit(
+    int thread_idx, const ClickHouseRecordStageConfig& stage_cfg) {
+  if (tl_inited) {
+    throw std::runtime_error(
+        "ClickHouseRecordInsertStage::ThreadInit() called more than once in "
+        "the same thread");
+  }
+  if (tl_cleaned) {
+    throw std::runtime_error(
+        "ClickHouseRecordInsertStage::ThreadInit() called after "
+        "ThreadCleanup() in the same thread");
+  }
+
+  ValidateRecordSchema(stage_cfg.schema);
+  const ClickHouseClientConfig& cfg = stage_cfg.client;
+  tl_db = cfg.database;
+  tl_table.clear();
+
+  clickhouse::ClientOptions opts;
+  opts.SetHost(cfg.host);
+  opts.SetPort(static_cast<uint16_t>(cfg.port));
+  opts.SetUser(cfg.username);
+  opts.SetPassword(cfg.password);
+  if (cfg.connect_timeout_ms < 0 || cfg.receive_timeout_ms < 0 ||
+      cfg.send_timeout_ms < 0) {
+    throw std::invalid_argument("ClickHouse socket timeouts must be non-negative");
+  }
+  opts.SetConnectionConnectTimeout(
+      std::chrono::milliseconds(cfg.connect_timeout_ms));
+  opts.SetConnectionRecvTimeout(
+      std::chrono::milliseconds(cfg.receive_timeout_ms));
+  opts.SetConnectionSendTimeout(
+      std::chrono::milliseconds(cfg.send_timeout_ms));
+  opts.SetDefaultDatabase("default");
+  if (cfg.secure) {
+    opts.SetSSLOptions(clickhouse::ClientOptions::SSLOptions{});
+  }
+  {
+    const std::string compression = ToLower(cfg.client_side_compress);
+    if (compression == "lz4" || compression == "true" ||
+        compression == "1") {
+      SetCompressionCompat(opts, clickhouse::CompressionMethod::LZ4);
+    } else if (compression == "zstd") {
+      SetCompressionCompat(opts, clickhouse::CompressionMethod::ZSTD);
+    } else if (compression == "none" || compression == "false" ||
+               compression == "0" || compression.empty()) {
+      SetCompressionCompat(opts, clickhouse::CompressionMethod::None);
+    } else {
+      throw std::invalid_argument(
+          "client_side_compress must be one of: "
+          "'none','lz4','zstd','true','false'");
+    }
+  }
+
+  try {
+    const std::string endpoint_prefix =
+        cfg.host + '\0' + std::to_string(cfg.port) + '\0' +
+        (cfg.secure ? "1" : "0") + '\0';
+    const std::string db_key = endpoint_prefix + cfg.database;
+
+    {
+      std::lock_guard<std::mutex> lock(g_schema_mutex);
+      if (g_schema_inited_dbs.find(db_key) == g_schema_inited_dbs.end()) {
+        RunDbInitOnce(cfg, opts);
+        if (cfg.create_database_if_missing || cfg.drop_existing_database) {
+          g_schema_inited_dbs.insert(db_key);
+        }
+      }
+
+      // This is deliberately a live startup check, not a process-lifetime
+      // schema cache: a table may be dropped or recreated between engine
+      // instances in the same process.
+      InitializeAndValidateRecordTables(cfg, stage_cfg.schema, opts);
+    }
+
+    tl_client = std::make_unique<clickhouse::Client>(opts);
+    tl_client->Ping();
+    tl_client->Execute("USE " + QuoteIdent(cfg.database));
+    ApplySessionSettings(*tl_client, cfg);
+  } catch (const std::exception& e) {
+    tl_client.reset();
+    LogClickHouseInitFailure(cfg, e.what());
+    throw;
+  } catch (...) {
+    tl_client.reset();
+    LogClickHouseInitFailure(cfg, "unknown non-std exception");
+    throw;
+  }
+
+  tl_record_schema = stage_cfg.schema;
+  tl_worker_index = thread_idx;
+  tl_runtime_metrics = cfg.runtime_metrics;
+  tl_inited = true;
+  tl_runtime_metrics->WorkerReady(thread_idx);
+}
+
+void ClickHouseRecordInsertStage::ThreadCleanup() noexcept {
+  ClickHouseInsertStage::ThreadCleanup();
+}
+
+void ClickHouseRecordInsertStage::InsertBatch(
+    std::vector<dmx_host_queue_item>&& batch) {
+  clickhouse::Client& client = ClientOrThrow();
+  if (batch.empty()) return;
+  if (!tl_record_schema) {
+    throw std::runtime_error("record schema is not initialized in this worker");
+  }
+
+  struct LayoutBatch {
+    const RecordLayout* layout = nullptr;
+    std::vector<StagedRecordRow> rows;
+    std::uint64_t logical_bytes = 0;
+  };
+  std::map<std::string, LayoutBatch> grouped;
+
+  for (auto& item : batch) {
+    if (!std::holds_alternative<GenericRecordRow>(item.row)) {
+      throw std::invalid_argument(
+          "schema-driven ClickHouse stage received a fixed inference row");
+    }
+    GenericRecordRow record =
+        std::move(std::get<GenericRecordRow>(item.row));
+    const RecordLayout& layout =
+        FindRecordLayout(*tl_record_schema, record.layout);
+    auto& group = grouped[layout.name];
+    group.layout = &layout;
+    group.logical_bytes += item.item_size;
+    group.rows.emplace_back(
+        StageGenericRecordRow(std::move(record), layout));
+  }
+
+  for (auto& [layout_name, group] : grouped) {
+    (void)layout_name;
+    const RecordLayout& layout = *group.layout;
+    clickhouse::Block block;
+
+    for (std::size_t column_index = 0;
+         column_index < layout.columns.size(); ++column_index) {
+      const RecordColumn& definition = layout.columns[column_index];
+      switch (definition.type) {
+        case RecordCellType::STRING: {
+          auto column = std::make_shared<clickhouse::ColumnString>();
+          for (const auto& row : group.rows)
+            column->Append(std::get<std::string>(row.cells[column_index]));
+          block.AppendColumn(definition.name, column);
+          break;
+        }
+        case RecordCellType::INT32: {
+          auto column = std::make_shared<clickhouse::ColumnInt32>();
+          for (const auto& row : group.rows)
+            column->Append(std::get<int32_t>(row.cells[column_index]));
+          block.AppendColumn(definition.name, column);
+          break;
+        }
+        case RecordCellType::INT64: {
+          auto column = std::make_shared<clickhouse::ColumnInt64>();
+          for (const auto& row : group.rows)
+            column->Append(std::get<int64_t>(row.cells[column_index]));
+          block.AppendColumn(definition.name, column);
+          break;
+        }
+        case RecordCellType::FLOAT64: {
+          auto column = std::make_shared<clickhouse::ColumnFloat64>();
+          for (const auto& row : group.rows)
+            column->Append(std::get<double>(row.cells[column_index]));
+          block.AppendColumn(definition.name, column);
+          break;
+        }
+        case RecordCellType::INT64_ARRAY: {
+          auto values = std::make_shared<clickhouse::ColumnInt64>();
+          auto offsets = std::make_shared<clickhouse::ColumnUInt64>();
+          auto column = std::make_shared<clickhouse::ColumnArray>(values, offsets);
+          std::uint64_t offset = 0;
+          for (const auto& row : group.rows) {
+            const auto& array =
+                std::get<std::vector<int64_t>>(row.cells[column_index]);
+            for (const auto value : array) values->Append(value);
+            offset += static_cast<std::uint64_t>(array.size());
+            offsets->Append(offset);
+          }
+          block.AppendColumn(definition.name, column);
+          break;
+        }
+        case RecordCellType::TENSOR: {
+          auto dtype = std::make_shared<clickhouse::ColumnString>();
+          auto shape_values = std::make_shared<clickhouse::ColumnInt64>();
+          auto shape_offsets = std::make_shared<clickhouse::ColumnUInt64>();
+          auto shape = std::make_shared<clickhouse::ColumnArray>(
+              shape_values, shape_offsets);
+          auto bytes = std::make_shared<clickhouse::ColumnString>();
+          std::uint64_t shape_offset = 0;
+          for (const auto& row : group.rows) {
+            const auto& tensor =
+                std::get<EncodedTensor>(row.cells[column_index]);
+            dtype->Append(tensor.dtype);
+            for (const auto dimension : tensor.shape)
+              shape_values->Append(dimension);
+            shape_offset += static_cast<std::uint64_t>(tensor.shape.size());
+            shape_offsets->Append(shape_offset);
+            bytes->AppendNoManagedLifetime(tensor.bytes_view);
+          }
+          block.AppendColumn(definition.dtype_column, dtype);
+          block.AppendColumn(definition.shape_column, shape);
+          block.AppendColumn(definition.bytes_column, bytes);
+          break;
+        }
+      }
+    }
+
+    const std::string table =
+        QualifiedTableNameQuoted(tl_db, layout.table);
+    const std::uint64_t row_count = group.rows.size();
+    const auto started = std::chrono::steady_clock::now();
+    tl_runtime_metrics->BeginInsert();
+    try {
+      client.Insert(table, block);
+    } catch (...) {
+      const double seconds = std::chrono::duration<double>(
+          std::chrono::steady_clock::now() - started).count();
+      tl_runtime_metrics->EndInsert(tl_worker_index, row_count,
+                                    group.logical_bytes, seconds);
+      throw;
+    }
+    const double seconds = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - started).count();
+    tl_runtime_metrics->EndInsert(tl_worker_index, row_count,
+                                  group.logical_bytes, seconds);
+  }
+}
+
 // Force emission of the specialization referenced from bindings.cpp:
 template std::optional<std::vector<dmx_host_queue_item>>
 ClickHouseInsertStage::ProcessFn<DMXHostEngine::QueueT>(
+    std::vector<dmx_host_queue_item>,
+    DMXHostEngine::QueueT*);
+
+template std::optional<std::vector<dmx_host_queue_item>>
+ClickHouseRecordInsertStage::ProcessFn<DMXHostEngine::QueueT>(
     std::vector<dmx_host_queue_item>,
     DMXHostEngine::QueueT*);
 

--- a/native/csrc/clickhouse_client.h
+++ b/native/csrc/clickhouse_client.h
@@ -17,6 +17,7 @@
 #include <clickhouse/client.h>
 
 #include "dmx_host_utils.h"
+#include "record_schema.h"
 
 namespace dmx_host {
 
@@ -101,6 +102,14 @@ struct ClickHouseClientConfig {
       std::make_shared<ClickHouseRuntimeMetrics>();
 };
 
+// Internal, immutable worker initialization value for the additive generic
+// record stage. ClickHouseClientConfig itself remains the released connection
+// configuration and is intentionally not extended with schema state.
+struct ClickHouseRecordStageConfig {
+  ClickHouseClientConfig client;
+  RecordSchema schema;
+};
+
 /**
  * ClickHouse sink stage for PipelinedEngine.
  *
@@ -143,6 +152,32 @@ class ClickHouseInsertStage final {
                                                                     QueueT* /*next_q*/) {
     InsertBatch(std::move(batch));
     return std::vector<dmx_host_queue_item>{};  // sink: no outputs
+  }
+};
+
+/** Schema-driven typed-row sink. This is a separate opt-in stage; it does not
+ * route through or reinterpret ClickHouseInsertStage's fixed inference row.
+ */
+class ClickHouseRecordInsertStage final {
+ public:
+  static void ThreadInit(int thread_idx,
+                         const ClickHouseRecordStageConfig& cfg);
+  static void ThreadCleanup() noexcept;
+  static void InsertBatch(std::vector<dmx_host_queue_item>&& batch);
+
+  static inline void ThreadInitAny(int thread_idx, const std::any& cfg_any) {
+    ThreadInit(
+        thread_idx,
+        std::any_cast<const ClickHouseRecordStageConfig&>(cfg_any));
+  }
+
+  static inline void ThreadCleanupAny() noexcept { ThreadCleanup(); }
+
+  template <typename QueueT>
+  static inline std::optional<std::vector<dmx_host_queue_item>> ProcessFn(
+      std::vector<dmx_host_queue_item> batch, QueueT* /*next_q*/) {
+    InsertBatch(std::move(batch));
+    return std::vector<dmx_host_queue_item>{};
   }
 };
 

--- a/native/csrc/clickhouse_record_sink.cpp
+++ b/native/csrc/clickhouse_record_sink.cpp
@@ -59,7 +59,6 @@ std::vector<std::int64_t> resolve_shape(const ring::PayloadSlice& slice,
                                         std::uint64_t length_bytes,
                                         at::ScalarType dtype) {
     std::vector<std::int64_t> shape = slice.logical_shape;
-    if (shape.empty()) invalid("tensor payload requires a logical shape");
 
     const auto element_bytes =
         static_cast<std::uint64_t>(at::elementSize(dtype));

--- a/native/csrc/clickhouse_record_sink.cpp
+++ b/native/csrc/clickhouse_record_sink.cpp
@@ -1,0 +1,230 @@
+#include "clickhouse_record_sink.h"
+
+#include <ATen/ATen.h>
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace dmx_host {
+
+namespace {
+
+[[noreturn]] void invalid(const std::string& message) {
+    throw std::runtime_error("clickhouse record sink: " + message);
+}
+
+std::uint64_t checked_product(const std::vector<std::int64_t>& shape,
+                              std::int32_t skip_dimension) {
+    std::uint64_t result = 1;
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+        if (static_cast<std::int32_t>(i) == skip_dimension) continue;
+        if (shape[i] < 0) invalid("negative logical tensor dimension");
+        const auto dimension = static_cast<std::uint64_t>(shape[i]);
+        if (dimension != 0 &&
+            result > std::numeric_limits<std::uint64_t>::max() / dimension) {
+            invalid("logical tensor shape overflows uint64");
+        }
+        result *= dimension;
+    }
+    return result;
+}
+
+at::ScalarType checked_dtype(std::int32_t encoded) {
+    if (encoded < 0 ||
+        encoded >= static_cast<std::int32_t>(at::ScalarType::NumOptions)) {
+        invalid("unsupported encoded dtype");
+    }
+    const auto dtype = static_cast<at::ScalarType>(encoded);
+    if (at::elementSize(dtype) <= 0) {
+        invalid("dtype has no materializable element size");
+    }
+    return dtype;
+}
+
+std::uint64_t resolve_slice_length(const ring::PayloadSlice& slice,
+                                   std::uint64_t payload_bytes) {
+    if (slice.offset_bytes > payload_bytes) {
+        invalid("payload-slice offset exceeds actual payload bytes");
+    }
+    const std::uint64_t available = payload_bytes - slice.offset_bytes;
+    const std::uint64_t length = slice.length_bytes.value_or(available);
+    if (length > available) {
+        invalid("payload-slice length exceeds actual payload bytes");
+    }
+    return length;
+}
+
+std::vector<std::int64_t> resolve_shape(const ring::PayloadSlice& slice,
+                                        std::uint64_t length_bytes,
+                                        at::ScalarType dtype) {
+    std::vector<std::int64_t> shape = slice.logical_shape;
+    if (shape.empty()) invalid("tensor payload requires a logical shape");
+
+    const auto element_bytes =
+        static_cast<std::uint64_t>(at::elementSize(dtype));
+    if (length_bytes % element_bytes != 0) {
+        invalid("payload-slice bytes are not divisible by dtype size");
+    }
+    const std::uint64_t elements = length_bytes / element_bytes;
+
+    if (slice.inferred_dynamic_dim >= 0) {
+        if (slice.inferred_dynamic_dim >=
+            static_cast<std::int32_t>(shape.size())) {
+            invalid("inferred dynamic dimension is out of range");
+        }
+        const std::uint64_t fixed =
+            checked_product(shape, slice.inferred_dynamic_dim);
+        if (fixed == 0 || elements % fixed != 0) {
+            invalid("payload bytes cannot infer the requested tensor dimension");
+        }
+        const std::uint64_t inferred = elements / fixed;
+        if (inferred >
+            static_cast<std::uint64_t>(
+                std::numeric_limits<std::int64_t>::max())) {
+            invalid("inferred tensor dimension exceeds int64");
+        }
+        shape[static_cast<std::size_t>(slice.inferred_dynamic_dim)] =
+            static_cast<std::int64_t>(inferred);
+    } else if (checked_product(shape, -1) != elements) {
+        invalid("fixed tensor shape does not match payload-slice bytes");
+    }
+    return shape;
+}
+
+at::Tensor materialize_tensor(const at::Tensor& payload,
+                              const ring::PayloadSlice& slice,
+                              std::uint64_t length_bytes,
+                              at::ScalarType dtype) {
+    const std::vector<std::int64_t> shape =
+        resolve_shape(slice, length_bytes, dtype);
+    const auto element_bytes =
+        static_cast<std::uint64_t>(at::elementSize(dtype));
+    if (slice.offset_bytes % element_bytes != 0) {
+        invalid("payload-slice offset is not aligned to its dtype size");
+    }
+    at::Tensor bytes = payload.narrow(
+        0, static_cast<std::int64_t>(slice.offset_bytes),
+        static_cast<std::int64_t>(length_bytes));
+
+    // The ClickHouse host queue may outlive this envelope.  Other sinks can
+    // consume the owned payload directly without paying this per-cell copy.
+    return bytes.view(dtype).reshape(shape).clone();
+}
+
+}  // namespace
+
+ClickHouseRecordSink::ClickHouseRecordSink(SubmitRowFn submit_row,
+                                           FlushFn flush,
+                                           RethrowFn rethrow)
+    : submit_row_(std::move(submit_row)),
+      flush_(std::move(flush)),
+      rethrow_(std::move(rethrow)) {
+    if (!submit_row_ || !flush_ || !rethrow_) {
+        throw std::invalid_argument(
+            "ClickHouseRecordSink requires submit, flush, and failure callbacks");
+    }
+}
+
+void ClickHouseRecordSink::submit(ring::RecordEnvelope envelope) {
+    const auto& descriptor = envelope.descriptor;
+    const auto& payload = envelope.payload;
+    if (descriptor.layout.empty()) invalid("record layout is empty");
+
+    const auto payload_bytes = static_cast<std::uint64_t>(payload.numel());
+    for (const ring::EncodedRecordRow& encoded_row : descriptor.rows) {
+        GenericRecordRow row;
+        row.layout = descriptor.layout;
+        row.cells.reserve(encoded_row.cells.size());
+
+        std::uint64_t accounted_bytes = 0;
+        for (const ring::EncodedRecordCell& encoded_cell : encoded_row.cells) {
+            if (const auto* value = std::get_if<std::string>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value =
+                           std::get_if<std::int32_t>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value =
+                           std::get_if<std::int64_t>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value = std::get_if<double>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value =
+                           std::get_if<std::vector<std::int64_t>>(
+                               &encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else {
+                const auto& slice = std::get<ring::PayloadSlice>(encoded_cell);
+                const std::uint64_t length =
+                    resolve_slice_length(slice, payload_bytes);
+                accounted_bytes += length;
+                const at::ScalarType dtype = checked_dtype(slice.dtype);
+
+                switch (slice.materialization) {
+                    case ring::PayloadMaterialization::TENSOR:
+                        row.cells.emplace_back(materialize_tensor(
+                            payload, slice, length, dtype));
+                        break;
+                    case ring::PayloadMaterialization::FLOAT_SCALAR: {
+                        if (!c10::isFloatingType(dtype)) {
+                            invalid(
+                                "floating scalar requires a floating-point dtype");
+                        }
+                        if (length != static_cast<std::uint64_t>(
+                                          at::elementSize(dtype))) {
+                            invalid(
+                                "floating scalar slice must contain exactly one element");
+                        }
+                        if (slice.offset_bytes %
+                                static_cast<std::uint64_t>(
+                                    at::elementSize(dtype)) !=
+                            0) {
+                            invalid(
+                                "floating scalar offset is not dtype-aligned");
+                        }
+                        at::Tensor scalar = payload.narrow(
+                            0, static_cast<std::int64_t>(slice.offset_bytes),
+                            static_cast<std::int64_t>(length)).view(dtype);
+                        row.cells.emplace_back(scalar.item<double>());
+                        break;
+                    }
+                    case ring::PayloadMaterialization::INT_SCALAR: {
+                        if (!c10::isIntegralType(
+                                dtype, /*includeBool=*/false)) {
+                            invalid(
+                                "integer scalar requires an integral dtype");
+                        }
+                        if (length != static_cast<std::uint64_t>(
+                                          at::elementSize(dtype))) {
+                            invalid(
+                                "integer scalar slice must contain exactly one element");
+                        }
+                        if (slice.offset_bytes %
+                                static_cast<std::uint64_t>(
+                                    at::elementSize(dtype)) !=
+                            0) {
+                            invalid("integer scalar offset is not dtype-aligned");
+                        }
+                        at::Tensor scalar = payload.narrow(
+                            0, static_cast<std::int64_t>(slice.offset_bytes),
+                            static_cast<std::int64_t>(length)).view(dtype);
+                        row.cells.emplace_back(scalar.item<std::int64_t>());
+                        break;
+                    }
+                }
+            }
+        }
+
+        submit_row_(std::move(row), accounted_bytes);
+    }
+}
+
+bool ClickHouseRecordSink::flush_and_wait(Duration timeout) {
+    return flush_(timeout);
+}
+
+void ClickHouseRecordSink::rethrow_if_failed() const {
+    rethrow_();
+}
+
+}  // namespace dmx_host

--- a/native/csrc/clickhouse_record_sink.h
+++ b/native/csrc/clickhouse_record_sink.h
@@ -1,0 +1,33 @@
+// Adapter from backend-neutral record envelopes to ClickHouse host rows.
+
+#pragma once
+
+#include "dmx_host_utils.h"
+#include "ring/record_sink.h"
+
+#include <functional>
+
+namespace dmx_host {
+
+class ClickHouseRecordSink final : public ring::RecordSink {
+public:
+    using SubmitRowFn =
+        std::function<void(GenericRecordRow, std::uint64_t)>;
+    using FlushFn = std::function<bool(Duration)>;
+    using RethrowFn = std::function<void()>;
+
+    ClickHouseRecordSink(SubmitRowFn submit_row,
+                         FlushFn flush,
+                         RethrowFn rethrow);
+
+    void submit(ring::RecordEnvelope envelope) override;
+    bool flush_and_wait(Duration timeout) override;
+    void rethrow_if_failed() const override;
+
+private:
+    SubmitRowFn submit_row_;
+    FlushFn flush_;
+    RethrowFn rethrow_;
+};
+
+}  // namespace dmx_host

--- a/native/csrc/dmx_host_engine.h
+++ b/native/csrc/dmx_host_engine.h
@@ -45,6 +45,17 @@ public:
         return metrics_->Snapshot();
     }
 
+    void validate_record_schema(const RecordSchema& schema) const {
+        if (!record_stage_) {
+            throw std::logic_error(
+                "record runtime requires a schema-driven record stage");
+        }
+        if (RecordSchemaIdentity(schema) != record_schema_identity_) {
+            throw std::invalid_argument(
+                "record runtime schema does not match the host record stage");
+        }
+    }
+
     // Submit a pre-assembled ClickHouseRow directly to the insert stage.
     // Fields must match the order expected by ClickHouseInsertStage:
     //   [0] model_id     (string)
@@ -58,33 +69,75 @@ public:
     void submit_direct(ClickHouseRow row, uint64_t nbytes) {
         std::vector<dmx_host_queue_item> items;
         items.emplace_back(std::move(row), nbytes);
-        submit_items(std::move(items));
+        Base::submit_items(std::move(items));
+    }
+
+    void submit_record(GenericRecordRow row, uint64_t nbytes) {
+        std::vector<dmx_host_queue_item> items;
+        items.emplace_back(std::move(row), nbytes);
+        Base::submit_items(std::move(items));
+    }
+
+    bool flush_and_wait(Duration timeout) {
+        if (timeout.count() < 0.0) {
+            throw std::invalid_argument("timeout must be non-negative");
+        }
+        if (!record_stage_) {
+            throw std::logic_error(
+                "durable record flush requires a schema-driven record stage");
+        }
+        return Base::flush_and_wait(timeout);
     }
 
 private:
     struct PreparedStage {
         StageConfig stage;
         std::shared_ptr<ClickHouseRuntimeMetrics> metrics;
+        bool record_stage{false};
+        std::string record_schema_identity;
     };
 
     static PreparedStage Prepare(StageConfig stage) {
         if (stage.parallelism <= 0) {
             throw std::invalid_argument("parallelism must be positive");
         }
-        auto config =
-            std::any_cast<ClickHouseClientConfig>(stage.thread_init_config);
         auto metrics =
             std::make_shared<ClickHouseRuntimeMetrics>(stage.parallelism);
-        config.runtime_metrics = metrics;
-        stage.thread_init_config = std::move(config);
-        return PreparedStage{std::move(stage), std::move(metrics)};
+        bool record_stage = false;
+        std::string record_schema_identity;
+        if (stage.thread_init_config.type() == typeid(ClickHouseClientConfig)) {
+            auto config =
+                std::any_cast<ClickHouseClientConfig>(stage.thread_init_config);
+            config.runtime_metrics = metrics;
+            stage.thread_init_config = std::move(config);
+        } else if (stage.thread_init_config.type() ==
+                   typeid(ClickHouseRecordStageConfig)) {
+            record_stage = true;
+            auto config =
+                std::any_cast<ClickHouseRecordStageConfig>(
+                    stage.thread_init_config);
+            record_schema_identity = RecordSchemaIdentity(config.schema);
+            config.client.runtime_metrics = metrics;
+            stage.thread_init_config = std::move(config);
+        } else {
+            throw std::invalid_argument(
+                "unsupported DMXHostEngine stage initialization config");
+        }
+        return PreparedStage{
+            std::move(stage), std::move(metrics), record_stage,
+            std::move(record_schema_identity)};
     }
 
     explicit DMXHostEngine(PreparedStage prepared)
         : Base(std::array<StageConfig, 1>{std::move(prepared.stage)}, EngineConfig{}),
-          metrics_(std::move(prepared.metrics)) {}
+          metrics_(std::move(prepared.metrics)),
+          record_stage_(prepared.record_stage),
+          record_schema_identity_(
+              std::move(prepared.record_schema_identity)) {}
 
     std::shared_ptr<ClickHouseRuntimeMetrics> metrics_;
+    bool record_stage_{false};
+    std::string record_schema_identity_;
 };
 
 }

--- a/native/csrc/dmx_host_utils.h
+++ b/native/csrc/dmx_host_utils.h
@@ -11,22 +11,36 @@
 
 namespace dmx_host{
 
-// Input cell types for a row.
+// Released fixed inference row cell types. Keep this alias and its eight-cell
+// contract unchanged.
 using ClickHouseValue = std::variant<std::string, int32_t, std::vector<int64_t>, at::Tensor>;
-
-// One item == one row (vector of cells).
 using ClickHouseRow = std::vector<ClickHouseValue>;
+
+// Additive schema-driven record cells. The integration has already encoded
+// semantic metadata before this host-only representation is constructed.
+using RecordValue = std::variant<std::string, int32_t, int64_t, double,
+                                 std::vector<int64_t>, at::Tensor>;
+
+struct GenericRecordRow {
+    std::string layout;
+    std::vector<RecordValue> cells;
+};
+
+using DmxHostRow = std::variant<ClickHouseRow, GenericRecordRow>;
 
 struct dmx_host_queue_item{
     uint64_t item_size;
-    ClickHouseRow core;
-    dmx_host_queue_item(ClickHouseRow queued_core, uint64_t size){
-        this->item_size = size;
-        this->core = std::move(queued_core);
-    };
+    DmxHostRow row;
+
+    dmx_host_queue_item(ClickHouseRow queued_core, uint64_t size)
+        : item_size(size), row(std::move(queued_core)) {}
+
+    dmx_host_queue_item(GenericRecordRow queued_record, uint64_t size)
+        : item_size(size), row(std::move(queued_record)) {}
+
     uint64_t size() const {
         return this->item_size;
-    };
+    }
 };
 
 }

--- a/native/csrc/pipelined_engine.hpp
+++ b/native/csrc/pipelined_engine.hpp
@@ -355,6 +355,10 @@ class PipelinedEngine
     validate_config_();
     build_queues_();
     init_engine_profiling_();
+    if constexpr (NumStages == 1) {
+      acknowledged_generation_by_worker_.assign(
+          static_cast<std::size_t>(stages_[0].parallelism), 0);
+    }
   }
 
   ~PipelinedEngine() noexcept {
@@ -482,24 +486,31 @@ class PipelinedEngine
   }
 
   void close_input() {
-    std::lock_guard<std::mutex> lk(state_mu_);
-    if (input_closed_) return;
-    input_closed_ = true;
-    queues_[0]->close();
+    {
+      std::lock_guard<std::mutex> lk(state_mu_);
+      if (input_closed_) return;
+      input_closed_ = true;
+      queues_[0]->close();
+    }
+    fail_active_flush_noexcept_("input closed during durable flush");
   }
 
   void request_abort() {
+    bool already_stopping = false;
     {
       std::lock_guard<std::mutex> lk(state_mu_);
       if (stop_event_.load(std::memory_order_acquire)) {
         input_closed_ = true;
-        return;
+        already_stopping = true;
+      } else {
+        stop_event_.store(true, std::memory_order_release);
+        input_closed_ = true;
       }
-      stop_event_.store(true, std::memory_order_release);
-      input_closed_ = true;
     }
 
-    if (cfg_.close_queues_on_abort) {
+    mark_flush_terminal_failure_noexcept_("engine stopped or aborted");
+
+    if (!already_stopping && cfg_.close_queues_on_abort) {
       for (auto& q : queues_) {
         try {
           q->close();
@@ -603,6 +614,140 @@ class PipelinedEngine
     if (want_stats) {
       prof_ingest_add_submit_enqueue_(want_timing ? std::chrono::duration<double>(Clock::now() - t0).count() : 0.0);
     }
+  }
+
+  // Force the currently queued items through the one-stage sink and wait until
+  // every worker has reached the resulting empty-queue rendezvous.
+  bool flush_and_wait(std::optional<Duration> timeout = std::nullopt) {
+    static_assert(
+        NumStages == 1,
+        "PipelinedEngine::flush_and_wait is supported only for one-stage engines");
+
+    if (timeout && timeout->count() < 0.0) {
+      throw std::invalid_argument("flush timeout must be nonnegative");
+    }
+    TimePoint end_at;
+    const bool have_deadline = timeout.has_value();
+    if (have_deadline) {
+      end_at = Clock::now() +
+          std::chrono::duration_cast<Clock::duration>(*timeout);
+    }
+
+    {
+      std::lock_guard<std::mutex> lk(state_mu_);
+      if (!started_) {
+        throw std::runtime_error("cannot flush an engine that has not started");
+      }
+      if (input_closed_) {
+        throw std::runtime_error("cannot flush an engine with closed input");
+      }
+      if (stop_event_.load(std::memory_order_acquire)) {
+        throw std::runtime_error("cannot flush a stopped or aborted engine");
+      }
+    }
+    raise_if_failed();
+
+    std::uint64_t generation = 0;
+    {
+      std::lock_guard<std::mutex> lk(flush_mu_);
+      if (flush_terminal_failure_) {
+        throw std::runtime_error(
+            "durable flush is unavailable after terminal failure: " +
+            flush_terminal_reason_);
+      }
+      if (flush_in_progress_) {
+        throw std::runtime_error("concurrent durable flush is unsupported");
+      }
+      if (acknowledged_generation_by_worker_.size() !=
+          static_cast<std::size_t>(stages_[0].parallelism)) {
+        throw std::logic_error("durable-flush worker registry is inconsistent");
+      }
+
+      generation = ++next_flush_generation_;
+      active_flush_generation_ = generation;
+      remaining_flush_workers_ =
+          static_cast<std::size_t>(stages_[0].parallelism);
+      flush_in_progress_ = true;
+    }
+
+    try {
+      queues_[0]->begin_flush();
+    } catch (...) {
+      {
+        std::lock_guard<std::mutex> lk(flush_mu_);
+        flush_terminal_failure_ = true;
+        flush_terminal_reason_ = "failed to enable queue flush mode";
+        flush_in_progress_ = false;
+      }
+      flush_cv_.notify_all();
+      request_abort();
+      throw;
+    }
+
+    bool timed_out = false;
+    std::string failure_reason;
+    {
+      std::unique_lock<std::mutex> lk(flush_mu_);
+      const auto completed_or_failed = [this] {
+        return remaining_flush_workers_ == 0 || flush_terminal_failure_;
+      };
+      bool ready = true;
+      if (have_deadline) {
+        ready = flush_cv_.wait_until(lk, end_at, completed_or_failed);
+      } else {
+        flush_cv_.wait(lk, completed_or_failed);
+      }
+      if (!ready) {
+        timed_out = true;
+        flush_terminal_failure_ = true;
+        flush_terminal_reason_ = "durable flush timed out";
+      }
+      if (flush_terminal_failure_) {
+        failure_reason = flush_terminal_reason_;
+      }
+    }
+
+    try {
+      queues_[0]->end_flush();
+    } catch (...) {
+      {
+        std::lock_guard<std::mutex> lk(flush_mu_);
+        flush_terminal_failure_ = true;
+        flush_terminal_reason_ = "failed to disable queue flush mode";
+        flush_in_progress_ = false;
+      }
+      flush_cv_.notify_all();
+      request_abort();
+      throw;
+    }
+
+    bool success = false;
+    {
+      std::lock_guard<std::mutex> lk(flush_mu_);
+      if (!flush_terminal_failure_ && have_deadline &&
+          Clock::now() > end_at) {
+        timed_out = true;
+        flush_terminal_failure_ = true;
+        flush_terminal_reason_ = "durable flush timed out";
+        failure_reason = flush_terminal_reason_;
+      }
+      success = !flush_terminal_failure_ && remaining_flush_workers_ == 0;
+      if (success) {
+        completed_flush_generation_ = generation;
+      } else if (failure_reason.empty()) {
+        failure_reason = flush_terminal_reason_.empty()
+            ? "durable flush failed"
+            : flush_terminal_reason_;
+      }
+      flush_in_progress_ = false;
+    }
+    flush_cv_.notify_all();
+
+    if (success) return true;
+
+    request_abort();
+    if (timed_out) return false;
+    throw std::runtime_error(failure_reason);
   }
 
   // ------------------------------------------------------------
@@ -752,6 +897,75 @@ class PipelinedEngine
     } catch (...) {
       // swallow
     }
+    mark_flush_terminal_failure_noexcept_("engine worker failure");
+  }
+
+  void fail_active_flush_noexcept_(const char* reason) noexcept {
+    bool notify = false;
+    try {
+      std::lock_guard<std::mutex> lk(flush_mu_);
+      if (flush_in_progress_) {
+        flush_terminal_failure_ = true;
+        if (flush_terminal_reason_.empty()) flush_terminal_reason_ = reason;
+        notify = true;
+      }
+    } catch (...) {
+    }
+    if (notify) flush_cv_.notify_all();
+  }
+
+  void mark_flush_terminal_failure_noexcept_(const char* reason) noexcept {
+    try {
+      {
+        std::lock_guard<std::mutex> lk(flush_mu_);
+        flush_terminal_failure_ = true;
+        if (flush_terminal_reason_.empty()) flush_terminal_reason_ = reason;
+      }
+      flush_cv_.notify_all();
+    } catch (...) {
+    }
+  }
+
+  bool acknowledge_and_wait_for_flush_release_(
+      std::size_t stage_idx, int thread_idx) {
+    static_assert(
+        NumStages == 1,
+        "durable-flush worker rendezvous is supported only for one-stage engines");
+    if (stage_idx != 0 || thread_idx < 0) {
+      throw std::logic_error("invalid durable-flush worker identity");
+    }
+
+    std::unique_lock<std::mutex> lk(flush_mu_);
+    if (flush_terminal_failure_) return false;
+    if (!flush_in_progress_) {
+      throw std::logic_error(
+          "open-empty dequeue observed without an active durable flush");
+    }
+
+    const std::size_t worker_id = static_cast<std::size_t>(thread_idx);
+    if (worker_id >= acknowledged_generation_by_worker_.size()) {
+      throw std::logic_error("durable-flush worker identity is out of range");
+    }
+
+    const std::uint64_t generation = active_flush_generation_;
+    if (acknowledged_generation_by_worker_[worker_id] == generation) {
+      throw std::logic_error(
+          "worker acknowledged the same durable-flush generation twice");
+    }
+    if (remaining_flush_workers_ == 0) {
+      throw std::logic_error("durable-flush worker count underflow");
+    }
+
+    acknowledged_generation_by_worker_[worker_id] = generation;
+    --remaining_flush_workers_;
+    if (remaining_flush_workers_ == 0) flush_cv_.notify_all();
+
+    flush_cv_.wait(lk, [this, generation] {
+      return flush_terminal_failure_ || !flush_in_progress_ ||
+             active_flush_generation_ != generation;
+    });
+    return !flush_terminal_failure_ &&
+           completed_flush_generation_ >= generation;
   }
 
   void warn_once_no_output_handler_(const std::string& stage_name, std::size_t n_items) {
@@ -860,7 +1074,19 @@ class PipelinedEngine
         }
 
         if (stop_event_.load(std::memory_order_acquire)) return;
-        if (batch.empty()) return;  // closed and empty
+        if (batch.empty()) {
+          if (in_q.closed()) return;
+
+          if constexpr (NumStages == 1) {
+            if (!acknowledge_and_wait_for_flush_release_(stage_idx, thread_idx)) {
+              return;
+            }
+            continue;
+          } else {
+            throw std::logic_error(
+                "open-empty dequeue is unsupported for multi-stage engines");
+          }
+        }
 
         if (want_stats) {
           prof_stage_batched_io_(stage_idx, /*batches=*/1,
@@ -1209,6 +1435,18 @@ class PipelinedEngine
   // failures
   mutable std::mutex fail_mu_;
   std::vector<ThreadFailure> failures_;
+
+  // Nonterminal durable flush. Normal batches never acquire this mutex.
+  mutable std::mutex flush_mu_;
+  std::condition_variable flush_cv_;
+  std::uint64_t next_flush_generation_ = 0;
+  std::uint64_t active_flush_generation_ = 0;
+  std::uint64_t completed_flush_generation_ = 0;
+  bool flush_in_progress_ = false;
+  bool flush_terminal_failure_ = false;
+  std::string flush_terminal_reason_;
+  std::size_t remaining_flush_workers_ = 0;
+  std::vector<std::uint64_t> acknowledged_generation_by_worker_;
 
   // warnings
   mutable std::mutex warn_mu_;

--- a/native/csrc/record_schema.h
+++ b/native/csrc/record_schema.h
@@ -1,0 +1,55 @@
+#ifndef DMX_HOST_RECORD_SCHEMA_H_
+#define DMX_HOST_RECORD_SCHEMA_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dmx_host {
+
+// Framework-neutral logical cell types accepted by the schema-driven host
+// sink. TENSOR is one logical cell that expands into the three explicitly
+// named ClickHouse columns in RecordColumn.
+enum class RecordCellType : std::uint8_t {
+  STRING = 0,
+  INT32 = 1,
+  INT64 = 2,
+  FLOAT64 = 3,
+  INT64_ARRAY = 4,
+  TENSOR = 5,
+};
+
+struct RecordColumn {
+  std::string name;
+  RecordCellType type = RecordCellType::STRING;
+
+  // Required only for TENSOR. The integration chooses all physical names.
+  std::string dtype_column;
+  std::string shape_column;
+  std::string bytes_column;
+};
+
+struct RecordLayout {
+  // Descriptor-visible layout identifier and destination table.
+  std::string name;
+  std::string table;
+  std::vector<RecordColumn> columns;
+  std::vector<std::string> primary_key;
+  std::vector<std::string> order_by;
+};
+
+struct RecordSchema {
+  std::vector<RecordLayout> layouts;
+  int index_granularity = 8192;
+};
+
+// Validate once while constructing the stage. Native worker threads receive a
+// copied immutable schema and do not access Python objects.
+void ValidateRecordSchema(const RecordSchema& schema);
+std::string RecordSchemaIdentity(const RecordSchema& schema);
+const RecordLayout& FindRecordLayout(const RecordSchema& schema,
+                                     const std::string& name);
+
+}  // namespace dmx_host
+
+#endif  // DMX_HOST_RECORD_SCHEMA_H_

--- a/native/csrc/ring/drain_thread.cpp
+++ b/native/csrc/ring/drain_thread.cpp
@@ -246,37 +246,43 @@ void DrainThread::reserve(uint64_t payload_bytes, uint32_t num_tasks) {
     cpu_task_head_    += num_tasks;
 }
 
-void DrainThread::reserve_record(uint64_t payload_bytes, uint32_t num_tasks) {
-    if (payload_bytes % PAYLOAD_ALIGN != 0) {
-        throw std::invalid_argument(
-            "DrainThread::reserve_record payload bytes must be aligned");
-    }
-    if (num_tasks == 0) {
-        if (payload_bytes != 0) {
+void DrainThread::reserve_record(
+    const std::vector<RecordReservationItem>& items) {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
+    uint64_t payload_bytes = 0;
+    for (uint64_t index = 0; index < items.size(); ++index) {
+        const auto& item = items[index];
+        if (item.reserved_payload_bytes % PAYLOAD_ALIGN != 0) {
             throw std::invalid_argument(
-                "DrainThread::reserve_record cannot reserve payload without tasks");
+                "DrainThread::reserve_record payload bytes must be aligned");
         }
-        return;
+        if (payload_bytes > std::numeric_limits<uint64_t>::max() -
+                                item.reserved_payload_bytes) {
+            throw std::overflow_error(
+                "DrainThread::reserve_record payload byte total overflow");
+        }
+        payload_bytes += item.reserved_payload_bytes;
+        if (item.needs_reclaim) {
+            pending_task_reclaims_.push_back(
+                {cpu_task_head_ + index, item.reserved_payload_bytes});
+        }
     }
-
-    std::lock_guard<std::mutex> lk(mgmt_mu_);
-    RecordReservation reservation{};
-    reservation.first_task_sequence = cpu_task_head_;
-    reservation.reserved_payload_bytes = payload_bytes;
-    reservation.task_count = num_tasks;
-    record_reservations_.push_back(reservation);
     cpu_payload_head_ += payload_bytes;
-    cpu_task_head_ += num_tasks;
+    cpu_task_head_ += items.size();
 }
 
-uint64_t DrainThread::pending_record_reservations() const {
+void DrainThread::apply_pending_record_reclaims() {
     std::lock_guard<std::mutex> lk(mgmt_mu_);
-    return record_reservations_.size();
+    if (pending_reclaim_bytes_ > cpu_payload_head_) {
+        throw std::logic_error("record reclaim exceeds CPU payload head");
+    }
+    cpu_payload_head_ -= pending_reclaim_bytes_;
+    pending_reclaim_bytes_ = 0;
 }
 
-uint64_t DrainThread::reclaimed_record_bytes() const {
+uint64_t DrainThread::pending_record_reclaims() const {
     std::lock_guard<std::mutex> lk(mgmt_mu_);
-    return reclaimed_record_bytes_;
+    return pending_task_reclaims_.size();
 }
 
 void DrainThread::rethrow_record_reclaim_failure() const {
@@ -512,49 +518,33 @@ void DrainThread::scan_ready() {
 
 void DrainThread::account_record_task(uint64_t sequence,
                                       const TaskEntry& entry) {
-    if (record_reservations_.empty() || record_reclaim_failure_) return;
+    if (pending_task_reclaims_.empty() || record_reclaim_failure_) return;
 
-    RecordReservation& reservation = record_reservations_.front();
-    const uint64_t expected = reservation.first_task_sequence +
-        reservation.completed_tasks;
-
-    // A legacy task can precede the first record reservation.  Record-mode
-    // task ranges themselves are contiguous because reserve_record advances
-    // the task head once for the complete group.
-    if (sequence < reservation.first_task_sequence) return;
-    if (sequence != expected) {
+    const PendingTaskReclaim& pending = pending_task_reclaims_.front();
+    if (sequence < pending.task_sequence) return;
+    if (sequence != pending.task_sequence) {
         record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
-            "record reservation task sequence does not match ready TaskEntry"));
+            "record reclaim task sequence does not match ready TaskEntry"));
         return;
     }
 
     const uint64_t actual = align_up(entry.tensor_total_bytes, PAYLOAD_ALIGN);
-    if (reservation.actual_aligned_bytes >
-        std::numeric_limits<uint64_t>::max() - actual) {
-        record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
-            "record reservation actual byte accounting overflow"));
-        return;
-    }
-    reservation.actual_aligned_bytes += actual;
-    ++reservation.completed_tasks;
-
-    if (reservation.completed_tasks != reservation.task_count) return;
-
-    if (reservation.actual_aligned_bytes <=
-        reservation.reserved_payload_bytes) {
-        const uint64_t unused = reservation.reserved_payload_bytes -
-            reservation.actual_aligned_bytes;
-        cpu_payload_head_ -= unused;
-        reclaimed_record_bytes_ += unused;
-    } else {
-        // Preserve CPU/GPU logical-head agreement before surfacing the
-        // violated upper-bound invariant through checked completion.
-        cpu_payload_head_ += reservation.actual_aligned_bytes -
-            reservation.reserved_payload_bytes;
+    if (actual > pending.reserved_payload_bytes) {
         record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
             "record producer exceeded its conservative payload reservation"));
+        pending_task_reclaims_.pop_front();
+        return;
     }
-    record_reservations_.pop_front();
+    const uint64_t unused = pending.reserved_payload_bytes - actual;
+    if (pending_reclaim_bytes_ >
+        std::numeric_limits<uint64_t>::max() - unused) {
+        record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
+            "record reclaim byte accounting overflow"));
+        pending_task_reclaims_.pop_front();
+        return;
+    }
+    pending_reclaim_bytes_ += unused;
+    pending_task_reclaims_.pop_front();
 }
 
 // ---------------------------------------------------------------------------

--- a/native/csrc/ring/drain_thread.cpp
+++ b/native/csrc/ring/drain_thread.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstring>
 #include <future>
+#include <limits>
 #include <string>
 #include <stdexcept>
 
@@ -23,11 +24,11 @@ namespace ring {
 
 namespace {
 
-void report_cuda_failure(const char* operation, cudaError_t error) {
+void throw_cuda_failure(const char* operation, cudaError_t error) {
     if (error == cudaSuccess) return;
-    std::fprintf(stderr, "[drain] ERROR: %s failed: %s\n",
-                 operation, cudaGetErrorString(error));
-    std::fflush(stderr);
+    throw std::runtime_error(
+        std::string("DrainThread: ") + operation + " failed: " +
+        cudaGetErrorString(error));
 }
 
 }  // namespace
@@ -82,7 +83,10 @@ void DrainThread::start() {
 }
 
 void DrainThread::stop() {
-    if (!running_.exchange(false)) return;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (!running_.exchange(false)) return;
+    }
     cv_.notify_all();
     if (thread_.joinable()) thread_.join();
 }
@@ -102,17 +106,72 @@ void DrainThread::notify() {
 // cudaStreamSynchronize(main_stream) first so all GPU writes are visible.
 // ---------------------------------------------------------------------------
 void DrainThread::force_flush_and_wait() {
+    uint64_t generation = 0;
     {
         std::lock_guard<std::mutex> lk(mu_);
-        flush_requested_ = true;
-        flush_done_      = false;
-        notified_        = true;
+        // The legacy completion path historically reported drain CUDA errors
+        // to stderr instead of throwing.  Preserve that API behavior while
+        // allowing stop() to clean up a terminally failed drain worker.
+        if (drain_failure_) return;
+        generation = ++flush_requested_generation_;
+        notified_ = true;
     }
     cv_.notify_one();  // wake drain thread
 
     // Block until drain thread completes the flush
     std::unique_lock<std::mutex> lk(mu_);
-    flush_done_cv_.wait(lk, [this] { return flush_done_; });
+    flush_done_cv_.wait(lk, [this, generation] {
+        return flush_completed_generation_ >= generation;
+    });
+}
+
+bool DrainThread::force_flush_and_wait_until(
+    std::chrono::steady_clock::time_point deadline) {
+    uint64_t generation = 0;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (drain_failure_) std::rethrow_exception(drain_failure_);
+        generation = ++flush_requested_generation_;
+        notified_ = true;
+    }
+    cv_.notify_one();
+
+    std::unique_lock<std::mutex> lk(mu_);
+    const bool completed = flush_done_cv_.wait_until(
+        lk, deadline, [this, generation] {
+            return flush_completed_generation_ >= generation ||
+                   static_cast<bool>(drain_failure_);
+        });
+    if (!completed) return false;
+    std::exception_ptr failure = drain_failure_;
+    lk.unlock();
+    if (failure) std::rethrow_exception(failure);
+    return true;
+}
+
+void DrainThread::record_drain_failure(std::exception_ptr failure) {
+    bool first_failure = false;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (!drain_failure_) {
+            drain_failure_ = failure;
+            first_failure = true;
+        }
+        // Wake an already-issued checked flush.  Its waiter observes and
+        // rethrows drain_failure_ instead of treating this as completion.
+        flush_completed_generation_ = flush_requested_generation_;
+    }
+    flush_done_cv_.notify_all();
+
+    if (!first_failure) return;
+    try {
+        std::rethrow_exception(failure);
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "[drain] ERROR: %s\n", error.what());
+    } catch (...) {
+        std::fprintf(stderr, "[drain] ERROR: unknown drain failure\n");
+    }
+    std::fflush(stderr);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,18 +217,22 @@ void DrainThread::notify_staging_freed_bytes(uint64_t nbytes) {
 // Capacity query accessors
 // ---------------------------------------------------------------------------
 uint64_t DrainThread::cpu_payload_head() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
     return cpu_payload_head_;
 }
 
 uint64_t DrainThread::cpu_payload_tail_committed() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
     return cpu_payload_tail_committed_;
 }
 
 uint64_t DrainThread::cpu_task_head() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
     return cpu_task_head_;
 }
 
 uint64_t DrainThread::cpu_task_tail_committed() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
     return cpu_task_tail_;
 }
 
@@ -181,6 +244,57 @@ void DrainThread::reserve(uint64_t payload_bytes, uint32_t num_tasks) {
     std::lock_guard<std::mutex> lk(mgmt_mu_);
     cpu_payload_head_ += payload_bytes;
     cpu_task_head_    += num_tasks;
+}
+
+void DrainThread::reserve_record(uint64_t payload_bytes, uint32_t num_tasks) {
+    if (payload_bytes % PAYLOAD_ALIGN != 0) {
+        throw std::invalid_argument(
+            "DrainThread::reserve_record payload bytes must be aligned");
+    }
+    if (num_tasks == 0) {
+        if (payload_bytes != 0) {
+            throw std::invalid_argument(
+                "DrainThread::reserve_record cannot reserve payload without tasks");
+        }
+        return;
+    }
+
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
+    RecordReservation reservation{};
+    reservation.first_task_sequence = cpu_task_head_;
+    reservation.reserved_payload_bytes = payload_bytes;
+    reservation.task_count = num_tasks;
+    record_reservations_.push_back(reservation);
+    cpu_payload_head_ += payload_bytes;
+    cpu_task_head_ += num_tasks;
+}
+
+uint64_t DrainThread::pending_record_reservations() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
+    return record_reservations_.size();
+}
+
+uint64_t DrainThread::reclaimed_record_bytes() const {
+    std::lock_guard<std::mutex> lk(mgmt_mu_);
+    return reclaimed_record_bytes_;
+}
+
+void DrainThread::rethrow_record_reclaim_failure() const {
+    std::exception_ptr failure;
+    {
+        std::lock_guard<std::mutex> lk(mgmt_mu_);
+        failure = record_reclaim_failure_;
+    }
+    if (failure) std::rethrow_exception(failure);
+}
+
+void DrainThread::rethrow_drain_failure() {
+    std::exception_ptr failure;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        failure = drain_failure_;
+    }
+    if (failure) std::rethrow_exception(failure);
 }
 
 // ---------------------------------------------------------------------------
@@ -251,23 +365,40 @@ void DrainThread::loop() {
     while (running_.load(std::memory_order_relaxed)) {
         ++loop_iter;
 
-        // Check for force-flush request
-        bool flush_now = false;
         {
-            std::lock_guard<std::mutex> lk(mu_);
-            if (flush_requested_) {
-                flush_now = true;
-                flush_requested_ = false;
+            std::unique_lock<std::mutex> lk(mu_);
+            if (drain_failure_) {
+                // A failed copy leaves the already-released task/payload
+                // accounting unusable.  Keep the worker alive for orderly
+                // stop, but never attempt or submit another drain batch.
+                cv_.wait(lk, [this] {
+                    return !running_.load(std::memory_order_relaxed);
+                });
+                continue;
             }
         }
 
-        if (flush_now) {
-            do_full_flush();
+        // Check for force-flush request
+        uint64_t flush_generation = 0;
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            if (flush_requested_generation_ > flush_completed_generation_) {
+                flush_generation = flush_requested_generation_;
+            }
+        }
+
+        if (flush_generation != 0) {
+            try {
+                do_full_flush();
+            } catch (...) {
+                record_drain_failure(std::current_exception());
+                continue;
+            }
             {
                 std::lock_guard<std::mutex> lk(mu_);
-                flush_done_ = true;
+                flush_completed_generation_ = flush_generation;
             }
-            flush_done_cv_.notify_one();
+            flush_done_cv_.notify_all();
             continue;  // skip normal sleep, re-check immediately
         }
 
@@ -299,32 +430,38 @@ void DrainThread::loop() {
         }
 
         if (needs_flush) {
-            {
-                std::unique_lock<std::mutex> lk(staging_mu_);
-                staging_cv_.wait(lk, [&] {
-                    return staging_.free_bytes() >= flush_bytes;
-                });
-            }
+            try {
+                {
+                    std::unique_lock<std::mutex> lk(staging_mu_);
+                    staging_cv_.wait(lk, [&] {
+                        return staging_.free_bytes() >= flush_bytes;
+                    });
+                }
 
-            enqueue_d2h(flush_bytes);
-            sync_stream();
+                enqueue_d2h(flush_bytes);
+                sync_stream();
 
-            {
-                std::lock_guard<std::mutex> lk(mgmt_mu_);
-                cpu_payload_tail_committed_ = cpu_payload_tail_;
-            }
+                {
+                    std::lock_guard<std::mutex> lk(mgmt_mu_);
+                    cpu_payload_tail_committed_ = cpu_payload_tail_;
+                }
 
-            submit_to_p2p(flush_count, flush_bytes);
-            {
-                std::lock_guard<std::mutex> lk(mgmt_mu_);
-                trim_scanned(flush_count, flush_bytes);
+                submit_to_p2p(flush_count, flush_bytes);
+                {
+                    std::lock_guard<std::mutex> lk(mgmt_mu_);
+                    trim_scanned(flush_count, flush_bytes);
+                }
+            } catch (...) {
+                record_drain_failure(std::current_exception());
             }
         }
 
         {
             std::unique_lock<std::mutex> lk(mu_);
             auto pred = [this] {
-                return notified_ || flush_requested_ ||
+                return notified_ ||
+                       flush_requested_generation_ >
+                           flush_completed_generation_ ||
                        !running_.load(std::memory_order_relaxed);
             };
             cv_.wait_for(lk, std::chrono::microseconds(cfg_.drain_poll_timeout_us), pred);
@@ -332,9 +469,18 @@ void DrainThread::loop() {
         }
     }
 
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (drain_failure_) return;
+    }
+
     // Final flush
-    report_cuda_failure("cudaDeviceSynchronize", cudaDeviceSynchronize());
-    do_full_flush();
+    try {
+        throw_cuda_failure("cudaDeviceSynchronize", cudaDeviceSynchronize());
+        do_full_flush();
+    } catch (...) {
+        record_drain_failure(std::current_exception());
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +496,8 @@ void DrainThread::scan_ready() {
         const uint64_t idx = visible_head_ % task_cap;
         TaskEntry ec = ring_.task_entries[idx];
 
+        account_record_task(visible_head_, ec);
+
         scanned_.push_back(ec);
         pending_entries_++;
         pending_bytes_ += align_up(ec.tensor_total_bytes, PAYLOAD_ALIGN);
@@ -360,6 +508,53 @@ void DrainThread::scan_ready() {
             has_complete_time_ = true;
         }
     }
+}
+
+void DrainThread::account_record_task(uint64_t sequence,
+                                      const TaskEntry& entry) {
+    if (record_reservations_.empty() || record_reclaim_failure_) return;
+
+    RecordReservation& reservation = record_reservations_.front();
+    const uint64_t expected = reservation.first_task_sequence +
+        reservation.completed_tasks;
+
+    // A legacy task can precede the first record reservation.  Record-mode
+    // task ranges themselves are contiguous because reserve_record advances
+    // the task head once for the complete group.
+    if (sequence < reservation.first_task_sequence) return;
+    if (sequence != expected) {
+        record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
+            "record reservation task sequence does not match ready TaskEntry"));
+        return;
+    }
+
+    const uint64_t actual = align_up(entry.tensor_total_bytes, PAYLOAD_ALIGN);
+    if (reservation.actual_aligned_bytes >
+        std::numeric_limits<uint64_t>::max() - actual) {
+        record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
+            "record reservation actual byte accounting overflow"));
+        return;
+    }
+    reservation.actual_aligned_bytes += actual;
+    ++reservation.completed_tasks;
+
+    if (reservation.completed_tasks != reservation.task_count) return;
+
+    if (reservation.actual_aligned_bytes <=
+        reservation.reserved_payload_bytes) {
+        const uint64_t unused = reservation.reserved_payload_bytes -
+            reservation.actual_aligned_bytes;
+        cpu_payload_head_ -= unused;
+        reclaimed_record_bytes_ += unused;
+    } else {
+        // Preserve CPU/GPU logical-head agreement before surfacing the
+        // violated upper-bound invariant through checked completion.
+        cpu_payload_head_ += reservation.actual_aligned_bytes -
+            reservation.reserved_payload_bytes;
+        record_reclaim_failure_ = std::make_exception_ptr(std::runtime_error(
+            "record producer exceeded its conservative payload reservation"));
+    }
+    record_reservations_.pop_front();
 }
 
 // ---------------------------------------------------------------------------
@@ -401,8 +596,8 @@ void DrainThread::flush_state_update(uint64_t flush_count, uint64_t flush_bytes)
 }
 
 void DrainThread::sync_stream() {
-    report_cuda_failure("cudaStreamSynchronize",
-                        cudaStreamSynchronize(stream_));
+    throw_cuda_failure("cudaStreamSynchronize",
+                       cudaStreamSynchronize(stream_));
 }
 
 // ---------------------------------------------------------------------------
@@ -428,11 +623,8 @@ void DrainThread::enqueue_d2h(uint64_t flush_bytes) {
         cudaError_t err = cudaMemcpyAsync(staging_.base() + stg_cursor,
                         ring_.payload_buf + gpu_cursor,
                         chunk, cudaMemcpyDeviceToHost, stream_);
-        if (err != cudaSuccess) {
-            report_cuda_failure("cudaMemcpyAsync", err);
-        } else {
-            RING_DBG("[enqueue_d2h] chunk=%d enqueued OK\n", chunk_idx);
-        }
+        throw_cuda_failure("cudaMemcpyAsync", err);
+        RING_DBG("[enqueue_d2h] chunk=%d enqueued OK\n", chunk_idx);
 
         remaining  -= chunk;
         gpu_cursor  = (gpu_cursor + chunk) % gpu_cap;

--- a/native/csrc/ring/drain_thread.h
+++ b/native/csrc/ring/drain_thread.h
@@ -31,6 +31,11 @@
 
 namespace ring {
 
+struct RecordReservationItem {
+    uint64_t reserved_payload_bytes{0};
+    bool needs_reclaim{false};
+};
+
 class DrainThread {
 public:
     DrainThread(RingState& rs, PinnedStaging& staging, const RingConfig& cfg);
@@ -80,12 +85,10 @@ public:
     // Called from prepare_step after confirming space is available.
     void reserve(uint64_t payload_bytes, uint32_t num_tasks);
 
-    // Record-mode reservation.  Unlike the released exact-size reservation,
-    // payload_bytes is a conservative upper bound.  Reclamation occurs only
-    // after ready TaskEntries prove completion of every task in this group.
-    void reserve_record(uint64_t payload_bytes, uint32_t num_tasks);
-    uint64_t pending_record_reservations() const;
-    uint64_t reclaimed_record_bytes() const;
+    // Record-mode reservation preserves each possibly-short task's upper bound.
+    void reserve_record(const std::vector<RecordReservationItem>& items);
+    void apply_pending_record_reclaims();
+    uint64_t pending_record_reclaims() const;
     void rethrow_record_reclaim_failure() const;
     void rethrow_drain_failure();
 
@@ -116,15 +119,12 @@ private:
     uint64_t                cpu_payload_tail_{0};           // pending
     uint64_t                cpu_payload_tail_committed_{0}; // safe after D2H
 
-    struct RecordReservation {
-        uint64_t first_task_sequence{0};
+    struct PendingTaskReclaim {
+        uint64_t task_sequence{0};
         uint64_t reserved_payload_bytes{0};
-        uint64_t actual_aligned_bytes{0};
-        uint32_t task_count{0};
-        uint32_t completed_tasks{0};
     };
-    std::deque<RecordReservation> record_reservations_;
-    uint64_t                reclaimed_record_bytes_{0};
+    std::deque<PendingTaskReclaim> pending_task_reclaims_;
+    uint64_t                pending_reclaim_bytes_{0};
     std::exception_ptr      record_reclaim_failure_;
 
     std::chrono::steady_clock::time_point first_complete_time_{};

--- a/native/csrc/ring/drain_thread.h
+++ b/native/csrc/ring/drain_thread.h
@@ -20,9 +20,12 @@
 
 #include <cuda_runtime.h>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
+#include <exception>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -45,6 +48,13 @@ public:
     // until it finishes.  Caller must have done cudaStreamSynchronize on
     // the main stream first so all GPU writes are visible.
     void force_flush_and_wait();
+
+    // Deadline-aware form used only by checked generic-record completion.
+    // Returns false only when this request's flush generation has not
+    // completed by deadline.  A timed-out request remains owned by the drain
+    // thread; record-mode callers do not reuse the runtime after timeout.
+    bool force_flush_and_wait_until(
+        std::chrono::steady_clock::time_point deadline);
 
     // Submit a CPU-direct tensor to drain -> p2p pipeline.
     // The tensor is already in pageable CPU memory; skips D2H and staging.
@@ -70,6 +80,15 @@ public:
     // Called from prepare_step after confirming space is available.
     void reserve(uint64_t payload_bytes, uint32_t num_tasks);
 
+    // Record-mode reservation.  Unlike the released exact-size reservation,
+    // payload_bytes is a conservative upper bound.  Reclamation occurs only
+    // after ready TaskEntries prove completion of every task in this group.
+    void reserve_record(uint64_t payload_bytes, uint32_t num_tasks);
+    uint64_t pending_record_reservations() const;
+    uint64_t reclaimed_record_bytes() const;
+    void rethrow_record_reclaim_failure() const;
+    void rethrow_drain_failure();
+
 private:
     RingState&      ring_;
     PinnedStaging&  staging_;
@@ -84,7 +103,7 @@ private:
     bool                    notified_{false};
 
     // ---- mgmt_mu_ protects all state below this line ----
-    std::mutex              mgmt_mu_;
+    mutable std::mutex      mgmt_mu_;
 
     uint64_t                visible_head_{0};
     uint64_t                pending_entries_{0};
@@ -97,13 +116,27 @@ private:
     uint64_t                cpu_payload_tail_{0};           // pending
     uint64_t                cpu_payload_tail_committed_{0}; // safe after D2H
 
+    struct RecordReservation {
+        uint64_t first_task_sequence{0};
+        uint64_t reserved_payload_bytes{0};
+        uint64_t actual_aligned_bytes{0};
+        uint32_t task_count{0};
+        uint32_t completed_tasks{0};
+    };
+    std::deque<RecordReservation> record_reservations_;
+    uint64_t                reclaimed_record_bytes_{0};
+    std::exception_ptr      record_reclaim_failure_;
+
     std::chrono::steady_clock::time_point first_complete_time_{};
     bool                    has_complete_time_{false};
     // ---- end mgmt_mu_ protected state ----
 
-    // Force-flush signalling (Python thread -> drain thread)
-    bool                    flush_requested_{false};  // guarded by mu_
-    bool                    flush_done_{false};        // guarded by mu_
+    // Force-flush signalling (Python thread -> drain thread).  Generations
+    // prevent one completed request from releasing a later overlapping
+    // waiter.
+    uint64_t                flush_requested_generation_{0};  // guarded by mu_
+    uint64_t                flush_completed_generation_{0};  // guarded by mu_
+    std::exception_ptr      drain_failure_;                  // guarded by mu_
     std::condition_variable flush_done_cv_;
 
     std::deque<DrainTask>   task_queue_;
@@ -118,17 +151,19 @@ private:
 
     void loop();
 
-    // Drain all pending entries -- called by the drain thread when
-    // flush_requested_ is set.  Flushes repeatedly until empty.
+    // Drain all pending entries -- called by the drain thread for an
+    // outstanding flush generation.  Flushes repeatedly until empty.
     void do_full_flush();
 
     // Called under mgmt_mu_:
     void scan_ready();
+    void account_record_task(uint64_t sequence, const TaskEntry& entry);
     bool should_flush() const;
     void flush_state_update(uint64_t flush_count, uint64_t flush_bytes);
 
     void sync_stream();
     void enqueue_d2h(uint64_t flush_bytes);
+    void record_drain_failure(std::exception_ptr failure);
 
     // Split into two: submit_to_p2p pushes DrainTasks to the p2p queue
     // (uses queue_mu_/pop_mu_, NOT mgmt_mu_).  trim_scanned updates

--- a/native/csrc/ring/p2p_thread.cpp
+++ b/native/csrc/ring/p2p_thread.cpp
@@ -334,8 +334,8 @@ void P2PThread::do_post_processing(at::Tensor& tensor, const DrainTask& first_ta
 // RecordP2PThread -- fixed schema-driven consumer path.
 // ---------------------------------------------------------------------------
 RecordP2PThread::RecordP2PThread(
-    DrainThread& drain, RecordConsumer::SubmitFn submit_fn)
-    : drain_(drain), consumer_(std::move(submit_fn)) {}
+    DrainThread& drain, std::shared_ptr<RecordSink> sink)
+    : drain_(drain), consumer_(std::move(sink)) {}
 
 RecordP2PThread::~RecordP2PThread() noexcept {
     stop();
@@ -398,7 +398,7 @@ void RecordP2PThread::process(std::vector<DrainTask>& tasks) {
                 drain_.notify_staging_freed_bytes(task.alloc_bytes);
                 task.alloc_bytes = 0;
             }
-            consumer_.consume_payload(payload);
+            consumer_.consume_payload(std::move(payload));
         } catch (...) {
             if (task.alloc_bytes > 0) {
                 drain_.notify_staging_freed_bytes(task.alloc_bytes);

--- a/native/csrc/ring/p2p_thread.cpp
+++ b/native/csrc/ring/p2p_thread.cpp
@@ -330,4 +330,83 @@ void P2PThread::do_post_processing(at::Tensor& tensor, const DrainTask& first_ta
     }
 }
 
+// ---------------------------------------------------------------------------
+// RecordP2PThread -- fixed schema-driven consumer path.
+// ---------------------------------------------------------------------------
+RecordP2PThread::RecordP2PThread(
+    DrainThread& drain, RecordConsumer::SubmitFn submit_fn)
+    : drain_(drain), consumer_(std::move(submit_fn)) {}
+
+RecordP2PThread::~RecordP2PThread() noexcept {
+    stop();
+}
+
+void RecordP2PThread::start() {
+    thread_ = std::thread([this] { loop(); });
+}
+
+void RecordP2PThread::stop() {
+    if (thread_.joinable()) thread_.join();
+}
+
+void RecordP2PThread::loop() {
+    while (true) {
+        const uint64_t n = drain_.wait_for_tasks();
+        if (n == 0) break;
+
+        std::vector<DrainTask> local;
+        drain_.pop_tasks(n, local);
+        process(local);
+    }
+}
+
+void RecordP2PThread::process(std::vector<DrainTask>& tasks) {
+    for (DrainTask& task : tasks) {
+        try {
+            at::Tensor payload;
+            if (task.cpu_paged_tensor.defined()) {
+                payload = std::move(task.cpu_paged_tensor);
+                if (payload.scalar_type() != at::kByte || payload.dim() != 1) {
+                    at::Tensor source = payload.is_contiguous()
+                        ? payload : payload.contiguous();
+                    payload = at::empty(
+                        {static_cast<int64_t>(task.tensor_total_bytes)},
+                        at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+                    if (task.tensor_total_bytes > 0) {
+                        std::memcpy(payload.data_ptr<uint8_t>(),
+                                    source.data_ptr(),
+                                    task.tensor_total_bytes);
+                    }
+                }
+            } else {
+                payload = at::empty(
+                    {static_cast<int64_t>(task.tensor_total_bytes)},
+                    at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+                uint8_t* dst = payload.data_ptr<uint8_t>();
+                if (task.data_len1 > 0) {
+                    std::memcpy(dst, task.data_ptr1, task.data_len1);
+                }
+                if (task.data_len2 > 0) {
+                    std::memcpy(dst + task.data_len1,
+                                task.data_ptr2, task.data_len2);
+                }
+            }
+
+            // Once bytes are copied into pageable memory, the pinned range can
+            // be reused independently of record materialization and storage.
+            if (task.alloc_bytes > 0) {
+                drain_.notify_staging_freed_bytes(task.alloc_bytes);
+                task.alloc_bytes = 0;
+            }
+            consumer_.consume_payload(payload);
+        } catch (...) {
+            if (task.alloc_bytes > 0) {
+                drain_.notify_staging_freed_bytes(task.alloc_bytes);
+                task.alloc_bytes = 0;
+            }
+            consumer_.record_failure(std::current_exception());
+        }
+    }
+}
+
 }  // namespace ring

--- a/native/csrc/ring/p2p_thread.h
+++ b/native/csrc/ring/p2p_thread.h
@@ -64,7 +64,7 @@ private:
 // payload.  Construction fixes the consumer for the lifetime of the ring.
 class RecordP2PThread {
 public:
-    RecordP2PThread(DrainThread& drain, RecordConsumer::SubmitFn submit_fn);
+    RecordP2PThread(DrainThread& drain, std::shared_ptr<RecordSink> sink);
     ~RecordP2PThread() noexcept;
 
     RecordP2PThread(const RecordP2PThread&) = delete;

--- a/native/csrc/ring/p2p_thread.h
+++ b/native/csrc/ring/p2p_thread.h
@@ -9,6 +9,7 @@
 #include "drain_thread.h"
 #include "drain_task.h"
 #include "ring_config.h"
+#include "record_consumer.h"
 #include "tensor_meta.h"
 
 #include <functional>
@@ -56,6 +57,32 @@ private:
     void loop();
     void process(std::vector<DrainTask>& tasks);
     void do_post_processing(at::Tensor& tensor, const DrainTask& first_task);
+};
+
+// Schema-driven record path.  It intentionally has a distinct worker class
+// from P2PThread so the released inference path never selects a consumer per
+// payload.  Construction fixes the consumer for the lifetime of the ring.
+class RecordP2PThread {
+public:
+    RecordP2PThread(DrainThread& drain, RecordConsumer::SubmitFn submit_fn);
+    ~RecordP2PThread() noexcept;
+
+    RecordP2PThread(const RecordP2PThread&) = delete;
+    RecordP2PThread& operator=(const RecordP2PThread&) = delete;
+
+    void start();
+    void stop();
+
+    RecordConsumer& consumer() { return consumer_; }
+    const RecordConsumer& consumer() const { return consumer_; }
+
+private:
+    DrainThread&  drain_;
+    RecordConsumer consumer_;
+    std::thread   thread_;
+
+    void loop();
+    void process(std::vector<DrainTask>& tasks);
 };
 
 }  // namespace ring

--- a/native/csrc/ring/producer.cu
+++ b/native/csrc/ring/producer.cu
@@ -34,6 +34,8 @@
 #include "task_ring.cuh"
 #include "ring_config.h"
 
+#include <stdexcept>
+
 namespace ring {
 
 __device__ bool g_ring_null_mode = false;
@@ -319,6 +321,303 @@ __global__ void producer_chunked_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Generic-record producer helpers.  These deliberately do not alter or wrap
+// the released inference kernels above.
+// ---------------------------------------------------------------------------
+
+__device__ inline bool record_emit_allowed(const int32_t* emit_gate,
+                                           int32_t emit_value) {
+    return emit_gate == nullptr || *emit_gate == emit_value;
+}
+
+// A false record gate still consumes the task reservation made by the host.
+// Publish an empty entry in FIFO order without touching payload state.
+__device__ inline void record_publish_zero_byte_task(RingState& ring) {
+    if (threadIdx.x != 0) return;
+    const uint32_t finished = atomicAdd(&g_block_done_counter, 1);
+    if (finished != gridDim.x - 1) return;
+
+    const uint64_t task_head = *ring.task_head;
+    const TaskEntry entry{};
+    task_publish(ring.task_entries, ring.task_cap, task_head, entry);
+    *ring.task_head = task_head + 1;
+
+    g_block_done_counter = 0;
+}
+
+__device__ inline void record_copy_contiguous(
+    uint8_t*       payload_buf,
+    const TwoSpan& spans,
+    const uint8_t* src,
+    uint64_t       nbytes,
+    uint64_t       gtid,
+    uint64_t       stride) {
+    const uint64_t first = nbytes < spans.len1 ? nbytes : spans.len1;
+    d2d_copy_grid_stride(payload_buf + spans.off1, src, first, gtid, stride);
+    const uint64_t second = nbytes - first;
+    if (second > 0) {
+        d2d_copy_grid_stride(payload_buf + spans.off2, src + first,
+                             second, gtid, stride);
+    }
+}
+
+__device__ inline void record_copy_row_block(
+    uint8_t*       payload_buf,
+    const TwoSpan& spans,
+    uint64_t       dst_offset,
+    const uint8_t* src,
+    uint64_t       row_bytes) {
+    copy_chunk_with_wrap(payload_buf, spans, dst_offset, row_bytes, src,
+                         threadIdx.x, blockDim.x);
+}
+
+__global__ void record_producer_static_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value) {
+    if (g_ring_null_mode) return;
+    if (!record_emit_allowed(emit_gate, emit_value)) {
+        record_publish_zero_byte_task(ring);
+        return;
+    }
+
+    const uint64_t gtid = uint64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    const uint64_t stride = uint64_t(gridDim.x) * blockDim.x;
+    const uint64_t alloc_bytes = align_up(nbytes, PAYLOAD_ALIGN);
+    const uint64_t task_head = *ring.task_head;
+    const uint64_t payload_head = *ring.payload_head;
+    const TwoSpan spans = payload_compute_spans(
+        payload_head, ring.payload_cap, alloc_bytes);
+
+    record_copy_contiguous(ring.payload_buf, spans, src, nbytes, gtid, stride);
+    __threadfence();
+    __syncthreads();
+    publish_last_block_arrives(
+        ring, task_head, payload_head, alloc_bytes, spans, nbytes);
+}
+
+__global__ void record_producer_prefix_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   row_count_dev_ptr,
+    uint64_t         row_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value) {
+    if (g_ring_null_mode) return;
+    if (!record_emit_allowed(emit_gate, emit_value)) {
+        record_publish_zero_byte_task(ring);
+        return;
+    }
+
+    int64_t rows = *row_count_dev_ptr;
+    if (rows < 0) rows = 0;
+    uint64_t actual_bytes = nbytes_upper;
+    if (row_bytes != 0 &&
+        static_cast<uint64_t>(rows) <= nbytes_upper / row_bytes) {
+        actual_bytes = static_cast<uint64_t>(rows) * row_bytes;
+    }
+
+    const uint64_t gtid = uint64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    const uint64_t stride = uint64_t(gridDim.x) * blockDim.x;
+    const uint64_t alloc_bytes = align_up(actual_bytes, PAYLOAD_ALIGN);
+    const uint64_t task_head = *ring.task_head;
+    const uint64_t payload_head = *ring.payload_head;
+    const TwoSpan spans = payload_compute_spans(
+        payload_head, ring.payload_cap, alloc_bytes);
+
+    record_copy_contiguous(
+        ring.payload_buf, spans, src, actual_bytes, gtid, stride);
+    __threadfence();
+    __syncthreads();
+    publish_last_block_arrives(
+        ring, task_head, payload_head, alloc_bytes, spans, actual_bytes);
+}
+
+__global__ void record_producer_chunked_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   chunk_bytes_dev_ptr,
+    uint32_t         chunk_count,
+    const int32_t*   emit_gate,
+    int32_t          emit_value) {
+    if (g_ring_null_mode) return;
+    if (!record_emit_allowed(emit_gate, emit_value)) {
+        record_publish_zero_byte_task(ring);
+        return;
+    }
+
+    __shared__ int64_t selected[PRODUCER_MAX_K];
+    __shared__ int64_t prefix[PRODUCER_MAX_K + 1];
+    if (threadIdx.x == 0) {
+        const int64_t input_chunk =
+            static_cast<int64_t>(nbytes_upper / chunk_count);
+        prefix[0] = 0;
+        for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
+            int64_t bytes = chunk_bytes_dev_ptr[chunk];
+            if (bytes < 0) bytes = 0;
+            if (bytes > input_chunk) bytes = input_chunk;
+            selected[chunk] = bytes;
+            prefix[chunk + 1] = prefix[chunk] + bytes;
+        }
+    }
+    __syncthreads();
+
+    const uint64_t actual_bytes = static_cast<uint64_t>(prefix[chunk_count]);
+    const uint64_t input_chunk = nbytes_upper / chunk_count;
+    const uint64_t alloc_bytes = align_up(actual_bytes, PAYLOAD_ALIGN);
+    const uint64_t task_head = *ring.task_head;
+    const uint64_t payload_head = *ring.payload_head;
+    const TwoSpan spans = payload_compute_spans(
+        payload_head, ring.payload_cap, alloc_bytes);
+
+    const uint32_t blocks_per_chunk = gridDim.x / chunk_count;
+    const uint32_t chunk = blockIdx.x / blocks_per_chunk;
+    const uint32_t block_in_chunk = blockIdx.x % blocks_per_chunk;
+    const uint64_t gtid =
+        uint64_t(block_in_chunk) * blockDim.x + threadIdx.x;
+    const uint64_t stride = uint64_t(blocks_per_chunk) * blockDim.x;
+    const uint64_t selected_bytes = static_cast<uint64_t>(selected[chunk]);
+    if (selected_bytes > 0) {
+        copy_chunk_with_wrap(
+            ring.payload_buf, spans, static_cast<uint64_t>(prefix[chunk]),
+            selected_bytes, src + uint64_t(chunk) * input_chunk, gtid, stride);
+    }
+
+    __threadfence();
+    __syncthreads();
+    publish_last_block_arrives(
+        ring, task_head, payload_head, alloc_bytes, spans, actual_bytes);
+}
+
+__global__ void record_producer_seq_prefix_pack_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   valid_count_dev_ptr,
+    const int64_t*   valid_prefix_sum_dev_ptr,
+    uint32_t         batch,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value) {
+    if (g_ring_null_mode) return;
+    if (!record_emit_allowed(emit_gate, emit_value)) {
+        record_publish_zero_byte_task(ring);
+        return;
+    }
+    (void)valid_count_dev_ptr;
+
+    int64_t encoded_rows = valid_prefix_sum_dev_ptr[batch];
+    if (encoded_rows < 0) encoded_rows = 0;
+    uint64_t total_rows = static_cast<uint64_t>(encoded_rows);
+    const uint64_t max_rows = feature_bytes == 0
+        ? 0 : nbytes_upper / feature_bytes;
+    if (total_rows > max_rows) total_rows = max_rows;
+    const uint64_t actual_bytes = total_rows * feature_bytes;
+    const uint64_t alloc_bytes = align_up(actual_bytes, PAYLOAD_ALIGN);
+    const uint64_t task_head = *ring.task_head;
+    const uint64_t payload_head = *ring.payload_head;
+    const TwoSpan spans = payload_compute_spans(
+        payload_head, ring.payload_cap, alloc_bytes);
+
+    for (uint64_t row = blockIdx.x; row < total_rows; row += gridDim.x) {
+        uint32_t sample = 0;
+        while (sample + 1 < batch &&
+               row >= static_cast<uint64_t>(
+                   valid_prefix_sum_dev_ptr[sample + 1])) {
+            ++sample;
+        }
+        const uint64_t sample_row = row - static_cast<uint64_t>(
+            valid_prefix_sum_dev_ptr[sample]);
+        const uint64_t source_row = sample_row * batch + sample;
+        record_copy_row_block(
+            ring.payload_buf, spans, row * feature_bytes,
+            src + source_row * feature_bytes, feature_bytes);
+    }
+
+    __threadfence();
+    __syncthreads();
+    publish_last_block_arrives(
+        ring, task_head, payload_head, alloc_bytes, spans, actual_bytes);
+}
+
+__global__ void record_producer_segmented_pack_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   segment_start_dev_ptr,
+    const int64_t*   segment_end_dev_ptr,
+    uint32_t         segment_count,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value) {
+    if (g_ring_null_mode) return;
+    if (!record_emit_allowed(emit_gate, emit_value)) {
+        record_publish_zero_byte_task(ring);
+        return;
+    }
+
+    const uint64_t input_rows = feature_bytes == 0
+        ? 0 : nbytes_upper / feature_bytes;
+    uint64_t total_rows = 0;
+    for (uint32_t segment = 0; segment < segment_count; ++segment) {
+        int64_t start = segment_start_dev_ptr[segment];
+        int64_t end = segment_end_dev_ptr[segment];
+        if (start < 0) start = 0;
+        if (end < start) end = start;
+        if (static_cast<uint64_t>(start) > input_rows) {
+            start = static_cast<int64_t>(input_rows);
+        }
+        if (static_cast<uint64_t>(end) > input_rows) {
+            end = static_cast<int64_t>(input_rows);
+        }
+        total_rows += static_cast<uint64_t>(end - start);
+    }
+    if (total_rows > input_rows) total_rows = input_rows;
+
+    const uint64_t actual_bytes = total_rows * feature_bytes;
+    const uint64_t alloc_bytes = align_up(actual_bytes, PAYLOAD_ALIGN);
+    const uint64_t task_head = *ring.task_head;
+    const uint64_t payload_head = *ring.payload_head;
+    const TwoSpan spans = payload_compute_spans(
+        payload_head, ring.payload_cap, alloc_bytes);
+
+    for (uint64_t row = blockIdx.x; row < total_rows; row += gridDim.x) {
+        uint64_t remaining = row;
+        uint64_t source_row = 0;
+        for (uint32_t segment = 0; segment < segment_count; ++segment) {
+            int64_t start = segment_start_dev_ptr[segment];
+            int64_t end = segment_end_dev_ptr[segment];
+            if (start < 0) start = 0;
+            if (end < start) end = start;
+            if (static_cast<uint64_t>(start) > input_rows) {
+                start = static_cast<int64_t>(input_rows);
+            }
+            if (static_cast<uint64_t>(end) > input_rows) {
+                end = static_cast<int64_t>(input_rows);
+            }
+            const uint64_t length = static_cast<uint64_t>(end - start);
+            if (remaining < length) {
+                source_row = static_cast<uint64_t>(start) + remaining;
+                break;
+            }
+            remaining -= length;
+        }
+        record_copy_row_block(
+            ring.payload_buf, spans, row * feature_bytes,
+            src + source_row * feature_bytes, feature_bytes);
+    }
+
+    __threadfence();
+    __syncthreads();
+    publish_last_block_arrives(
+        ring, task_head, payload_head, alloc_bytes, spans, actual_bytes);
+}
+
+// ---------------------------------------------------------------------------
 // Host launchers
 // ---------------------------------------------------------------------------
 
@@ -371,6 +670,111 @@ void launch_producer_chunked(
     if (r != 0) n_blocks += (K - r);
     producer_chunked_kernel<<<n_blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
         ring, d_src, nbytes_upper, chunk_bytes_dev_ptr, K, hook_type);
+}
+
+void launch_record_producer_static(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream) {
+    const uint32_t blocks = pick_tier_blocks(nbytes);
+    record_producer_static_kernel<<<blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
+        ring, d_src, nbytes, emit_gate, emit_value);
+}
+
+void launch_record_producer_prefix(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   row_count_dev_ptr,
+    uint64_t         row_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream) {
+    if (row_bytes == 0) {
+        throw std::invalid_argument(
+            "record prefix producer requires positive row bytes");
+    }
+    const uint32_t blocks = pick_tier_blocks(nbytes_upper);
+    record_producer_prefix_kernel<<<blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
+        ring, d_src, nbytes_upper, row_count_dev_ptr, row_bytes,
+        emit_gate, emit_value);
+}
+
+void launch_record_producer_chunked(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   chunk_bytes_dev_ptr,
+    uint32_t         chunk_count,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream) {
+    if (chunk_count == 0 || chunk_count > PRODUCER_MAX_K ||
+        nbytes_upper % chunk_count != 0) {
+        throw std::invalid_argument(
+            "record chunked producer requires a valid evenly divided chunk count");
+    }
+    uint32_t blocks = pick_tier_blocks(nbytes_upper);
+    if (blocks < chunk_count) blocks = chunk_count;
+    const uint32_t remainder = blocks % chunk_count;
+    if (remainder != 0) blocks += chunk_count - remainder;
+    record_producer_chunked_kernel<<<blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
+        ring, d_src, nbytes_upper, chunk_bytes_dev_ptr, chunk_count,
+        emit_gate, emit_value);
+}
+
+void launch_record_producer_seq_prefix_pack(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   valid_count_dev_ptr,
+    const int64_t*   valid_prefix_sum_dev_ptr,
+    uint32_t         batch,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream) {
+    if (batch == 0 || feature_bytes == 0) {
+        throw std::invalid_argument(
+            "record sequence-prefix producer requires positive batch and feature bytes");
+    }
+    uint64_t max_rows = feature_bytes == 0 ? 0 : nbytes_upper / feature_bytes;
+    if (max_rows == 0) max_rows = 1;
+    const uint32_t blocks = static_cast<uint32_t>(
+        max_rows < RECORD_PACK_MAX_BLOCKS ? max_rows : RECORD_PACK_MAX_BLOCKS);
+    record_producer_seq_prefix_pack_kernel<<<
+        blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
+        ring, d_src, nbytes_upper, valid_count_dev_ptr,
+        valid_prefix_sum_dev_ptr, batch, feature_bytes, emit_gate, emit_value);
+}
+
+void launch_record_producer_segmented_pack(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   segment_start_dev_ptr,
+    const int64_t*   segment_end_dev_ptr,
+    uint32_t         segment_count,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream) {
+    if (segment_count == 0 || feature_bytes == 0) {
+        throw std::invalid_argument(
+            "record segmented producer requires positive segment count and feature bytes");
+    }
+    uint64_t max_rows = feature_bytes == 0 ? 0 : nbytes_upper / feature_bytes;
+    if (max_rows == 0) max_rows = 1;
+    const uint32_t blocks = static_cast<uint32_t>(
+        max_rows < RECORD_PACK_MAX_BLOCKS ? max_rows : RECORD_PACK_MAX_BLOCKS);
+    record_producer_segmented_pack_kernel<<<
+        blocks, PRODUCER_BLOCK_DIM, 0, stream>>>(
+        ring, d_src, nbytes_upper, segment_start_dev_ptr,
+        segment_end_dev_ptr, segment_count, feature_bytes,
+        emit_gate, emit_value);
 }
 
 }  // namespace ring

--- a/native/csrc/ring/producer.cu
+++ b/native/csrc/ring/producer.cu
@@ -34,6 +34,7 @@
 #include "task_ring.cuh"
 #include "ring_config.h"
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace ring {
@@ -330,6 +331,54 @@ __device__ inline bool record_emit_allowed(const int32_t* emit_gate,
     return emit_gate == nullptr || *emit_gate == emit_value;
 }
 
+// Generic records may pack rows or chunk prefixes whose byte widths are not
+// multiples of PAYLOAD_ALIGN.  Keep the vectorized copy when both addresses
+// are aligned, and use byte copies for an unaligned source or destination.
+__device__ inline void record_d2d_copy_grid_stride(
+    uint8_t*       dst,
+    const uint8_t* src,
+    uint64_t       nbytes,
+    uint64_t       gtid,
+    uint64_t       stride) {
+    const uintptr_t address_bits =
+        reinterpret_cast<uintptr_t>(dst) |
+        reinterpret_cast<uintptr_t>(src);
+    if ((address_bits & (PAYLOAD_ALIGN - 1)) == 0) {
+        d2d_copy_grid_stride(dst, src, nbytes, gtid, stride);
+        return;
+    }
+
+    for (uint64_t i = gtid; i < nbytes; i += stride) {
+        dst[i] = src[i];
+    }
+}
+
+__device__ inline void record_copy_chunk_with_wrap(
+    uint8_t*       payload_buf,
+    const TwoSpan& spans,
+    uint64_t       dst_off,
+    uint64_t       nbytes,
+    const uint8_t* src,
+    uint64_t       gtid,
+    uint64_t       stride) {
+    uint64_t in_span1 = 0;
+    if (dst_off < spans.len1) {
+        const uint64_t avail = spans.len1 - dst_off;
+        in_span1 = nbytes < avail ? nbytes : avail;
+        record_d2d_copy_grid_stride(
+            payload_buf + spans.off1 + dst_off,
+            src, in_span1, gtid, stride);
+    }
+    const uint64_t in_span2 = nbytes - in_span1;
+    if (in_span2 > 0) {
+        const uint64_t span2_off =
+            dst_off >= spans.len1 ? dst_off - spans.len1 : 0;
+        record_d2d_copy_grid_stride(
+            payload_buf + spans.off2 + span2_off,
+            src + in_span1, in_span2, gtid, stride);
+    }
+}
+
 // A false record gate still consumes the task reservation made by the host.
 // Publish an empty entry in FIFO order without touching payload state.
 __device__ inline void record_publish_zero_byte_task(RingState& ring) {
@@ -367,8 +416,8 @@ __device__ inline void record_copy_row_block(
     uint64_t       dst_offset,
     const uint8_t* src,
     uint64_t       row_bytes) {
-    copy_chunk_with_wrap(payload_buf, spans, dst_offset, row_bytes, src,
-                         threadIdx.x, blockDim.x);
+    record_copy_chunk_with_wrap(payload_buf, spans, dst_offset, row_bytes, src,
+                                threadIdx.x, blockDim.x);
 }
 
 __global__ void record_producer_static_kernel(
@@ -482,7 +531,7 @@ __global__ void record_producer_chunked_kernel(
     const uint64_t stride = uint64_t(blocks_per_chunk) * blockDim.x;
     const uint64_t selected_bytes = static_cast<uint64_t>(selected[chunk]);
     if (selected_bytes > 0) {
-        copy_chunk_with_wrap(
+        record_copy_chunk_with_wrap(
             ring.payload_buf, spans, static_cast<uint64_t>(prefix[chunk]),
             selected_bytes, src + uint64_t(chunk) * input_chunk, gtid, stride);
     }

--- a/native/csrc/ring/producer.cuh
+++ b/native/csrc/ring/producer.cuh
@@ -23,6 +23,17 @@
 // (caller's contract; see ring_torch_op.cpp).
 
 #pragma once
+
+#include <cstdint>
+
+namespace ring {
+
+// Upper bound on K (chunk count) for shared-memory sizing in the
+// chunked kernel and host-side argument validation.
+static constexpr uint32_t PRODUCER_MAX_K = 64;
+
+}  // namespace ring
+
 #ifdef __CUDACC__
 
 #include "ring_state.h"
@@ -43,9 +54,9 @@ static constexpr uint32_t TIER1_BLOCKS =  4;  // <= 4 MB
 static constexpr uint32_t TIER2_BLOCKS = 16;  // <= 32 MB
 static constexpr uint32_t TIER3_BLOCKS = 64;  // > 32 MB
 
-// Upper bound on K (chunk count) for shared-memory sizing in the
-// chunked kernel.  Covers expected num_local_experts under EP.
-static constexpr uint32_t PRODUCER_MAX_K = 64;
+// Record-only row packers use one block per logical output row and cap the
+// grid so a conservative upper bound cannot create an unbounded launch.
+static constexpr uint32_t RECORD_PACK_MAX_BLOCKS = 1024;
 
 // Static: copy all `nbytes`; no actual_dev_ptr, no row_bytes.
 __global__ void producer_static_kernel(
@@ -97,6 +108,114 @@ void launch_producer_chunked(
     const int64_t*   chunk_bytes_dev_ptr,
     uint32_t         K,
     uint32_t         hook_type,
+    cudaStream_t     stream = 0);
+
+// ---------------------------------------------------------------------------
+// Additive generic-record producers.
+//
+// These are separately named so the released inference torch-op schemas and
+// kernels above remain unchanged.  The optional int32 device scalar gates
+// emission without a host read: nullptr emits unconditionally; otherwise the
+// producer emits only when *emit_gate == emit_value.
+// ---------------------------------------------------------------------------
+
+__global__ void record_producer_static_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value);
+
+void launch_record_producer_static(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream = 0);
+
+__global__ void record_producer_prefix_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   row_count_dev_ptr,
+    uint64_t         row_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value);
+
+void launch_record_producer_prefix(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   row_count_dev_ptr,
+    uint64_t         row_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream = 0);
+
+__global__ void record_producer_chunked_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   chunk_bytes_dev_ptr,
+    uint32_t         chunk_count,
+    const int32_t*   emit_gate,
+    int32_t          emit_value);
+
+void launch_record_producer_chunked(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   chunk_bytes_dev_ptr,
+    uint32_t         chunk_count,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream = 0);
+
+__global__ void record_producer_seq_prefix_pack_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   valid_count_dev_ptr,
+    const int64_t*   valid_prefix_sum_dev_ptr,
+    uint32_t         batch,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value);
+
+void launch_record_producer_seq_prefix_pack(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   valid_count_dev_ptr,
+    const int64_t*   valid_prefix_sum_dev_ptr,
+    uint32_t         batch,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
+    cudaStream_t     stream = 0);
+
+__global__ void record_producer_segmented_pack_kernel(
+    RingState        ring,
+    const uint8_t*   src,
+    uint64_t         nbytes_upper,
+    const int64_t*   segment_start_dev_ptr,
+    const int64_t*   segment_end_dev_ptr,
+    uint32_t         segment_count,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value);
+
+void launch_record_producer_segmented_pack(
+    const RingState& ring,
+    const uint8_t*   d_src,
+    uint64_t         nbytes_upper,
+    const int64_t*   segment_start_dev_ptr,
+    const int64_t*   segment_end_dev_ptr,
+    uint32_t         segment_count,
+    uint64_t         feature_bytes,
+    const int32_t*   emit_gate,
+    int32_t          emit_value,
     cudaStream_t     stream = 0);
 
 void set_ring_null_mode(bool enabled);

--- a/native/csrc/ring/record_consumer.cpp
+++ b/native/csrc/ring/record_consumer.cpp
@@ -154,12 +154,13 @@ void RecordConsumer::consume_payload(const at::Tensor& payload) {
         }
         idle_cv_.notify_all();
     } catch (...) {
+        const std::exception_ptr failure = std::current_exception();
         {
             std::lock_guard<std::mutex> lock(mu_);
+            if (!failure_) failure_ = failure;
             --active_payloads_;
         }
         idle_cv_.notify_all();
-        record_failure(std::current_exception());
         throw;
     }
 }

--- a/native/csrc/ring/record_consumer.cpp
+++ b/native/csrc/ring/record_consumer.cpp
@@ -2,8 +2,6 @@
 
 #include <ATen/ATen.h>
 
-#include <cstring>
-#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -15,102 +13,10 @@ namespace {
     throw std::runtime_error("record consumer: " + message);
 }
 
-uint64_t checked_product(const std::vector<int64_t>& shape,
-                         int32_t skip_dimension) {
-    uint64_t result = 1;
-    for (size_t i = 0; i < shape.size(); ++i) {
-        if (static_cast<int32_t>(i) == skip_dimension) continue;
-        if (shape[i] < 0) invalid("negative logical tensor dimension");
-        const uint64_t dimension = static_cast<uint64_t>(shape[i]);
-        if (dimension != 0 &&
-            result > std::numeric_limits<uint64_t>::max() / dimension) {
-            invalid("logical tensor shape overflows uint64");
-        }
-        result *= dimension;
-    }
-    return result;
-}
-
-at::ScalarType checked_dtype(int32_t encoded) {
-    if (encoded < 0 || encoded >= static_cast<int32_t>(at::ScalarType::NumOptions)) {
-        invalid("unsupported encoded dtype");
-    }
-    const auto dtype = static_cast<at::ScalarType>(encoded);
-    const auto size = at::elementSize(dtype);
-    if (size <= 0) invalid("dtype has no materializable element size");
-    return dtype;
-}
-
-uint64_t resolve_slice_length(const PayloadSlice& slice,
-                              uint64_t payload_bytes) {
-    if (slice.offset_bytes > payload_bytes) {
-        invalid("payload-slice offset exceeds actual payload bytes");
-    }
-    const uint64_t available = payload_bytes - slice.offset_bytes;
-    const uint64_t length = slice.length_bytes.value_or(available);
-    if (length > available) {
-        invalid("payload-slice length exceeds actual payload bytes");
-    }
-    return length;
-}
-
-std::vector<int64_t> resolve_shape(const PayloadSlice& slice,
-                                   uint64_t length_bytes,
-                                   at::ScalarType dtype) {
-    std::vector<int64_t> shape = slice.logical_shape;
-    if (shape.empty()) invalid("tensor payload requires a logical shape");
-
-    const uint64_t element_bytes = static_cast<uint64_t>(at::elementSize(dtype));
-    if (length_bytes % element_bytes != 0) {
-        invalid("payload-slice bytes are not divisible by dtype size");
-    }
-    const uint64_t elements = length_bytes / element_bytes;
-
-    if (slice.inferred_dynamic_dim >= 0) {
-        if (slice.inferred_dynamic_dim >= static_cast<int32_t>(shape.size())) {
-            invalid("inferred dynamic dimension is out of range");
-        }
-        const uint64_t fixed = checked_product(shape, slice.inferred_dynamic_dim);
-        if (fixed == 0 || elements % fixed != 0) {
-            invalid("payload bytes cannot infer the requested tensor dimension");
-        }
-        const uint64_t inferred = elements / fixed;
-        if (inferred > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-            invalid("inferred tensor dimension exceeds int64");
-        }
-        shape[static_cast<size_t>(slice.inferred_dynamic_dim)] =
-            static_cast<int64_t>(inferred);
-    } else {
-        const uint64_t expected = checked_product(shape, -1);
-        if (expected != elements) {
-            invalid("fixed tensor shape does not match payload-slice bytes");
-        }
-    }
-    return shape;
-}
-
-at::Tensor materialize_tensor(const at::Tensor& payload,
-                              const PayloadSlice& slice,
-                              uint64_t length_bytes,
-                              at::ScalarType dtype) {
-    const std::vector<int64_t> shape = resolve_shape(slice, length_bytes, dtype);
-    const uint64_t element_bytes = static_cast<uint64_t>(at::elementSize(dtype));
-    if (slice.offset_bytes % element_bytes != 0) {
-        invalid("payload-slice offset is not aligned to its dtype size");
-    }
-    at::Tensor bytes = payload.narrow(
-        0, static_cast<int64_t>(slice.offset_bytes),
-        static_cast<int64_t>(length_bytes));
-
-    // Clone so a submitted row never aliases the reusable pageable payload
-    // buffer owned by the p2p worker.
-    return bytes.view(dtype).reshape(shape).clone();
-}
-
 }  // namespace
 
-RecordConsumer::RecordConsumer(SubmitFn submit_fn)
-    : submit_fn_(std::move(submit_fn)) {}
+RecordConsumer::RecordConsumer(std::shared_ptr<RecordSink> sink)
+    : sink_(std::move(sink)) {}
 
 void RecordConsumer::push_descriptor(RecordDescriptor descriptor) {
     std::lock_guard<std::mutex> lock(mu_);
@@ -118,7 +24,8 @@ void RecordConsumer::push_descriptor(RecordDescriptor descriptor) {
     descriptors_.push_back(std::move(descriptor));
 }
 
-void RecordConsumer::push_descriptors(std::vector<RecordDescriptor> descriptors) {
+void RecordConsumer::push_descriptors(
+    std::vector<RecordDescriptor> descriptors) {
     std::lock_guard<std::mutex> lock(mu_);
     if (failure_) std::rethrow_exception(failure_);
     for (auto& descriptor : descriptors) {
@@ -126,7 +33,7 @@ void RecordConsumer::push_descriptors(std::vector<RecordDescriptor> descriptors)
     }
 }
 
-void RecordConsumer::consume_payload(const at::Tensor& payload) {
+void RecordConsumer::consume_payload(at::Tensor payload) {
     RecordDescriptor descriptor;
     {
         std::lock_guard<std::mutex> lock(mu_);
@@ -145,9 +52,15 @@ void RecordConsumer::consume_payload(const at::Tensor& payload) {
         if (!payload.defined() || payload.device().type() != at::kCPU ||
             payload.scalar_type() != at::kByte || payload.dim() != 1 ||
             !payload.is_contiguous()) {
-            invalid("physical payload must be a contiguous one-dimensional CPU byte tensor");
+            invalid(
+                "physical payload must be a contiguous one-dimensional CPU byte tensor");
         }
-        materialize_and_submit(descriptor, payload);
+        if (descriptor.layout.empty()) invalid("record layout is empty");
+        if (!descriptor.rows.empty()) {
+            if (!sink_) invalid("record sink is not configured");
+            sink_->submit(RecordEnvelope{
+                std::move(descriptor), std::move(payload)});
+        }
         {
             std::lock_guard<std::mutex> lock(mu_);
             --active_payloads_;
@@ -156,6 +69,9 @@ void RecordConsumer::consume_payload(const at::Tensor& payload) {
     } catch (...) {
         const std::exception_ptr failure = std::current_exception();
         {
+            // Latch failure and retire the active payload atomically.  A flush
+            // waiter must never observe an idle consumer before the submit
+            // failure becomes visible.
             std::lock_guard<std::mutex> lock(mu_);
             if (!failure_) failure_ = failure;
             --active_payloads_;
@@ -179,7 +95,8 @@ void RecordConsumer::record_failure(std::exception_ptr failure) noexcept {
 bool RecordConsumer::wait_until_idle(
     std::chrono::milliseconds timeout) const {
     if (timeout.count() < 0) {
-        throw std::invalid_argument("record consumer timeout must be non-negative");
+        throw std::invalid_argument(
+            "record consumer timeout must be non-negative");
     }
     std::unique_lock<std::mutex> lock(mu_);
     const bool ready = idle_cv_.wait_for(lock, timeout, [this] {
@@ -205,94 +122,13 @@ void RecordConsumer::finish() const {
         invalid("durable completion found leftover encoded descriptors");
     }
     if (active_payloads_ != 0) {
-        invalid("durable completion found active record materialization");
+        invalid("durable completion found active sink submission");
     }
 }
 
 size_t RecordConsumer::pending_descriptors() const {
     std::lock_guard<std::mutex> lock(mu_);
     return descriptors_.size();
-}
-
-void RecordConsumer::materialize_and_submit(
-    const RecordDescriptor& descriptor,
-    const at::Tensor& payload) {
-    if (descriptor.layout.empty()) invalid("record layout is empty");
-    if (!submit_fn_ && !descriptor.rows.empty()) {
-        invalid("record submit callback is not configured");
-    }
-
-    const uint64_t payload_bytes = static_cast<uint64_t>(payload.numel());
-
-    for (const EncodedRecordRow& encoded_row : descriptor.rows) {
-        dmx_host::GenericRecordRow row;
-        row.layout = descriptor.layout;
-        row.cells.reserve(encoded_row.cells.size());
-
-        uint64_t accounted_bytes = 0;
-        for (const EncodedRecordCell& encoded_cell : encoded_row.cells) {
-            if (const auto* value = std::get_if<std::string>(&encoded_cell)) {
-                row.cells.emplace_back(*value);
-            } else if (const auto* value = std::get_if<int32_t>(&encoded_cell)) {
-                row.cells.emplace_back(*value);
-            } else if (const auto* value = std::get_if<int64_t>(&encoded_cell)) {
-                row.cells.emplace_back(*value);
-            } else if (const auto* value = std::get_if<double>(&encoded_cell)) {
-                row.cells.emplace_back(*value);
-            } else if (const auto* value =
-                           std::get_if<std::vector<int64_t>>(&encoded_cell)) {
-                row.cells.emplace_back(*value);
-            } else {
-                const auto& slice = std::get<PayloadSlice>(encoded_cell);
-                const uint64_t length = resolve_slice_length(slice, payload_bytes);
-                accounted_bytes += length;
-                const at::ScalarType dtype = checked_dtype(slice.dtype);
-
-                switch (slice.materialization) {
-                    case PayloadMaterialization::TENSOR:
-                        row.cells.emplace_back(materialize_tensor(
-                            payload, slice, length, dtype));
-                        break;
-                    case PayloadMaterialization::FLOAT_SCALAR: {
-                        if (!c10::isFloatingType(dtype)) {
-                            invalid("floating scalar requires a floating-point dtype");
-                        }
-                        if (length != static_cast<uint64_t>(at::elementSize(dtype))) {
-                            invalid("floating scalar slice must contain exactly one element");
-                        }
-                        if (slice.offset_bytes %
-                                static_cast<uint64_t>(at::elementSize(dtype)) != 0) {
-                            invalid("floating scalar offset is not dtype-aligned");
-                        }
-                        at::Tensor scalar = payload.narrow(
-                            0, static_cast<int64_t>(slice.offset_bytes),
-                            static_cast<int64_t>(length)).view(dtype);
-                        row.cells.emplace_back(scalar.item<double>());
-                        break;
-                    }
-                    case PayloadMaterialization::INT_SCALAR: {
-                        if (!c10::isIntegralType(dtype, /*includeBool=*/false)) {
-                            invalid("integer scalar requires an integral dtype");
-                        }
-                        if (length != static_cast<uint64_t>(at::elementSize(dtype))) {
-                            invalid("integer scalar slice must contain exactly one element");
-                        }
-                        if (slice.offset_bytes %
-                                static_cast<uint64_t>(at::elementSize(dtype)) != 0) {
-                            invalid("integer scalar offset is not dtype-aligned");
-                        }
-                        at::Tensor scalar = payload.narrow(
-                            0, static_cast<int64_t>(slice.offset_bytes),
-                            static_cast<int64_t>(length)).view(dtype);
-                        row.cells.emplace_back(scalar.item<int64_t>());
-                        break;
-                    }
-                }
-            }
-        }
-
-        submit_fn_(std::move(row), accounted_bytes);
-    }
 }
 
 }  // namespace ring

--- a/native/csrc/ring/record_consumer.cpp
+++ b/native/csrc/ring/record_consumer.cpp
@@ -1,0 +1,297 @@
+#include "record_consumer.h"
+
+#include <ATen/ATen.h>
+
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace ring {
+
+namespace {
+
+[[noreturn]] void invalid(const std::string& message) {
+    throw std::runtime_error("record consumer: " + message);
+}
+
+uint64_t checked_product(const std::vector<int64_t>& shape,
+                         int32_t skip_dimension) {
+    uint64_t result = 1;
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (static_cast<int32_t>(i) == skip_dimension) continue;
+        if (shape[i] < 0) invalid("negative logical tensor dimension");
+        const uint64_t dimension = static_cast<uint64_t>(shape[i]);
+        if (dimension != 0 &&
+            result > std::numeric_limits<uint64_t>::max() / dimension) {
+            invalid("logical tensor shape overflows uint64");
+        }
+        result *= dimension;
+    }
+    return result;
+}
+
+at::ScalarType checked_dtype(int32_t encoded) {
+    if (encoded < 0 || encoded >= static_cast<int32_t>(at::ScalarType::NumOptions)) {
+        invalid("unsupported encoded dtype");
+    }
+    const auto dtype = static_cast<at::ScalarType>(encoded);
+    const auto size = at::elementSize(dtype);
+    if (size <= 0) invalid("dtype has no materializable element size");
+    return dtype;
+}
+
+uint64_t resolve_slice_length(const PayloadSlice& slice,
+                              uint64_t payload_bytes) {
+    if (slice.offset_bytes > payload_bytes) {
+        invalid("payload-slice offset exceeds actual payload bytes");
+    }
+    const uint64_t available = payload_bytes - slice.offset_bytes;
+    const uint64_t length = slice.length_bytes.value_or(available);
+    if (length > available) {
+        invalid("payload-slice length exceeds actual payload bytes");
+    }
+    return length;
+}
+
+std::vector<int64_t> resolve_shape(const PayloadSlice& slice,
+                                   uint64_t length_bytes,
+                                   at::ScalarType dtype) {
+    std::vector<int64_t> shape = slice.logical_shape;
+    if (shape.empty()) invalid("tensor payload requires a logical shape");
+
+    const uint64_t element_bytes = static_cast<uint64_t>(at::elementSize(dtype));
+    if (length_bytes % element_bytes != 0) {
+        invalid("payload-slice bytes are not divisible by dtype size");
+    }
+    const uint64_t elements = length_bytes / element_bytes;
+
+    if (slice.inferred_dynamic_dim >= 0) {
+        if (slice.inferred_dynamic_dim >= static_cast<int32_t>(shape.size())) {
+            invalid("inferred dynamic dimension is out of range");
+        }
+        const uint64_t fixed = checked_product(shape, slice.inferred_dynamic_dim);
+        if (fixed == 0 || elements % fixed != 0) {
+            invalid("payload bytes cannot infer the requested tensor dimension");
+        }
+        const uint64_t inferred = elements / fixed;
+        if (inferred > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            invalid("inferred tensor dimension exceeds int64");
+        }
+        shape[static_cast<size_t>(slice.inferred_dynamic_dim)] =
+            static_cast<int64_t>(inferred);
+    } else {
+        const uint64_t expected = checked_product(shape, -1);
+        if (expected != elements) {
+            invalid("fixed tensor shape does not match payload-slice bytes");
+        }
+    }
+    return shape;
+}
+
+at::Tensor materialize_tensor(const at::Tensor& payload,
+                              const PayloadSlice& slice,
+                              uint64_t length_bytes,
+                              at::ScalarType dtype) {
+    const std::vector<int64_t> shape = resolve_shape(slice, length_bytes, dtype);
+    const uint64_t element_bytes = static_cast<uint64_t>(at::elementSize(dtype));
+    if (slice.offset_bytes % element_bytes != 0) {
+        invalid("payload-slice offset is not aligned to its dtype size");
+    }
+    at::Tensor bytes = payload.narrow(
+        0, static_cast<int64_t>(slice.offset_bytes),
+        static_cast<int64_t>(length_bytes));
+
+    // Clone so a submitted row never aliases the reusable pageable payload
+    // buffer owned by the p2p worker.
+    return bytes.view(dtype).reshape(shape).clone();
+}
+
+}  // namespace
+
+RecordConsumer::RecordConsumer(SubmitFn submit_fn)
+    : submit_fn_(std::move(submit_fn)) {}
+
+void RecordConsumer::push_descriptor(RecordDescriptor descriptor) {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (failure_) std::rethrow_exception(failure_);
+    descriptors_.push_back(std::move(descriptor));
+}
+
+void RecordConsumer::push_descriptors(std::vector<RecordDescriptor> descriptors) {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (failure_) std::rethrow_exception(failure_);
+    for (auto& descriptor : descriptors) {
+        descriptors_.push_back(std::move(descriptor));
+    }
+}
+
+void RecordConsumer::consume_payload(const at::Tensor& payload) {
+    RecordDescriptor descriptor;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (failure_) std::rethrow_exception(failure_);
+        if (descriptors_.empty()) {
+            failure_ = std::make_exception_ptr(std::runtime_error(
+                "record consumer: physical payload arrived without an encoded descriptor"));
+            std::rethrow_exception(failure_);
+        }
+        descriptor = std::move(descriptors_.front());
+        descriptors_.pop_front();
+        ++active_payloads_;
+    }
+
+    try {
+        if (!payload.defined() || payload.device().type() != at::kCPU ||
+            payload.scalar_type() != at::kByte || payload.dim() != 1 ||
+            !payload.is_contiguous()) {
+            invalid("physical payload must be a contiguous one-dimensional CPU byte tensor");
+        }
+        materialize_and_submit(descriptor, payload);
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            --active_payloads_;
+        }
+        idle_cv_.notify_all();
+    } catch (...) {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            --active_payloads_;
+        }
+        idle_cv_.notify_all();
+        record_failure(std::current_exception());
+        throw;
+    }
+}
+
+void RecordConsumer::record_failure(std::exception_ptr failure) noexcept {
+    if (!failure) return;
+    try {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (!failure_) failure_ = std::move(failure);
+        idle_cv_.notify_all();
+    } catch (...) {
+        // Failure reporting must not terminate a worker while unwinding.
+    }
+}
+
+bool RecordConsumer::wait_until_idle(
+    std::chrono::milliseconds timeout) const {
+    if (timeout.count() < 0) {
+        throw std::invalid_argument("record consumer timeout must be non-negative");
+    }
+    std::unique_lock<std::mutex> lock(mu_);
+    const bool ready = idle_cv_.wait_for(lock, timeout, [this] {
+        return failure_ || (descriptors_.empty() && active_payloads_ == 0);
+    });
+    if (failure_) std::rethrow_exception(failure_);
+    return ready;
+}
+
+void RecordConsumer::rethrow_if_failed() const {
+    std::exception_ptr failure;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        failure = failure_;
+    }
+    if (failure) std::rethrow_exception(failure);
+}
+
+void RecordConsumer::finish() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (failure_) std::rethrow_exception(failure_);
+    if (!descriptors_.empty()) {
+        invalid("durable completion found leftover encoded descriptors");
+    }
+    if (active_payloads_ != 0) {
+        invalid("durable completion found active record materialization");
+    }
+}
+
+size_t RecordConsumer::pending_descriptors() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return descriptors_.size();
+}
+
+void RecordConsumer::materialize_and_submit(
+    const RecordDescriptor& descriptor,
+    const at::Tensor& payload) {
+    if (descriptor.layout.empty()) invalid("record layout is empty");
+    if (!submit_fn_ && !descriptor.rows.empty()) {
+        invalid("record submit callback is not configured");
+    }
+
+    const uint64_t payload_bytes = static_cast<uint64_t>(payload.numel());
+
+    for (const EncodedRecordRow& encoded_row : descriptor.rows) {
+        dmx_host::GenericRecordRow row;
+        row.layout = descriptor.layout;
+        row.cells.reserve(encoded_row.cells.size());
+
+        uint64_t accounted_bytes = 0;
+        for (const EncodedRecordCell& encoded_cell : encoded_row.cells) {
+            if (const auto* value = std::get_if<std::string>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value = std::get_if<int32_t>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value = std::get_if<int64_t>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value = std::get_if<double>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else if (const auto* value =
+                           std::get_if<std::vector<int64_t>>(&encoded_cell)) {
+                row.cells.emplace_back(*value);
+            } else {
+                const auto& slice = std::get<PayloadSlice>(encoded_cell);
+                const uint64_t length = resolve_slice_length(slice, payload_bytes);
+                accounted_bytes += length;
+                const at::ScalarType dtype = checked_dtype(slice.dtype);
+
+                switch (slice.materialization) {
+                    case PayloadMaterialization::TENSOR:
+                        row.cells.emplace_back(materialize_tensor(
+                            payload, slice, length, dtype));
+                        break;
+                    case PayloadMaterialization::FLOAT_SCALAR: {
+                        if (!c10::isFloatingType(dtype)) {
+                            invalid("floating scalar requires a floating-point dtype");
+                        }
+                        if (length != static_cast<uint64_t>(at::elementSize(dtype))) {
+                            invalid("floating scalar slice must contain exactly one element");
+                        }
+                        if (slice.offset_bytes %
+                                static_cast<uint64_t>(at::elementSize(dtype)) != 0) {
+                            invalid("floating scalar offset is not dtype-aligned");
+                        }
+                        at::Tensor scalar = payload.narrow(
+                            0, static_cast<int64_t>(slice.offset_bytes),
+                            static_cast<int64_t>(length)).view(dtype);
+                        row.cells.emplace_back(scalar.item<double>());
+                        break;
+                    }
+                    case PayloadMaterialization::INT_SCALAR: {
+                        if (!c10::isIntegralType(dtype, /*includeBool=*/false)) {
+                            invalid("integer scalar requires an integral dtype");
+                        }
+                        if (length != static_cast<uint64_t>(at::elementSize(dtype))) {
+                            invalid("integer scalar slice must contain exactly one element");
+                        }
+                        if (slice.offset_bytes %
+                                static_cast<uint64_t>(at::elementSize(dtype)) != 0) {
+                            invalid("integer scalar offset is not dtype-aligned");
+                        }
+                        at::Tensor scalar = payload.narrow(
+                            0, static_cast<int64_t>(slice.offset_bytes),
+                            static_cast<int64_t>(length)).view(dtype);
+                        row.cells.emplace_back(scalar.item<int64_t>());
+                        break;
+                    }
+                }
+            }
+        }
+
+        submit_fn_(std::move(row), accounted_bytes);
+    }
+}
+
+}  // namespace ring

--- a/native/csrc/ring/record_consumer.h
+++ b/native/csrc/ring/record_consumer.h
@@ -1,0 +1,63 @@
+// FIFO descriptor-to-payload association and generic materialization.
+
+#pragma once
+
+#include "record_descriptor.h"
+#include "../dmx_host_utils.h"
+
+#include <ATen/ATen.h>
+
+#include <cstddef>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace ring {
+
+class RecordConsumer {
+public:
+    using SubmitFn = std::function<void(dmx_host::GenericRecordRow, uint64_t)>;
+
+    explicit RecordConsumer(SubmitFn submit_fn);
+
+    RecordConsumer(const RecordConsumer&) = delete;
+    RecordConsumer& operator=(const RecordConsumer&) = delete;
+
+    // Publish descriptors before the corresponding producer launch/replay.
+    void push_descriptor(RecordDescriptor descriptor);
+    void push_descriptors(std::vector<RecordDescriptor> descriptors);
+
+    // Consume exactly one descriptor for one physical payload.  The payload
+    // must be a contiguous CPU byte tensor containing the actual produced
+    // bytes from its ready TaskEntry.
+    void consume_payload(const at::Tensor& payload);
+
+    // Latch an asynchronous worker failure.  The first failure is retained.
+    void record_failure(std::exception_ptr failure) noexcept;
+
+    // Checked durable-completion helpers.
+    void rethrow_if_failed() const;
+    bool wait_until_idle(std::chrono::milliseconds timeout) const;
+    void finish() const;
+    size_t pending_descriptors() const;
+
+private:
+    SubmitFn submit_fn_;
+
+    mutable std::mutex mu_;
+    mutable std::condition_variable idle_cv_;
+    std::deque<RecordDescriptor> descriptors_;
+    std::exception_ptr failure_;
+    size_t active_payloads_{0};
+
+    void materialize_and_submit(const RecordDescriptor& descriptor,
+                                const at::Tensor& payload);
+};
+
+}  // namespace ring

--- a/native/csrc/ring/record_consumer.h
+++ b/native/csrc/ring/record_consumer.h
@@ -1,9 +1,9 @@
-// FIFO descriptor-to-payload association and generic materialization.
+// FIFO descriptor-to-payload association at the backend-neutral sink boundary.
 
 #pragma once
 
 #include "record_descriptor.h"
-#include "../dmx_host_utils.h"
+#include "record_sink.h"
 
 #include <ATen/ATen.h>
 
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <deque>
 #include <exception>
-#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -22,9 +22,7 @@ namespace ring {
 
 class RecordConsumer {
 public:
-    using SubmitFn = std::function<void(dmx_host::GenericRecordRow, uint64_t)>;
-
-    explicit RecordConsumer(SubmitFn submit_fn);
+    explicit RecordConsumer(std::shared_ptr<RecordSink> sink);
 
     RecordConsumer(const RecordConsumer&) = delete;
     RecordConsumer& operator=(const RecordConsumer&) = delete;
@@ -36,7 +34,7 @@ public:
     // Consume exactly one descriptor for one physical payload.  The payload
     // must be a contiguous CPU byte tensor containing the actual produced
     // bytes from its ready TaskEntry.
-    void consume_payload(const at::Tensor& payload);
+    void consume_payload(at::Tensor payload);
 
     // Latch an asynchronous worker failure.  The first failure is retained.
     void record_failure(std::exception_ptr failure) noexcept;
@@ -48,16 +46,13 @@ public:
     size_t pending_descriptors() const;
 
 private:
-    SubmitFn submit_fn_;
+    std::shared_ptr<RecordSink> sink_;
 
     mutable std::mutex mu_;
     mutable std::condition_variable idle_cv_;
     std::deque<RecordDescriptor> descriptors_;
     std::exception_ptr failure_;
     size_t active_payloads_{0};
-
-    void materialize_and_submit(const RecordDescriptor& descriptor,
-                                const at::Tensor& payload);
 };
 
 }  // namespace ring

--- a/native/csrc/ring/record_descriptor.h
+++ b/native/csrc/ring/record_descriptor.h
@@ -1,0 +1,62 @@
+// Framework-neutral encoded record descriptors.
+//
+// Integrations encode semantic metadata into literal cells before publishing
+// a payload.  The native record consumer only associates the next descriptor
+// with the next physical payload and materializes the declared payload slices.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace ring {
+
+enum class PayloadMaterialization : uint8_t {
+    TENSOR = 0,
+    FLOAT_SCALAR = 1,
+    INT_SCALAR = 2,
+};
+
+// Dtype is the numeric at::ScalarType value.  Keeping it encoded avoids an
+// ATen dependency in the descriptor itself while allowing the consumer to
+// validate and construct an at::Tensor.
+struct PayloadSlice {
+    uint64_t offset_bytes{0};
+
+    // A missing length means "all actual payload bytes after offset".  This is
+    // required for a dynamic producer whose exact byte count is device-known
+    // only when its TaskEntry becomes ready.  An explicit zero remains a real
+    // zero-length slice.
+    std::optional<uint64_t> length_bytes;
+
+    PayloadMaterialization materialization{PayloadMaterialization::TENSOR};
+    int32_t dtype{0};
+    std::vector<int64_t> logical_shape;
+
+    // -1 means every logical dimension is fixed.  Otherwise the selected
+    // dimension is inferred from the actual slice byte count while all other
+    // dimensions remain fixed.
+    int32_t inferred_dynamic_dim{-1};
+};
+
+using EncodedRecordCell = std::variant<
+    std::string,
+    int32_t,
+    int64_t,
+    double,
+    std::vector<int64_t>,
+    PayloadSlice>;
+
+struct EncodedRecordRow {
+    std::vector<EncodedRecordCell> cells;
+};
+
+struct RecordDescriptor {
+    std::string layout;
+    std::vector<EncodedRecordRow> rows;
+};
+
+}  // namespace ring

--- a/native/csrc/ring/record_sink.h
+++ b/native/csrc/ring/record_sink.h
@@ -1,0 +1,39 @@
+// Backend-neutral ownership and completion boundary for generic records.
+
+#pragma once
+
+#include "record_descriptor.h"
+
+#include <ATen/ATen.h>
+
+#include <chrono>
+
+namespace ring {
+
+// One descriptor paired with its owned, contiguous host payload.  submit()
+// transfers both objects to the sink; the ring never accesses them again.
+struct RecordEnvelope {
+    RecordDescriptor descriptor;
+    at::Tensor payload;
+};
+
+// Native sinks may enqueue work asynchronously, but they must expose one
+// checked, non-closing durability barrier.  The exact durability boundary is
+// a property of the concrete sink (for example, ClickHouse acknowledgement,
+// local spool commit, or remote object-store commit).
+//
+// The ring invokes submit() from its single record p2p worker.  It invokes
+// flush_and_wait() only after every earlier submit() has returned, so a sink
+// owns any additional internal concurrency and backpressure policy.
+class RecordSink {
+public:
+    using Duration = std::chrono::milliseconds;
+
+    virtual ~RecordSink() = default;
+
+    virtual void submit(RecordEnvelope envelope) = 0;
+    virtual bool flush_and_wait(Duration timeout) = 0;
+    virtual void rethrow_if_failed() const = 0;
+};
+
+}  // namespace ring

--- a/native/csrc/ring/ring_engine.cu
+++ b/native/csrc/ring/ring_engine.cu
@@ -36,8 +36,8 @@ RingEngine::RingEngine(const RingConfig& cfg, ring_py::TensorMetaFifo& fifo,
 }
 
 RingEngine::RingEngine(const RingConfig& cfg,
-                       RecordConsumer::SubmitFn submit_fn)
-    : cfg_(cfg), ring_(cfg)
+                       std::shared_ptr<RecordSink> sink)
+    : cfg_(cfg), ring_(cfg), record_sink_(std::move(sink))
 {
     if (cfg_.payload_ring_bytes % PAYLOAD_ALIGN != 0) {
         throw std::runtime_error(
@@ -61,7 +61,7 @@ RingEngine::RingEngine(const RingConfig& cfg,
     staging_.init(cfg.effective_staging_bytes());
     drain_ = std::make_unique<DrainThread>(ring_.state(), staging_, cfg_);
     record_p2p_ = std::make_unique<RecordP2PThread>(
-        *drain_, std::move(submit_fn));
+        *drain_, record_sink_);
 }
 
 RingEngine::~RingEngine() noexcept {

--- a/native/csrc/ring/ring_engine.cu
+++ b/native/csrc/ring/ring_engine.cu
@@ -35,12 +35,42 @@ RingEngine::RingEngine(const RingConfig& cfg, ring_py::TensorMetaFifo& fifo,
     p2p_   = std::make_unique<P2PThread>(*drain_, fifo, cfg_, std::move(submit_fn));
 }
 
+RingEngine::RingEngine(const RingConfig& cfg,
+                       RecordConsumer::SubmitFn submit_fn)
+    : cfg_(cfg), ring_(cfg)
+{
+    if (cfg_.payload_ring_bytes % PAYLOAD_ALIGN != 0) {
+        throw std::runtime_error(
+            "RingConfig: payload_ring_bytes must be a multiple of "
+            "PAYLOAD_ALIGN (wrap offset alignment)");
+    }
+    if (cfg_.drain_poll_timeout_us == 0) {
+        throw std::runtime_error(
+            "RingConfig: drain_poll_timeout_us must be > 0. "
+            "The drain thread must poll periodically to process entries "
+            "published mid-forward.");
+    }
+
+    auto* buf = ring_.state().payload_buf;
+    if (reinterpret_cast<uintptr_t>(buf) % PAYLOAD_ALIGN != 0) {
+        throw std::runtime_error(
+            "RingEngine: payload_buf is not PAYLOAD_ALIGN-aligned "
+            "(unexpected: cudaMalloc guarantees >= 256-byte alignment)");
+    }
+
+    staging_.init(cfg.effective_staging_bytes());
+    drain_ = std::make_unique<DrainThread>(ring_.state(), staging_, cfg_);
+    record_p2p_ = std::make_unique<RecordP2PThread>(
+        *drain_, std::move(submit_fn));
+}
+
 RingEngine::~RingEngine() noexcept {
     if (drain_) {
         drain_->stop();
         drain_->signal_p2p_stop();
     }
     if (p2p_) p2p_->stop();
+    if (record_p2p_) record_p2p_->stop();
 }
 
 void RingEngine::init(cudaStream_t stream) {
@@ -49,7 +79,8 @@ void RingEngine::init(cudaStream_t stream) {
 
 void RingEngine::start() {
     drain_->start();
-    p2p_->start();
+    if (p2p_) p2p_->start();
+    if (record_p2p_) record_p2p_->start();
 }
 
 void RingEngine::stop() {
@@ -61,7 +92,22 @@ void RingEngine::stop() {
 
     drain_->stop();
     drain_->signal_p2p_stop();
-    p2p_->stop();
+    if (p2p_) p2p_->stop();
+    if (record_p2p_) record_p2p_->stop();
+}
+
+RecordConsumer& RingEngine::record_consumer() {
+    if (!record_p2p_) {
+        throw std::logic_error("record consumer requested from legacy ring");
+    }
+    return record_p2p_->consumer();
+}
+
+const RecordConsumer& RingEngine::record_consumer() const {
+    if (!record_p2p_) {
+        throw std::logic_error("record consumer requested from legacy ring");
+    }
+    return record_p2p_->consumer();
 }
 
 }  // namespace ring

--- a/native/csrc/ring/ring_engine.h
+++ b/native/csrc/ring/ring_engine.h
@@ -16,6 +16,7 @@ class RingEngine {
 public:
     RingEngine(const RingConfig& cfg, ring_py::TensorMetaFifo& fifo,
                SubmitFn submit_fn);
+    RingEngine(const RingConfig& cfg, RecordConsumer::SubmitFn submit_fn);
     ~RingEngine() noexcept;
 
     RingEngine(const RingEngine&)            = delete;
@@ -27,6 +28,9 @@ public:
 
     RingState&   ring_state()    { return ring_.state(); }
     DrainThread& drain_thread()  { return *drain_; }
+    RecordConsumer& record_consumer();
+    const RecordConsumer& record_consumer() const;
+    bool record_mode() const { return static_cast<bool>(record_p2p_); }
 
     uint64_t  payload_cap() const { return cfg_.payload_ring_bytes; }
     uint64_t  staging_cap() const { return staging_.capacity(); }
@@ -38,6 +42,7 @@ private:
     PinnedStaging   staging_;
     std::unique_ptr<DrainThread>  drain_;
     std::unique_ptr<P2PThread>    p2p_;
+    std::unique_ptr<RecordP2PThread> record_p2p_;
 };
 
 }  // namespace ring

--- a/native/csrc/ring/ring_engine.h
+++ b/native/csrc/ring/ring_engine.h
@@ -5,6 +5,7 @@
 #include "pinned_staging.h"
 #include "drain_thread.h"
 #include "p2p_thread.h"
+#include "record_sink.h"
 #include "tensor_meta.h"
 
 #include <memory>
@@ -16,7 +17,7 @@ class RingEngine {
 public:
     RingEngine(const RingConfig& cfg, ring_py::TensorMetaFifo& fifo,
                SubmitFn submit_fn);
-    RingEngine(const RingConfig& cfg, RecordConsumer::SubmitFn submit_fn);
+    RingEngine(const RingConfig& cfg, std::shared_ptr<RecordSink> sink);
     ~RingEngine() noexcept;
 
     RingEngine(const RingEngine&)            = delete;
@@ -30,6 +31,7 @@ public:
     DrainThread& drain_thread()  { return *drain_; }
     RecordConsumer& record_consumer();
     const RecordConsumer& record_consumer() const;
+    std::shared_ptr<RecordSink> record_sink() const { return record_sink_; }
     bool record_mode() const { return static_cast<bool>(record_p2p_); }
 
     uint64_t  payload_cap() const { return cfg_.payload_ring_bytes; }
@@ -42,6 +44,7 @@ private:
     PinnedStaging   staging_;
     std::unique_ptr<DrainThread>  drain_;
     std::unique_ptr<P2PThread>    p2p_;
+    std::shared_ptr<RecordSink> record_sink_;
     std::unique_ptr<RecordP2PThread> record_p2p_;
 };
 

--- a/native/csrc/ring/ring_engine_py.cu
+++ b/native/csrc/ring/ring_engine_py.cu
@@ -134,8 +134,8 @@ struct RingEnginePy::Impl {
             at::TensorOptions().dtype(at::kByte).device(at::kCUDA, dev_idx));
     }
 
-    Impl(ring::RingConfig cfg, RecordSubmitFn sf)
-        : engine(std::move(cfg), std::move(sf)), record_mode(true)
+    Impl(ring::RingConfig cfg, std::shared_ptr<ring::RecordSink> sink)
+        : engine(std::move(cfg), std::move(sink)), record_mode(true)
     {
         const auto& state = engine.ring_state();
         int dev_idx = 0;
@@ -170,8 +170,9 @@ RingEnginePy::RingEnginePy(RingConfig cfg, SubmitFn submit_fn) {
     impl_ = std::make_unique<Impl>(convert(cfg), std::move(submit_fn));
 }
 
-RingEnginePy::RingEnginePy(RingConfig cfg, RecordSubmitFn submit_fn) {
-    impl_ = std::make_unique<Impl>(convert(cfg), std::move(submit_fn));
+RingEnginePy::RingEnginePy(
+    RingConfig cfg, std::shared_ptr<ring::RecordSink> sink) {
+    impl_ = std::make_unique<Impl>(convert(cfg), std::move(sink));
 }
 
 RingEnginePy::~RingEnginePy() = default;
@@ -550,6 +551,18 @@ bool RingEnginePy::flush_records_and_wait(uint64_t timeout_ms) {
         : std::chrono::milliseconds::zero();
     if (!consumer.wait_until_idle(remaining)) return false;
     consumer.finish();
+
+    const auto sink = impl_->engine.record_sink();
+    if (sink) {
+        sink->rethrow_if_failed();
+        const auto before_sink = FlushClock::now();
+        if (before_sink >= deadline) return false;
+        const auto sink_timeout =
+            std::chrono::duration_cast<ring::RecordSink::Duration>(
+                deadline - before_sink);
+        if (!sink->flush_and_wait(sink_timeout)) return false;
+        sink->rethrow_if_failed();
+    }
     if (FlushClock::now() > deadline) return false;
     return true;
 }

--- a/native/csrc/ring/ring_engine_py.cu
+++ b/native/csrc/ring/ring_engine_py.cu
@@ -11,6 +11,11 @@
 #include "ring/producer.cuh"
 #include "ring/ring_debug.h"
 #include <ATen/cuda/CUDAContext.h>  // at::cuda::getCurrentCUDAStream
+#include <algorithm>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
 
 // Forward-declare symbols from producer.cu
 namespace ring {
@@ -18,6 +23,83 @@ void set_ring_null_mode(bool enabled);
 }  // namespace ring
 
 namespace ring_py {
+
+namespace {
+
+using FlushClock = std::chrono::steady_clock;
+
+void check_flush_cuda(cudaError_t error, const char* operation) {
+    if (error == cudaSuccess) return;
+    throw std::runtime_error(
+        std::string("record flush ") + operation + " failed: " +
+        cudaGetErrorString(error));
+}
+
+class ScopedFlushEvent {
+public:
+    ScopedFlushEvent() {
+        check_flush_cuda(
+            cudaEventCreateWithFlags(&event_, cudaEventDisableTiming),
+            "cudaEventCreateWithFlags");
+    }
+
+    ~ScopedFlushEvent() noexcept {
+        if (event_ != nullptr) cudaEventDestroy(event_);
+    }
+
+    ScopedFlushEvent(const ScopedFlushEvent&) = delete;
+    ScopedFlushEvent& operator=(const ScopedFlushEvent&) = delete;
+
+    cudaEvent_t get() const { return event_; }
+
+    cudaError_t destroy() noexcept {
+        if (event_ == nullptr) return cudaSuccess;
+        cudaEvent_t event = event_;
+        event_ = nullptr;
+        return cudaEventDestroy(event);
+    }
+
+private:
+    cudaEvent_t event_{nullptr};
+};
+
+bool wait_for_stream_prefix_until(
+    cudaStream_t stream, FlushClock::time_point deadline) {
+    ScopedFlushEvent event;
+    check_flush_cuda(cudaEventRecord(event.get(), stream), "cudaEventRecord");
+
+    for (;;) {
+        const cudaError_t status = cudaEventQuery(event.get());
+        if (status == cudaSuccess) {
+            check_flush_cuda(event.destroy(), "cudaEventDestroy");
+            return true;
+        }
+        if (status != cudaErrorNotReady) {
+            check_flush_cuda(status, "cudaEventQuery");
+        }
+
+        const auto now = FlushClock::now();
+        if (now >= deadline) {
+            check_flush_cuda(event.destroy(), "cudaEventDestroy");
+            return false;
+        }
+        std::this_thread::sleep_until(
+            std::min(deadline, now + std::chrono::microseconds(50)));
+    }
+}
+
+FlushClock::time_point record_flush_deadline(uint64_t timeout_ms) {
+    const auto now = FlushClock::now();
+    const auto max_remaining = FlushClock::time_point::max() - now;
+    const auto max_milliseconds =
+        std::chrono::duration_cast<std::chrono::milliseconds>(max_remaining);
+    if (timeout_ms >= static_cast<uint64_t>(max_milliseconds.count())) {
+        return FlushClock::time_point::max();
+    }
+    return now + std::chrono::milliseconds(timeout_ms);
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------------------
 struct RingEnginePy::Impl {
@@ -37,9 +119,22 @@ struct RingEnginePy::Impl {
     // engine init; returned by payload_tensor().  Used as the
     // Tensor(a!) mutation alias passed to every producer op call.
     at::Tensor       payload_view;
+    bool             record_mode{false};
 
     Impl(ring::RingConfig cfg, SubmitFn sf)
         : engine(std::move(cfg), fifo, std::move(sf))
+    {
+        const auto& state = engine.ring_state();
+        int dev_idx = 0;
+        cudaGetDevice(&dev_idx);
+        payload_view = at::from_blob(
+            state.payload_buf,
+            {static_cast<int64_t>(state.payload_cap)},
+            at::TensorOptions().dtype(at::kByte).device(at::kCUDA, dev_idx));
+    }
+
+    Impl(ring::RingConfig cfg, RecordSubmitFn sf)
+        : engine(std::move(cfg), std::move(sf)), record_mode(true)
     {
         const auto& state = engine.ring_state();
         int dev_idx = 0;
@@ -74,6 +169,10 @@ RingEnginePy::RingEnginePy(RingConfig cfg, SubmitFn submit_fn) {
     impl_ = std::make_unique<Impl>(convert(cfg), std::move(submit_fn));
 }
 
+RingEnginePy::RingEnginePy(RingConfig cfg, RecordSubmitFn submit_fn) {
+    impl_ = std::make_unique<Impl>(convert(cfg), std::move(submit_fn));
+}
+
 RingEnginePy::~RingEnginePy() = default;
 
 void RingEnginePy::init(uint64_t stream_handle) {
@@ -105,6 +204,10 @@ void RingEnginePy::set_null_mode(bool enabled) {
 
 
 void RingEnginePy::push_step(StepContext* ctx, std::vector<TensorMeta>& metas) {
+    if (impl_->record_mode) {
+        delete ctx;
+        throw std::logic_error("legacy metadata cannot be pushed to a record ring");
+    }
     impl_->fifo.push_step(ctx, metas);
 }
 
@@ -165,6 +268,88 @@ void RingEnginePy::hook_no_notify_chunked(uint64_t d_ptr, uint64_t nbytes_upper,
         reinterpret_cast<const int64_t*>(chunk_bytes_dev_ptr),
         K,
         hook_type, stream);
+}
+
+void RingEnginePy::record_no_notify(
+    uint64_t d_ptr, uint64_t nbytes,
+    uint64_t emit_gate_ptr, int32_t emit_value,
+    uint64_t stream_handle) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record producer requires a record ring");
+    }
+    ring::launch_record_producer_static(
+        impl_->engine.ring_state(),
+        reinterpret_cast<const uint8_t*>(d_ptr), nbytes,
+        reinterpret_cast<const int32_t*>(emit_gate_ptr), emit_value,
+        reinterpret_cast<cudaStream_t>(stream_handle));
+}
+
+void RingEnginePy::record_no_notify_prefix(
+    uint64_t d_ptr, uint64_t nbytes_upper,
+    uint64_t row_count_dev_ptr, uint64_t row_bytes,
+    uint64_t emit_gate_ptr, int32_t emit_value,
+    uint64_t stream_handle) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record producer requires a record ring");
+    }
+    ring::launch_record_producer_prefix(
+        impl_->engine.ring_state(),
+        reinterpret_cast<const uint8_t*>(d_ptr), nbytes_upper,
+        reinterpret_cast<const int64_t*>(row_count_dev_ptr), row_bytes,
+        reinterpret_cast<const int32_t*>(emit_gate_ptr), emit_value,
+        reinterpret_cast<cudaStream_t>(stream_handle));
+}
+
+void RingEnginePy::record_no_notify_chunked(
+    uint64_t d_ptr, uint64_t nbytes_upper,
+    uint64_t chunk_bytes_dev_ptr, uint32_t chunk_count,
+    uint64_t emit_gate_ptr, int32_t emit_value,
+    uint64_t stream_handle) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record producer requires a record ring");
+    }
+    ring::launch_record_producer_chunked(
+        impl_->engine.ring_state(),
+        reinterpret_cast<const uint8_t*>(d_ptr), nbytes_upper,
+        reinterpret_cast<const int64_t*>(chunk_bytes_dev_ptr), chunk_count,
+        reinterpret_cast<const int32_t*>(emit_gate_ptr), emit_value,
+        reinterpret_cast<cudaStream_t>(stream_handle));
+}
+
+void RingEnginePy::record_no_notify_seq_prefix_pack(
+    uint64_t d_ptr, uint64_t nbytes_upper,
+    uint64_t valid_count_dev_ptr, uint64_t valid_prefix_sum_dev_ptr,
+    uint32_t batch, uint64_t feature_bytes,
+    uint64_t emit_gate_ptr, int32_t emit_value,
+    uint64_t stream_handle) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record producer requires a record ring");
+    }
+    ring::launch_record_producer_seq_prefix_pack(
+        impl_->engine.ring_state(),
+        reinterpret_cast<const uint8_t*>(d_ptr), nbytes_upper,
+        reinterpret_cast<const int64_t*>(valid_count_dev_ptr),
+        reinterpret_cast<const int64_t*>(valid_prefix_sum_dev_ptr), batch,
+        feature_bytes, reinterpret_cast<const int32_t*>(emit_gate_ptr),
+        emit_value, reinterpret_cast<cudaStream_t>(stream_handle));
+}
+
+void RingEnginePy::record_no_notify_segmented_pack(
+    uint64_t d_ptr, uint64_t nbytes_upper,
+    uint64_t segment_start_dev_ptr, uint64_t segment_end_dev_ptr,
+    uint32_t segment_count, uint64_t feature_bytes,
+    uint64_t emit_gate_ptr, int32_t emit_value,
+    uint64_t stream_handle) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record producer requires a record ring");
+    }
+    ring::launch_record_producer_segmented_pack(
+        impl_->engine.ring_state(),
+        reinterpret_cast<const uint8_t*>(d_ptr), nbytes_upper,
+        reinterpret_cast<const int64_t*>(segment_start_dev_ptr),
+        reinterpret_cast<const int64_t*>(segment_end_dev_ptr), segment_count,
+        feature_bytes, reinterpret_cast<const int32_t*>(emit_gate_ptr),
+        emit_value, reinterpret_cast<cudaStream_t>(stream_handle));
 }
 
 void RingEnginePy::notify_drain() {
@@ -247,6 +432,115 @@ int RingEnginePy::prepare_step(uint64_t step_total_bytes,
     drain.force_flush_and_wait();
     drain.reserve(step_total_bytes, num_hooks);
     return STEP_RING_FLUSHED;
+}
+
+int RingEnginePy::reserve_record(uint64_t reservation_bytes,
+                                 uint32_t num_tasks) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record reservation requires a record ring");
+    }
+    if (reservation_bytes % ring::PAYLOAD_ALIGN != 0) {
+        throw std::invalid_argument(
+            "record reservation bytes must be PAYLOAD_ALIGN-aligned");
+    }
+    if (num_tasks == 0) {
+        if (reservation_bytes != 0) {
+            throw std::invalid_argument(
+                "record reservation cannot contain bytes without tasks");
+        }
+        return STEP_RING_OK;
+    }
+
+    const uint64_t payload_cap = impl_->engine.payload_cap();
+    const uint64_t staging_cap = impl_->engine.staging_cap();
+    const uint64_t effective_cap = std::min(payload_cap, staging_cap);
+    const uint64_t task_cap = impl_->engine.task_cap();
+    auto& drain = impl_->engine.drain_thread();
+    drain.rethrow_drain_failure();
+    drain.rethrow_record_reclaim_failure();
+
+    if (reservation_bytes > effective_cap || num_tasks > task_cap) {
+        cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+        cudaStreamSynchronize(stream);
+        drain.force_flush_and_wait();
+        drain.rethrow_drain_failure();
+        drain.rethrow_record_reclaim_failure();
+        if (drain.pending_record_reservations() != 0) {
+            throw std::runtime_error(
+                "record flush found incomplete producer reservations");
+        }
+        return STEP_OVERSIZED;
+    }
+
+    const uint64_t payload_used =
+        drain.cpu_payload_head() - drain.cpu_payload_tail_committed();
+    const uint64_t task_used =
+        drain.cpu_task_head() - drain.cpu_task_tail_committed();
+    if (reservation_bytes <= payload_cap - payload_used &&
+        num_tasks <= task_cap - task_used) {
+        drain.reserve_record(reservation_bytes, num_tasks);
+        return STEP_RING_OK;
+    }
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    cudaStreamSynchronize(stream);
+    drain.force_flush_and_wait();
+    drain.rethrow_drain_failure();
+    drain.rethrow_record_reclaim_failure();
+    if (drain.pending_record_reservations() != 0) {
+        throw std::runtime_error(
+            "record flush found incomplete producer reservations");
+    }
+    drain.reserve_record(reservation_bytes, num_tasks);
+    return STEP_RING_FLUSHED;
+}
+
+void RingEnginePy::push_record_descriptors(
+    std::vector<ring::RecordDescriptor> descriptors) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record descriptors require a record ring");
+    }
+    impl_->engine.record_consumer().push_descriptors(std::move(descriptors));
+}
+
+void RingEnginePy::submit_record_cpu_direct(
+    at::Tensor cpu_tensor, uint64_t tensor_bytes) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record CPU submission requires a record ring");
+    }
+    impl_->engine.drain_thread().submit_cpu_direct(
+        std::move(cpu_tensor), tensor_bytes);
+}
+
+bool RingEnginePy::flush_records_and_wait(uint64_t timeout_ms) {
+    if (!impl_->record_mode) {
+        throw std::logic_error("record flush requires a record ring");
+    }
+    const auto deadline = record_flush_deadline(timeout_ms);
+    auto& drain = impl_->engine.drain_thread();
+    auto& consumer = impl_->engine.record_consumer();
+    drain.rethrow_drain_failure();
+    drain.rethrow_record_reclaim_failure();
+    consumer.rethrow_if_failed();
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    if (!wait_for_stream_prefix_until(stream, deadline)) return false;
+    if (!drain.force_flush_and_wait_until(deadline)) return false;
+    drain.rethrow_record_reclaim_failure();
+
+    if (drain.pending_record_reservations() != 0) {
+        throw std::runtime_error(
+            "record flush found incomplete producer reservations");
+    }
+
+    const auto now = FlushClock::now();
+    const auto remaining = now < deadline
+        ? std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+        : std::chrono::milliseconds::zero();
+    if (!consumer.wait_until_idle(remaining)) return false;
+    consumer.finish();
+    if (FlushClock::now() > deadline) return false;
+    return true;
 }
 
 void RingEnginePy::submit_cpu_direct(at::Tensor cpu_tensor, uint64_t tensor_bytes) {

--- a/native/csrc/ring/ring_engine_py.cu
+++ b/native/csrc/ring/ring_engine_py.cu
@@ -13,6 +13,7 @@
 #include <ATen/cuda/CUDAContext.h>  // at::cuda::getCurrentCUDAStream
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -434,22 +435,28 @@ int RingEnginePy::prepare_step(uint64_t step_total_bytes,
     return STEP_RING_FLUSHED;
 }
 
-int RingEnginePy::reserve_record(uint64_t reservation_bytes,
-                                 uint32_t num_tasks) {
+int RingEnginePy::reserve_record(
+    const std::vector<std::pair<uint64_t, bool>>& reservation_items) {
     if (!impl_->record_mode) {
         throw std::logic_error("record reservation requires a record ring");
     }
-    if (reservation_bytes % ring::PAYLOAD_ALIGN != 0) {
-        throw std::invalid_argument(
-            "record reservation bytes must be PAYLOAD_ALIGN-aligned");
-    }
-    if (num_tasks == 0) {
-        if (reservation_bytes != 0) {
+    uint64_t reservation_bytes = 0;
+    std::vector<ring::RecordReservationItem> items;
+    items.reserve(reservation_items.size());
+    for (const auto& item : reservation_items) {
+        if (item.first % ring::PAYLOAD_ALIGN != 0) {
             throw std::invalid_argument(
-                "record reservation cannot contain bytes without tasks");
+                "record reservation bytes must be PAYLOAD_ALIGN-aligned");
         }
-        return STEP_RING_OK;
+        if (reservation_bytes >
+            std::numeric_limits<uint64_t>::max() - item.first) {
+            throw std::overflow_error("record reservation byte total overflow");
+        }
+        reservation_bytes += item.first;
+        items.push_back({item.first, item.second});
     }
+    if (items.empty()) return STEP_RING_OK;
+    const uint64_t num_tasks = items.size();
 
     const uint64_t payload_cap = impl_->engine.payload_cap();
     const uint64_t staging_cap = impl_->engine.staging_cap();
@@ -458,6 +465,7 @@ int RingEnginePy::reserve_record(uint64_t reservation_bytes,
     auto& drain = impl_->engine.drain_thread();
     drain.rethrow_drain_failure();
     drain.rethrow_record_reclaim_failure();
+    drain.apply_pending_record_reclaims();
 
     if (reservation_bytes > effective_cap || num_tasks > task_cap) {
         cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
@@ -465,9 +473,10 @@ int RingEnginePy::reserve_record(uint64_t reservation_bytes,
         drain.force_flush_and_wait();
         drain.rethrow_drain_failure();
         drain.rethrow_record_reclaim_failure();
-        if (drain.pending_record_reservations() != 0) {
+        drain.apply_pending_record_reclaims();
+        if (drain.pending_record_reclaims() != 0) {
             throw std::runtime_error(
-                "record flush found incomplete producer reservations");
+                "record flush found incomplete producer reclaims");
         }
         return STEP_OVERSIZED;
     }
@@ -478,7 +487,7 @@ int RingEnginePy::reserve_record(uint64_t reservation_bytes,
         drain.cpu_task_head() - drain.cpu_task_tail_committed();
     if (reservation_bytes <= payload_cap - payload_used &&
         num_tasks <= task_cap - task_used) {
-        drain.reserve_record(reservation_bytes, num_tasks);
+        drain.reserve_record(items);
         return STEP_RING_OK;
     }
 
@@ -487,11 +496,12 @@ int RingEnginePy::reserve_record(uint64_t reservation_bytes,
     drain.force_flush_and_wait();
     drain.rethrow_drain_failure();
     drain.rethrow_record_reclaim_failure();
-    if (drain.pending_record_reservations() != 0) {
+    drain.apply_pending_record_reclaims();
+    if (drain.pending_record_reclaims() != 0) {
         throw std::runtime_error(
-            "record flush found incomplete producer reservations");
+            "record flush found incomplete producer reclaims");
     }
-    drain.reserve_record(reservation_bytes, num_tasks);
+    drain.reserve_record(items);
     return STEP_RING_FLUSHED;
 }
 
@@ -528,9 +538,10 @@ bool RingEnginePy::flush_records_and_wait(uint64_t timeout_ms) {
     if (!drain.force_flush_and_wait_until(deadline)) return false;
     drain.rethrow_record_reclaim_failure();
 
-    if (drain.pending_record_reservations() != 0) {
+    drain.apply_pending_record_reclaims();
+    if (drain.pending_record_reclaims() != 0) {
         throw std::runtime_error(
-            "record flush found incomplete producer reservations");
+            "record flush found incomplete producer reclaims");
     }
 
     const auto now = FlushClock::now();

--- a/native/csrc/ring/ring_engine_py.h
+++ b/native/csrc/ring/ring_engine_py.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ring/tensor_meta.h"   // TensorMeta, TensorMetaFifo
@@ -164,9 +165,9 @@ public:
 
     int prepare_step(uint64_t step_total_bytes, uint32_t num_hooks);
 
-    // Record-mode reservation uses conservative aligned upper bounds and is
-    // reconciled from ready TaskEntry byte counts by the drain thread.
-    int reserve_record(uint64_t reservation_bytes, uint32_t num_tasks);
+    // Each item is (aligned upper bound, needs actual-byte reconciliation).
+    int reserve_record(
+        const std::vector<std::pair<uint64_t, bool>>& reservation_items);
 
     void push_record_descriptors(std::vector<ring::RecordDescriptor> descriptors);
     void submit_record_cpu_direct(at::Tensor cpu_tensor,

--- a/native/csrc/ring/ring_engine_py.h
+++ b/native/csrc/ring/ring_engine_py.h
@@ -13,9 +13,11 @@
 #include <vector>
 
 #include "ring/tensor_meta.h"   // TensorMeta, TensorMetaFifo
+#include "ring/record_descriptor.h"
 
 // Forward-declare at::Tensor so SubmitFn can use it without including ATen here.
 namespace at { class Tensor; }
+namespace dmx_host { struct GenericRecordRow; }
 
 namespace ring_py {
 
@@ -49,10 +51,15 @@ using SubmitFn = std::function<void(
     int32_t            end_token,
     at::Tensor         slice)>;
 
+using RecordSubmitFn = std::function<void(
+    dmx_host::GenericRecordRow row,
+    uint64_t                   payload_bytes)>;
+
 // Opaque RAII engine.
 class RingEnginePy {
 public:
     explicit RingEnginePy(RingConfig cfg, SubmitFn submit_fn);
+    explicit RingEnginePy(RingConfig cfg, RecordSubmitFn submit_fn);
     ~RingEnginePy();
 
     RingEnginePy(const RingEnginePy&)            = delete;
@@ -94,6 +101,34 @@ public:
                                  uint32_t hook_type,
                                  uint64_t stream_handle);
 
+    // Additive schema-driven producers.  These methods are reachable only
+    // through the separately registered ring::record_producer* operations.
+    void record_no_notify(uint64_t d_ptr, uint64_t nbytes,
+                          uint64_t emit_gate_ptr, int32_t emit_value,
+                          uint64_t stream_handle);
+    void record_no_notify_prefix(uint64_t d_ptr, uint64_t nbytes_upper,
+                                 uint64_t row_count_dev_ptr,
+                                 uint64_t row_bytes,
+                                 uint64_t emit_gate_ptr, int32_t emit_value,
+                                 uint64_t stream_handle);
+    void record_no_notify_chunked(uint64_t d_ptr, uint64_t nbytes_upper,
+                                  uint64_t chunk_bytes_dev_ptr,
+                                  uint32_t chunk_count,
+                                  uint64_t emit_gate_ptr, int32_t emit_value,
+                                  uint64_t stream_handle);
+    void record_no_notify_seq_prefix_pack(
+        uint64_t d_ptr, uint64_t nbytes_upper,
+        uint64_t valid_count_dev_ptr, uint64_t valid_prefix_sum_dev_ptr,
+        uint32_t batch, uint64_t feature_bytes,
+        uint64_t emit_gate_ptr, int32_t emit_value,
+        uint64_t stream_handle);
+    void record_no_notify_segmented_pack(
+        uint64_t d_ptr, uint64_t nbytes_upper,
+        uint64_t segment_start_dev_ptr, uint64_t segment_end_dev_ptr,
+        uint32_t segment_count, uint64_t feature_bytes,
+        uint64_t emit_gate_ptr, int32_t emit_value,
+        uint64_t stream_handle);
+
     // Lightweight wake-up for the drain thread.
     void notify_drain();
 
@@ -128,6 +163,20 @@ public:
     static constexpr int STEP_OVERSIZED    = 2;
 
     int prepare_step(uint64_t step_total_bytes, uint32_t num_hooks);
+
+    // Record-mode reservation uses conservative aligned upper bounds and is
+    // reconciled from ready TaskEntry byte counts by the drain thread.
+    int reserve_record(uint64_t reservation_bytes, uint32_t num_tasks);
+
+    void push_record_descriptors(std::vector<ring::RecordDescriptor> descriptors);
+    void submit_record_cpu_direct(at::Tensor cpu_tensor,
+                                  uint64_t tensor_bytes);
+
+    // Complete the GPU-to-host record prefix and validate descriptor and
+    // reservation accounting within one timeout.  Returns false only on
+    // timeout.  Database durability is checked separately by MonitoringEngine
+    // through DMXHostEngine.flush_and_wait().
+    bool flush_records_and_wait(uint64_t timeout_ms);
 
     // Submit a CPU-direct tensor to drain -> p2p pipeline.
     void submit_cpu_direct(at::Tensor cpu_tensor, uint64_t tensor_bytes);

--- a/native/csrc/ring/ring_engine_py.h
+++ b/native/csrc/ring/ring_engine_py.h
@@ -16,9 +16,10 @@
 #include "ring/tensor_meta.h"   // TensorMeta, TensorMetaFifo
 #include "ring/record_descriptor.h"
 
-// Forward-declare at::Tensor so SubmitFn can use it without including ATen here.
+// Forward-declare ATen and the generic sink so this plain interface does not
+// expose their implementation headers.
 namespace at { class Tensor; }
-namespace dmx_host { struct GenericRecordRow; }
+namespace ring { class RecordSink; }
 
 namespace ring_py {
 
@@ -52,15 +53,12 @@ using SubmitFn = std::function<void(
     int32_t            end_token,
     at::Tensor         slice)>;
 
-using RecordSubmitFn = std::function<void(
-    dmx_host::GenericRecordRow row,
-    uint64_t                   payload_bytes)>;
-
 // Opaque RAII engine.
 class RingEnginePy {
 public:
     explicit RingEnginePy(RingConfig cfg, SubmitFn submit_fn);
-    explicit RingEnginePy(RingConfig cfg, RecordSubmitFn submit_fn);
+    explicit RingEnginePy(RingConfig cfg,
+                          std::shared_ptr<ring::RecordSink> sink);
     ~RingEnginePy();
 
     RingEnginePy(const RingEnginePy&)            = delete;
@@ -174,9 +172,8 @@ public:
                                   uint64_t tensor_bytes);
 
     // Complete the GPU-to-host record prefix and validate descriptor and
-    // reservation accounting within one timeout.  Returns false only on
-    // timeout.  Database durability is checked separately by MonitoringEngine
-    // through DMXHostEngine.flush_and_wait().
+    // reservation accounting and the configured sink's durability boundary
+    // within one timeout.  Returns false only on timeout.
     bool flush_records_and_wait(uint64_t timeout_ms);
 
     // Submit a CPU-direct tensor to drain -> p2p pipeline.

--- a/native/csrc/ring/ring_torch_op.cpp
+++ b/native/csrc/ring/ring_torch_op.cpp
@@ -1,6 +1,9 @@
 #include <torch/library.h>
 #include <ATen/cuda/CUDAContext.h>
 #include "ring_torch_op.h"
+#include "producer.cuh"
+
+#include <limits>
 
 // Active ring engine pointer. Set via ring_set_active_engine() from Python
 // activate()/deactivate(). Accessed only during CUDA graph CAPTURE (when this
@@ -139,6 +142,198 @@ void ring_producer_chunked_impl(
     }
 }
 
+namespace {
+
+const int32_t* checked_record_gate(
+    const c10::optional<at::Tensor>& emit_gate,
+    const at::Tensor& tensor) {
+    if (!emit_gate.has_value() || !emit_gate->defined()) return nullptr;
+    TORCH_CHECK(emit_gate->is_cuda(),
+                "record producer emit_gate must be a CUDA tensor");
+    TORCH_CHECK(emit_gate->is_contiguous(),
+                "record producer emit_gate must be contiguous");
+    TORCH_CHECK(emit_gate->scalar_type() == at::kInt,
+                "record producer emit_gate must have dtype int32");
+    TORCH_CHECK(emit_gate->numel() == 1,
+                "record producer emit_gate must contain one element");
+    TORCH_CHECK(emit_gate->device() == tensor.device(),
+                "record producer emit_gate must be on the payload device");
+    return emit_gate->data_ptr<int32_t>();
+}
+
+int32_t checked_emit_value(int64_t emit_value) {
+    TORCH_CHECK(emit_value >= std::numeric_limits<int32_t>::min() &&
+                    emit_value <= std::numeric_limits<int32_t>::max(),
+                "record producer emit_value must fit in int32");
+    return static_cast<int32_t>(emit_value);
+}
+
+void checked_record_tensor(const at::Tensor& tensor) {
+    TORCH_CHECK(tensor.is_cuda(),
+                "record producer payload must be a CUDA tensor");
+    TORCH_CHECK(tensor.is_contiguous(),
+                "record producer payload must be contiguous");
+}
+
+void checked_record_index_tensor(const at::Tensor& value,
+                                 const at::Tensor& payload,
+                                 const char* name) {
+    TORCH_CHECK(value.defined() && value.is_cuda(), name,
+                " must be a CUDA tensor");
+    TORCH_CHECK(value.is_contiguous(), name, " must be contiguous");
+    TORCH_CHECK(value.scalar_type() == at::kLong, name,
+                " must have dtype int64");
+    TORCH_CHECK(value.device() == payload.device(), name,
+                " must be on the payload device");
+}
+
+}  // namespace
+
+void ring_record_producer_impl(
+    const at::Tensor& /*ring_payload*/,
+    const at::Tensor& tensor,
+    const c10::optional<at::Tensor>& emit_gate,
+    int64_t emit_value) {
+    if (!g_active_engine) return;
+    checked_record_tensor(tensor);
+    const int32_t* gate = checked_record_gate(emit_gate, tensor);
+    auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
+    g_active_engine->record_no_notify(
+        reinterpret_cast<uint64_t>(tensor.data_ptr()),
+        static_cast<uint64_t>(tensor.nbytes()),
+        reinterpret_cast<uint64_t>(gate),
+        checked_emit_value(emit_value),
+        reinterpret_cast<uint64_t>(stream.stream()));
+}
+
+void ring_record_producer_prefix_impl(
+    const at::Tensor& /*ring_payload*/,
+    const at::Tensor& tensor,
+    const at::Tensor& row_count,
+    int64_t row_bytes,
+    const c10::optional<at::Tensor>& emit_gate,
+    int64_t emit_value) {
+    if (!g_active_engine) return;
+    checked_record_tensor(tensor);
+    checked_record_index_tensor(row_count, tensor, "record row_count");
+    TORCH_CHECK(row_count.numel() == 1,
+                "record row_count must contain one element");
+    TORCH_CHECK(row_bytes > 0,
+                "record row_bytes must be positive");
+    const int32_t* gate = checked_record_gate(emit_gate, tensor);
+    auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
+    g_active_engine->record_no_notify_prefix(
+        reinterpret_cast<uint64_t>(tensor.data_ptr()),
+        static_cast<uint64_t>(tensor.nbytes()),
+        reinterpret_cast<uint64_t>(row_count.data_ptr()),
+        static_cast<uint64_t>(row_bytes),
+        reinterpret_cast<uint64_t>(gate),
+        checked_emit_value(emit_value),
+        reinterpret_cast<uint64_t>(stream.stream()));
+}
+
+void ring_record_producer_chunked_impl(
+    const at::Tensor& /*ring_payload*/,
+    const at::Tensor& tensor,
+    const at::Tensor& chunk_bytes,
+    const c10::optional<at::Tensor>& emit_gate,
+    int64_t emit_value) {
+    if (!g_active_engine) return;
+    checked_record_tensor(tensor);
+    checked_record_index_tensor(chunk_bytes, tensor, "record chunk_bytes");
+    TORCH_CHECK(chunk_bytes.dim() == 1,
+                "record chunk_bytes must be one-dimensional");
+    TORCH_CHECK(chunk_bytes.numel() > 0 &&
+                    chunk_bytes.numel() <= ring::PRODUCER_MAX_K,
+                "record chunk count must be in [1, PRODUCER_MAX_K]");
+    TORCH_CHECK(tensor.nbytes() % chunk_bytes.numel() == 0,
+                "record payload bytes must divide evenly into chunks");
+    const int32_t* gate = checked_record_gate(emit_gate, tensor);
+    auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
+    g_active_engine->record_no_notify_chunked(
+        reinterpret_cast<uint64_t>(tensor.data_ptr()),
+        static_cast<uint64_t>(tensor.nbytes()),
+        reinterpret_cast<uint64_t>(chunk_bytes.data_ptr()),
+        static_cast<uint32_t>(chunk_bytes.numel()),
+        reinterpret_cast<uint64_t>(gate),
+        checked_emit_value(emit_value),
+        reinterpret_cast<uint64_t>(stream.stream()));
+}
+
+void ring_record_producer_seq_prefix_pack_impl(
+    const at::Tensor& /*ring_payload*/,
+    const at::Tensor& tensor,
+    const at::Tensor& valid_count,
+    const at::Tensor& valid_prefix_sum,
+    int64_t feature_bytes,
+    const c10::optional<at::Tensor>& emit_gate,
+    int64_t emit_value) {
+    if (!g_active_engine) return;
+    checked_record_tensor(tensor);
+    checked_record_index_tensor(valid_count, tensor, "record valid_count");
+    checked_record_index_tensor(
+        valid_prefix_sum, tensor, "record valid_prefix_sum");
+    TORCH_CHECK(valid_count.dim() == 1 && valid_count.numel() > 0,
+                "record valid_count must be a non-empty one-dimensional tensor");
+    TORCH_CHECK(valid_prefix_sum.dim() == 1 &&
+                    valid_prefix_sum.numel() == valid_count.numel() + 1,
+                "record valid_prefix_sum length must equal batch + 1");
+    TORCH_CHECK(tensor.dim() >= 2 && tensor.size(1) == valid_count.numel(),
+                "record sequence-pack payload must be [S, B, ...]");
+    TORCH_CHECK(feature_bytes > 0,
+                "record sequence-pack feature_bytes must be positive");
+    TORCH_CHECK(tensor.nbytes() %
+                    (valid_count.numel() * feature_bytes) == 0,
+                "record sequence-pack payload has incompatible feature bytes");
+    const int32_t* gate = checked_record_gate(emit_gate, tensor);
+    auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
+    g_active_engine->record_no_notify_seq_prefix_pack(
+        reinterpret_cast<uint64_t>(tensor.data_ptr()),
+        static_cast<uint64_t>(tensor.nbytes()),
+        reinterpret_cast<uint64_t>(valid_count.data_ptr()),
+        reinterpret_cast<uint64_t>(valid_prefix_sum.data_ptr()),
+        static_cast<uint32_t>(valid_count.numel()),
+        static_cast<uint64_t>(feature_bytes),
+        reinterpret_cast<uint64_t>(gate),
+        checked_emit_value(emit_value),
+        reinterpret_cast<uint64_t>(stream.stream()));
+}
+
+void ring_record_producer_segmented_pack_impl(
+    const at::Tensor& /*ring_payload*/,
+    const at::Tensor& tensor,
+    const at::Tensor& segment_start,
+    const at::Tensor& segment_end,
+    int64_t feature_bytes,
+    const c10::optional<at::Tensor>& emit_gate,
+    int64_t emit_value) {
+    if (!g_active_engine) return;
+    checked_record_tensor(tensor);
+    checked_record_index_tensor(segment_start, tensor, "record segment_start");
+    checked_record_index_tensor(segment_end, tensor, "record segment_end");
+    TORCH_CHECK(segment_start.dim() == 1 && segment_start.numel() > 0,
+                "record segment_start must be a non-empty one-dimensional tensor");
+    TORCH_CHECK(segment_end.dim() == 1 &&
+                    segment_end.numel() == segment_start.numel(),
+                "record segment_start/end lengths must match");
+    TORCH_CHECK(feature_bytes > 0,
+                "record segmented-pack feature_bytes must be positive");
+    TORCH_CHECK(tensor.nbytes() % feature_bytes == 0,
+                "record segmented-pack payload has incompatible feature bytes");
+    const int32_t* gate = checked_record_gate(emit_gate, tensor);
+    auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
+    g_active_engine->record_no_notify_segmented_pack(
+        reinterpret_cast<uint64_t>(tensor.data_ptr()),
+        static_cast<uint64_t>(tensor.nbytes()),
+        reinterpret_cast<uint64_t>(segment_start.data_ptr()),
+        reinterpret_cast<uint64_t>(segment_end.data_ptr()),
+        static_cast<uint32_t>(segment_start.numel()),
+        static_cast<uint64_t>(feature_bytes),
+        reinterpret_cast<uint64_t>(gate),
+        checked_emit_value(emit_value),
+        reinterpret_cast<uint64_t>(stream.stream()));
+}
+
 TORCH_LIBRARY(ring, m) {
     m.def("producer(Tensor(a!) ring_payload, Tensor x, "
           "int hook_type, int hook_id) -> ()");
@@ -147,10 +342,30 @@ TORCH_LIBRARY(ring, m) {
           "int hook_type, int hook_id) -> ()");
     m.def("producer_chunked(Tensor(a!) ring_payload, Tensor x, "
           "Tensor chunk_bytes, int hook_type, int hook_id) -> ()");
+    m.def("record_producer(Tensor(a!) ring_payload, Tensor x, "
+          "Tensor? emit_gate=None, int emit_value=0) -> ()");
+    m.def("record_producer_prefix(Tensor(a!) ring_payload, Tensor x, "
+          "Tensor row_count, int row_bytes, Tensor? emit_gate=None, "
+          "int emit_value=0) -> ()");
+    m.def("record_producer_chunked(Tensor(a!) ring_payload, Tensor x, "
+          "Tensor chunk_bytes, Tensor? emit_gate=None, int emit_value=0) -> ()");
+    m.def("record_producer_seq_prefix_pack(Tensor(a!) ring_payload, Tensor x, "
+          "Tensor valid_count, Tensor valid_prefix_sum, int feature_bytes, "
+          "Tensor? emit_gate=None, int emit_value=0) -> ()");
+    m.def("record_producer_segmented_pack(Tensor(a!) ring_payload, Tensor x, "
+          "Tensor segment_start, Tensor segment_end, int feature_bytes, "
+          "Tensor? emit_gate=None, int emit_value=0) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(ring, CUDA, m) {
     m.impl("producer",         ring_producer_impl);
     m.impl("producer_prefix",  ring_producer_prefix_impl);
     m.impl("producer_chunked", ring_producer_chunked_impl);
+    m.impl("record_producer", ring_record_producer_impl);
+    m.impl("record_producer_prefix", ring_record_producer_prefix_impl);
+    m.impl("record_producer_chunked", ring_record_producer_chunked_impl);
+    m.impl("record_producer_seq_prefix_pack",
+           ring_record_producer_seq_prefix_pack_impl);
+    m.impl("record_producer_segmented_pack",
+           ring_record_producer_segmented_pack_impl);
 }

--- a/native/csrc/ring/ring_torch_op.h
+++ b/native/csrc/ring/ring_torch_op.h
@@ -8,3 +8,7 @@
 void ring_set_active_engine(ring_py::RingEnginePy* e);
 void ring_diag_reset_host_counters();
 void ring_diag_print_host_counters();
+
+// The additive ring::record_producer* torch ops use the same explicitly
+// activated engine pointer.  They are registered separately from the released
+// inference producer ops; no legacy schema is widened or reinterpreted.

--- a/src/dmi/api/v1/__init__.py
+++ b/src/dmi/api/v1/__init__.py
@@ -22,6 +22,21 @@ from ...config import CaptureSchedule, MonitoringConfig
 from ...engine import HostEngineConfig, MonitoringEngine, RingCapacities
 from ...hooks.dispatch import install_ring_hooks
 from ...hooks.point import HookPoint
+from ...hooks.dynamic import (
+    HookOutput,
+    HookPointV1,
+    HookRuntime,
+    HookSpecV1,
+    OutputStorage,
+    RecordType,
+    TransportSpec,
+    TransportType,
+)
+from ...hooks.producer_plan import (
+    ProducerPlan,
+    ProducerPlanBuilder,
+    ProducerPlanEntry,
+)
 from ...hooks import specs as _specs
 from ...hooks.specs import (
     HOOK_TYPE_ATTN_OUT,
@@ -67,6 +82,17 @@ from ...hooks.selection import (
     select_hook_specs,
 )
 from ...adapters.types import StepContext
+from ...records import (
+    PayloadSlice,
+    RecordCell,
+    RecordCellType,
+    RecordColumn,
+    RecordDescriptor,
+    RecordFormat,
+    RecordLayout,
+    RecordRuntime,
+    RecordSchema,
+)
 
 from .model_shape import make_model_shape_from_hf_config
 
@@ -178,6 +204,26 @@ __all__ = [
     "HostEngineConfig",
     "deactivate_ring_transport",
     "HookPoint",
+    "HookPointV1",
+    "HookSpecV1",
+    "HookOutput",
+    "HookRuntime",
+    "TransportSpec",
+    "TransportType",
+    "OutputStorage",
+    "RecordType",
+    "ProducerPlanEntry",
+    "ProducerPlan",
+    "ProducerPlanBuilder",
+    "PayloadSlice",
+    "RecordCell",
+    "RecordCellType",
+    "RecordColumn",
+    "RecordDescriptor",
+    "RecordFormat",
+    "RecordLayout",
+    "RecordRuntime",
+    "RecordSchema",
     "HookSpec",
     "HookRowBasis",
     "ModelShapeConfig",

--- a/src/dmi/api/v1/__init__.py
+++ b/src/dmi/api/v1/__init__.py
@@ -22,7 +22,7 @@ from ...config import CaptureSchedule, MonitoringConfig
 from ...engine import HostEngineConfig, MonitoringEngine, RingCapacities
 from ...hooks.dispatch import install_ring_hooks
 from ...hooks.point import HookPoint
-from ...hooks.dynamic import (
+from ...hooks.record import (
     HookOutput,
     HookPointV1,
     HookRuntime,

--- a/src/dmi/engine.py
+++ b/src/dmi/engine.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import importlib
-from typing import Any, Optional, Sequence
+import time
+from typing import Any, Optional, Sequence, TYPE_CHECKING, TypeVar
 
 from .config import MonitoringConfig
+
+if TYPE_CHECKING:
+    from .records import RecordFormat, RecordRuntime
+
+
+MetadataT = TypeVar("MetadataT")
 
 
 DEFAULT_DRAIN_FLUSH_TIMEOUT_US = 0
@@ -93,6 +100,8 @@ class MonitoringEngine:
         self._host_engine: Optional[Any] = None
 
         self._ring_transport: Optional[Any] = None
+        self._ring_config: Optional[Any] = None
+        self._record_mode = False
 
         if host_engine is not None and db_config is not None:
             raise ValueError("Provide either host_engine or db_config, not both")
@@ -109,7 +118,9 @@ class MonitoringEngine:
                     raise RuntimeError("Failed to import native DMXHostEngine") from exc
                 stages = tuple(db_config.stages)
                 if len(stages) != 1:
-                    raise ValueError("db_config.stages must contain exactly 1 StageConfig object (clickhouse_insert)")
+                    raise ValueError(
+                        "db_config.stages must contain exactly 1 StageConfig object"
+                    )
 
                 try:
                     self._host_engine = DMXHostEngine(stages[0])  # type: ignore[call-arg]
@@ -180,6 +191,80 @@ class MonitoringEngine:
         # null_offload.  Never carry a prior oversized-step decision across a
         # lifecycle toggle; the next committed step recomputes it.
         transport.force_eager = False
+
+    def create_record_runtime(
+        self,
+        record_format: "RecordFormat[MetadataT]",
+    ) -> "RecordRuntime[MetadataT]":
+        """Create an opt-in, non-owning runtime for encoded records."""
+
+        transport = self._ring_transport
+        ring_config = self._ring_config
+        if transport is None or ring_config is None:
+            raise RuntimeError("Ring transport is not enabled")
+        if self._record_mode:
+            raise RuntimeError("A record runtime is already active")
+
+        from .records import RecordFormat, RecordRuntime, RecordSchema
+
+        if not isinstance(record_format, RecordFormat):
+            raise TypeError("record_format must implement RecordFormat")
+        record_schema = record_format.schema
+        if not isinstance(record_schema, RecordSchema):
+            raise TypeError("record_format.schema must be a RecordSchema")
+
+        _native_engine = _native_module()
+        if self._host_engine is not None:
+            _native_engine._load_extension()._validate_record_host_schema(
+                self._host_engine,
+                record_schema,
+            )
+        _rt = _ring_module()
+        if not self.capture_enabled:
+            self.set_capture_enabled(True)
+        ring_engine = getattr(self, "_ring_engine", None)
+        if ring_engine is not None:
+            ring_engine.stop()
+        _rt.deactivate()
+        self._ring_transport = None
+        self._ring_engine = None
+
+        record_engine = _native_engine.RingEngine.create_record(
+            ring_config,
+            self._host_engine,
+        )
+        record_engine.init()
+        record_engine.start()
+        record_transport = _rt.RingTransport(record_engine)
+        self._ring_engine = record_engine
+        self._ring_transport = record_transport
+        self._record_mode = True
+        _rt.activate(record_transport)
+        return RecordRuntime(record_transport, record_format)
+
+    def flush_and_wait(self, timeout_s: float = 600.0) -> None:
+        """Durably complete generic-record work and surface async failures."""
+
+        if timeout_s <= 0:
+            raise ValueError("timeout_s must be positive")
+        transport = self._ring_transport
+        if transport is None:
+            raise RuntimeError("Ring transport is not enabled")
+        if not self._record_mode:
+            raise RuntimeError("Record runtime is not active")
+        deadline = time.monotonic() + float(timeout_s)
+        transport.flush_records_and_wait(float(timeout_s))
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("durable record flush timed out")
+        host_engine = self._host_engine
+        if host_engine is None:
+            return
+        completed = host_engine.flush_and_wait(remaining)
+        if completed is False:
+            raise TimeoutError("durable record flush timed out")
+        if time.monotonic() > deadline:
+            raise TimeoutError("durable record flush timed out")
 
     @staticmethod
     def _make_default_ring_config(
@@ -260,6 +345,8 @@ class MonitoringEngine:
             transport.set_model_cfg(model_shape)
         self._ring_engine = ring_engine
         self._ring_transport = transport
+        self._ring_config = ring_config
+        self._record_mode = False
 
         _rt.activate(transport)
         return transport
@@ -302,6 +389,7 @@ class MonitoringEngine:
                 pass
             self._ring_transport = None
             self._ring_engine = None
+            self._record_mode = False
 
         if self._host_engine is not None:
             try:

--- a/src/dmi/engine.py
+++ b/src/dmi/engine.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import importlib
-import time
 from typing import Any, Optional, Sequence, TYPE_CHECKING, TypeVar
 
 from .config import MonitoringConfig
@@ -243,7 +242,7 @@ class MonitoringEngine:
         return RecordRuntime(record_transport, record_format)
 
     def flush_and_wait(self, timeout_s: float = 600.0) -> None:
-        """Durably complete generic-record work and surface async failures."""
+        """Complete the record ring and its configured sink durability boundary."""
 
         if timeout_s <= 0:
             raise ValueError("timeout_s must be positive")
@@ -252,19 +251,7 @@ class MonitoringEngine:
             raise RuntimeError("Ring transport is not enabled")
         if not self._record_mode:
             raise RuntimeError("Record runtime is not active")
-        deadline = time.monotonic() + float(timeout_s)
         transport.flush_records_and_wait(float(timeout_s))
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError("durable record flush timed out")
-        host_engine = self._host_engine
-        if host_engine is None:
-            return
-        completed = host_engine.flush_and_wait(remaining)
-        if completed is False:
-            raise TimeoutError("durable record flush timed out")
-        if time.monotonic() > deadline:
-            raise TimeoutError("durable record flush timed out")
 
     @staticmethod
     def _make_default_ring_config(

--- a/src/dmi/hooks/dynamic.py
+++ b/src/dmi/hooks/dynamic.py
@@ -1,0 +1,352 @@
+"""Framework-neutral dynamic hooks for the opt-in record runtime.
+
+The released :class:`dmi.hooks.point.HookPoint` path remains independent of
+this module.  ``HookPointV1`` is a side-effect-only tap: an integration owns
+eligibility and metadata association, while DMI owns preprocessing, ordered
+physical outputs, and record-producer dispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+from typing import Any, Callable, Protocol, Sequence, runtime_checkable
+
+import torch
+import torch.nn as nn
+
+from ..adapters.base import StepReservation
+
+
+class TransportType(str, Enum):
+    """Physical transformation performed while copying one logical output."""
+
+    IDENTITY = "identity"
+    PREFIX_STRIP = "prefix_strip"
+    CHUNKED = "chunked"
+    SEQ_PREFIX_PACK = "seq_prefix_pack"
+    SEGMENTED_PACK = "segmented_pack"
+
+
+class OutputStorage(IntEnum):
+    """Host materialization requested for a producer output."""
+
+    TENSOR = 0
+    SCALAR_FLOAT = 1
+    SCALAR_INT = 2
+
+
+class RecordType(IntEnum):
+    """Logical row granularity supplied to an integration's record format."""
+
+    PER_SAMPLE = 0
+    PER_ITERATION = 1
+    PER_EXECUTION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class HookOutput:
+    """One tensor output and any device tensors consumed by its transport."""
+
+    tensor: torch.Tensor
+    producer_meta: tuple[torch.Tensor, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tensor, torch.Tensor):
+            raise TypeError("HookOutput.tensor must be a Tensor")
+        object.__setattr__(self, "producer_meta", tuple(self.producer_meta))
+        if not all(isinstance(item, torch.Tensor) for item in self.producer_meta):
+            raise TypeError("HookOutput producer metadata must contain only tensors")
+
+
+@dataclass(frozen=True, slots=True)
+class TransportSpec:
+    """Static physical contract for one ordered hook output.
+
+    ``reservation_upper_bytes`` is optional for fixed-size outputs, whose
+    bound is the captured tensor size.  Dynamic producers may provide a larger
+    conservative bound.  ``output_shape`` may contain one ``-1`` dimension,
+    which the record consumer infers from the actual produced byte count.
+    """
+
+    name: str
+    transport_type: TransportType = TransportType.IDENTITY
+    storage: OutputStorage = OutputStorage.TENSOR
+    record_type: RecordType = RecordType.PER_SAMPLE
+    reservation_upper_bytes: int | None = None
+    output_shape: tuple[int, ...] | None = None
+    row_bytes: int | None = None
+    feature_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("TransportSpec.name must not be empty")
+        if not isinstance(self.transport_type, TransportType):
+            raise TypeError("transport_type must be a TransportType")
+        if not isinstance(self.storage, OutputStorage):
+            raise TypeError("storage must be an OutputStorage")
+        if not isinstance(self.record_type, RecordType):
+            raise TypeError("record_type must be a RecordType")
+        if self.output_shape is not None:
+            object.__setattr__(
+                self, "output_shape", tuple(int(dim) for dim in self.output_shape)
+            )
+        if self.reservation_upper_bytes is not None and self.reservation_upper_bytes < 0:
+            raise ValueError("reservation_upper_bytes must be non-negative")
+        if self.output_shape is not None:
+            dynamic_dims = sum(int(dim) == -1 for dim in self.output_shape)
+            if dynamic_dims > 1 or any(int(dim) < -1 for dim in self.output_shape):
+                raise ValueError("output_shape supports at most one -1 dimension")
+        if self.transport_type is TransportType.PREFIX_STRIP:
+            if self.row_bytes is None or self.row_bytes <= 0:
+                raise ValueError("PREFIX_STRIP requires a positive row_bytes")
+        elif self.row_bytes is not None:
+            raise ValueError("row_bytes is valid only for PREFIX_STRIP")
+        if self.transport_type in (
+            TransportType.SEQ_PREFIX_PACK,
+            TransportType.SEGMENTED_PACK,
+        ):
+            if self.feature_bytes is None or self.feature_bytes <= 0:
+                raise ValueError(
+                    f"{self.transport_type.value} requires a positive feature_bytes"
+                )
+        elif self.feature_bytes is not None:
+            raise ValueError(
+                "feature_bytes is valid only for sequence or segmented packing"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class HookSpecV1:
+    """Declarative definition of one dynamic hook and its ordered outputs."""
+
+    name: str
+    outputs: tuple[TransportSpec, ...]
+    preprocess: Callable[..., Any] | None = None
+    enabled_by: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("HookSpecV1.name must not be empty")
+        object.__setattr__(self, "outputs", tuple(self.outputs))
+        object.__setattr__(self, "enabled_by", frozenset(self.enabled_by))
+        if not self.outputs:
+            raise ValueError("HookSpecV1 requires at least one output")
+        if not all(isinstance(output, TransportSpec) for output in self.outputs):
+            raise TypeError("HookSpecV1.outputs must contain TransportSpec values")
+        names = [output.name for output in self.outputs]
+        if len(names) != len(set(names)):
+            raise ValueError("HookSpecV1 output names must be unique")
+
+
+@runtime_checkable
+class HookRuntime(Protocol):
+    """Integration-owned association policy called by ``HookPointV1``.
+
+    ``prepare_output`` runs before the producer launch.  Eager integrations
+    normally call :meth:`RecordRuntime.emit_output` there; capture integrations
+    append to a :class:`ProducerPlanBuilder` and return ``None``.  Returning an
+    ``OVERSIZED`` reservation tells the hook that the runtime already completed
+    the CPU-direct transfer and that no producer kernel should be launched.
+    """
+
+    def should_emit(self, hook: "HookPointV1") -> bool:
+        """Return eligibility before preprocessing executes."""
+
+    def prepare_output(
+        self,
+        *,
+        hook: "HookPointV1",
+        output_index: int,
+        output_id: int,
+        output_spec: TransportSpec,
+        output: HookOutput,
+    ) -> StepReservation | None:
+        """Associate or record one physical output before producer dispatch."""
+
+
+def _normalize_outputs(value: Any, count: int) -> tuple[Any, ...]:
+    if count == 1:
+        return (value,)
+    if not isinstance(value, (tuple, list)):
+        raise ValueError(
+            f"HookPointV1 expected {count} outputs, got non-sequence "
+            f"{type(value).__name__}"
+        )
+    if len(value) != count:
+        raise ValueError(f"HookPointV1 expected {count} outputs, got {len(value)}")
+    return tuple(value)
+
+
+def _as_hook_output(value: Any) -> HookOutput:
+    if isinstance(value, HookOutput):
+        return value
+    if isinstance(value, torch.Tensor):
+        return HookOutput(value)
+    if isinstance(value, tuple) and value and isinstance(value[0], torch.Tensor):
+        producer_meta = tuple(value[1:])
+        if not all(isinstance(item, torch.Tensor) for item in producer_meta):
+            raise TypeError("HookOutput producer metadata must contain only tensors")
+        return HookOutput(value[0], producer_meta)
+    raise TypeError(
+        "HookPointV1 output must be a Tensor, HookOutput, or a tuple beginning "
+        "with a Tensor"
+    )
+
+
+class HookPointV1(nn.Module):
+    """Variadic side-effect hook with optional preprocessing and multiple outputs."""
+
+    def __init__(self, spec: HookSpecV1 | None = None) -> None:
+        super().__init__()
+        self.enabled = True
+        self.spec = spec
+        self._output_ids: tuple[int, ...] = ()
+        self._ring_payload: torch.Tensor | None = None
+        self._hook_runtime: HookRuntime | None = None
+        self._gate_tensor: torch.Tensor | None = None
+        self._gate_value = 0
+
+    def _bind_record_runtime(
+        self,
+        *,
+        output_ids: Sequence[int],
+        ring_payload: torch.Tensor,
+        hook_runtime: HookRuntime,
+        gate_tensor: torch.Tensor | None,
+        gate_value: int,
+    ) -> None:
+        spec = self.spec
+        if spec is None:
+            raise RuntimeError("HookPointV1 must have a HookSpecV1 before binding")
+        ids = tuple(int(value) for value in output_ids)
+        if len(ids) != len(spec.outputs):
+            raise ValueError("output_ids length must match HookSpecV1.outputs")
+        if gate_tensor is not None:
+            if gate_tensor.numel() != 1:
+                raise ValueError("gate_tensor must contain exactly one value")
+            if gate_tensor.dtype is not torch.int32:
+                raise TypeError("gate_tensor must use int32")
+            if not gate_tensor.is_cuda:
+                raise TypeError("gate_tensor must be a CUDA tensor")
+            if not gate_tensor.is_contiguous():
+                raise ValueError("gate_tensor must be contiguous")
+        self._output_ids = ids
+        self._ring_payload = ring_payload
+        self._hook_runtime = hook_runtime
+        self._gate_tensor = gate_tensor
+        self._gate_value = int(gate_value)
+
+    def forward(self, *inputs: Any) -> None:
+        spec = self.spec
+        runtime = self._hook_runtime
+        if not self.enabled or spec is None or runtime is None:
+            return None
+        if not runtime.should_emit(self):
+            return None
+
+        if spec.preprocess is None:
+            if len(inputs) != len(spec.outputs):
+                raise ValueError(
+                    "HookPointV1 without preprocessing requires one input per "
+                    f"declared output; expected {len(spec.outputs)}, got {len(inputs)}"
+                )
+            outputs = tuple(inputs)
+        else:
+            outputs = _normalize_outputs(
+                spec.preprocess(*inputs), len(spec.outputs)
+            )
+        for index, (output_spec, output_id, value) in enumerate(
+            zip(spec.outputs, self._output_ids, outputs)
+        ):
+            output = _as_hook_output(value)
+            reservation = runtime.prepare_output(
+                hook=self,
+                output_index=index,
+                output_id=output_id,
+                output_spec=output_spec,
+                output=output,
+            )
+            if reservation is not StepReservation.OVERSIZED:
+                self._dispatch(output_spec, output)
+        return None
+
+    def _dispatch(self, spec: TransportSpec, output: HookOutput) -> None:
+        ring_payload = self._ring_payload
+        if ring_payload is None:
+            raise RuntimeError("HookPointV1 is not bound to a record runtime")
+        tensor = output.tensor.contiguous()
+        gate = self._gate_tensor
+        gate_value = self._gate_value
+
+        if spec.transport_type is TransportType.IDENTITY:
+            torch.ops.ring.record_producer(
+                ring_payload, tensor, gate, gate_value
+            )
+            return
+        if spec.transport_type is TransportType.PREFIX_STRIP:
+            row_count = self._producer_tensor(output, 0, "row_count")
+            torch.ops.ring.record_producer_prefix(
+                ring_payload,
+                tensor,
+                row_count,
+                int(spec.row_bytes),
+                gate,
+                gate_value,
+            )
+            return
+        if spec.transport_type is TransportType.CHUNKED:
+            chunk_bytes = self._producer_tensor(output, 0, "chunk_bytes")
+            torch.ops.ring.record_producer_chunked(
+                ring_payload, tensor, chunk_bytes, gate, gate_value
+            )
+            return
+        if spec.transport_type is TransportType.SEQ_PREFIX_PACK:
+            valid_count = self._producer_tensor(output, 0, "valid_count")
+            valid_prefix_sum = self._producer_tensor(output, 1, "valid_prefix_sum")
+            torch.ops.ring.record_producer_seq_prefix_pack(
+                ring_payload,
+                tensor,
+                valid_count,
+                valid_prefix_sum,
+                int(spec.feature_bytes),
+                gate,
+                gate_value,
+            )
+            return
+        if spec.transport_type is TransportType.SEGMENTED_PACK:
+            starts = self._producer_tensor(output, 0, "segment_start")
+            ends = self._producer_tensor(output, 1, "segment_end")
+            torch.ops.ring.record_producer_segmented_pack(
+                ring_payload,
+                tensor,
+                starts,
+                ends,
+                int(spec.feature_bytes),
+                gate,
+                gate_value,
+            )
+            return
+        raise ValueError(f"Unsupported transport type {spec.transport_type!r}")
+
+    @staticmethod
+    def _producer_tensor(output: HookOutput, index: int, name: str) -> torch.Tensor:
+        try:
+            value = output.producer_meta[index]
+        except IndexError as exc:
+            raise ValueError(f"record producer requires {name} tensor") from exc
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"{name} must be a Tensor")
+        return value
+
+
+__all__ = [
+    "HookOutput",
+    "HookPointV1",
+    "HookRuntime",
+    "HookSpecV1",
+    "OutputStorage",
+    "RecordType",
+    "TransportSpec",
+    "TransportType",
+]

--- a/src/dmi/hooks/producer_plan.py
+++ b/src/dmi/hooks/producer_plan.py
@@ -7,7 +7,7 @@ from typing import Any, Sequence
 
 import torch
 
-from .dynamic import HookOutput, OutputStorage, RecordType, TransportSpec, TransportType
+from .record import HookOutput, OutputStorage, RecordType, TransportSpec, TransportType
 
 
 def _align_up(value: int, alignment: int = 16) -> int:

--- a/src/dmi/hooks/producer_plan.py
+++ b/src/dmi/hooks/producer_plan.py
@@ -1,0 +1,161 @@
+"""Ordered physical producer plans for the opt-in record runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import torch
+
+from .dynamic import HookOutput, OutputStorage, RecordType, TransportSpec, TransportType
+
+
+def _align_up(value: int, alignment: int = 16) -> int:
+    return (int(value) + alignment - 1) & ~(alignment - 1)
+
+
+@dataclass(frozen=True, slots=True)
+class ProducerPlanEntry:
+    """Physical state required to reserve and emit one producer output."""
+
+    output_id: int
+    input_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    dtype: torch.dtype
+    transport_type: TransportType
+    transport_args: tuple[int, ...]
+    storage: OutputStorage
+    record_type: RecordType
+    reservation_upper_bytes: int
+    task_count: int = 1
+
+    def __post_init__(self) -> None:
+        if self.output_id < 0:
+            raise ValueError("output_id must be non-negative")
+        if self.reservation_upper_bytes < 0:
+            raise ValueError("reservation_upper_bytes must be non-negative")
+        if self.task_count != 1:
+            raise ValueError("each ProducerPlanEntry currently represents one task")
+
+    @property
+    def aligned_reservation_bytes(self) -> int:
+        return _align_up(self.reservation_upper_bytes)
+
+
+@dataclass(frozen=True, slots=True)
+class ProducerPlan:
+    """Immutable producer order learned during one graph capture."""
+
+    entries: tuple[ProducerPlanEntry, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "entries", tuple(self.entries))
+
+    @property
+    def total_reservation_bytes(self) -> int:
+        return sum(entry.aligned_reservation_bytes for entry in self.entries)
+
+    @property
+    def task_count(self) -> int:
+        return sum(entry.task_count for entry in self.entries)
+
+    @property
+    def signature(self) -> tuple[tuple[Any, ...], ...]:
+        return tuple(
+            (
+                entry.output_id,
+                entry.input_shape,
+                entry.output_shape,
+                entry.dtype,
+                entry.transport_type,
+                entry.transport_args,
+                entry.storage,
+                entry.record_type,
+                entry.reservation_upper_bytes,
+                entry.task_count,
+            )
+            for entry in self.entries
+        )
+
+    def assert_compatible(self, other: "ProducerPlan") -> None:
+        if self.signature == other.signature:
+            return
+        if len(self.entries) != len(other.entries):
+            raise ValueError(
+                "producer plan entry-count mismatch: "
+                f"expected {len(self.entries)}, got {len(other.entries)}"
+            )
+        for index, (expected, actual) in enumerate(
+            zip(self.signature, other.signature)
+        ):
+            if expected != actual:
+                raise ValueError(
+                    f"producer plan mismatch at entry {index}: "
+                    f"expected {expected!r}, got {actual!r}"
+                )
+        raise ValueError("producer plan mismatch")
+
+
+class ProducerPlanBuilder:
+    """Append producer entries in the order in which hooks execute."""
+
+    def __init__(self) -> None:
+        self._entries: list[ProducerPlanEntry] = []
+
+    def record_output(
+        self,
+        *,
+        output_id: int,
+        output_spec: TransportSpec,
+        output: HookOutput,
+    ) -> ProducerPlanEntry:
+        tensor = output.tensor
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError("HookOutput.tensor must be a Tensor")
+        input_shape = tuple(int(dim) for dim in tensor.shape)
+        output_shape = (
+            input_shape
+            if output_spec.output_shape is None
+            else tuple(int(dim) for dim in output_spec.output_shape)
+        )
+        tensor_bytes = int(tensor.numel()) * int(tensor.element_size())
+        upper_bytes = (
+            tensor_bytes
+            if output_spec.reservation_upper_bytes is None
+            else int(output_spec.reservation_upper_bytes)
+        )
+        if upper_bytes < tensor_bytes and output_spec.transport_type is TransportType.IDENTITY:
+            raise ValueError(
+                "IDENTITY reservation_upper_bytes cannot be smaller than the tensor"
+            )
+        transport_args = self._transport_args(output_spec)
+        entry = ProducerPlanEntry(
+            output_id=int(output_id),
+            input_shape=input_shape,
+            output_shape=output_shape,
+            dtype=tensor.dtype,
+            transport_type=output_spec.transport_type,
+            transport_args=transport_args,
+            storage=output_spec.storage,
+            record_type=output_spec.record_type,
+            reservation_upper_bytes=upper_bytes,
+        )
+        self._entries.append(entry)
+        return entry
+
+    def build(self) -> ProducerPlan:
+        return ProducerPlan(tuple(self._entries))
+
+    @staticmethod
+    def _transport_args(spec: TransportSpec) -> tuple[int, ...]:
+        if spec.transport_type is TransportType.PREFIX_STRIP:
+            return (int(spec.row_bytes),)
+        if spec.transport_type in (
+            TransportType.SEQ_PREFIX_PACK,
+            TransportType.SEGMENTED_PACK,
+        ):
+            return (int(spec.feature_bytes),)
+        return ()
+
+
+__all__ = ["ProducerPlan", "ProducerPlanBuilder", "ProducerPlanEntry"]

--- a/src/dmi/hooks/record.py
+++ b/src/dmi/hooks/record.py
@@ -1,4 +1,4 @@
-"""Framework-neutral dynamic hooks for the opt-in record runtime.
+"""Framework-neutral hooks for the opt-in record runtime.
 
 The released :class:`dmi.hooks.point.HookPoint` path remains independent of
 this module.  ``HookPointV1`` is a side-effect-only tap: an integration owns
@@ -118,7 +118,7 @@ class TransportSpec:
 
 @dataclass(frozen=True, slots=True)
 class HookSpecV1:
-    """Declarative definition of one dynamic hook and its ordered outputs."""
+    """Declarative definition of one record hook and its ordered outputs."""
 
     name: str
     outputs: tuple[TransportSpec, ...]

--- a/src/dmi/hooks/record.py
+++ b/src/dmi/hooks/record.py
@@ -16,6 +16,7 @@ import torch
 import torch.nn as nn
 
 from ..adapters.base import StepReservation
+from . import point as _hook_point
 
 
 class TransportType(str, Enum):
@@ -260,6 +261,8 @@ class HookPointV1(nn.Module):
             zip(spec.outputs, self._output_ids, outputs)
         ):
             output = _as_hook_output(value)
+            if _hook_point._MONITORING_DEBUG:
+                self._validate_producer_metadata(output_spec, output)
             reservation = runtime.prepare_output(
                 hook=self,
                 output_index=index,
@@ -285,7 +288,7 @@ class HookPointV1(nn.Module):
             )
             return
         if spec.transport_type is TransportType.PREFIX_STRIP:
-            row_count = self._producer_tensor(output, 0, "row_count")
+            row_count = output.producer_meta[0]
             torch.ops.ring.record_producer_prefix(
                 ring_payload,
                 tensor,
@@ -296,14 +299,13 @@ class HookPointV1(nn.Module):
             )
             return
         if spec.transport_type is TransportType.CHUNKED:
-            chunk_bytes = self._producer_tensor(output, 0, "chunk_bytes")
+            chunk_bytes = output.producer_meta[0]
             torch.ops.ring.record_producer_chunked(
                 ring_payload, tensor, chunk_bytes, gate, gate_value
             )
             return
         if spec.transport_type is TransportType.SEQ_PREFIX_PACK:
-            valid_count = self._producer_tensor(output, 0, "valid_count")
-            valid_prefix_sum = self._producer_tensor(output, 1, "valid_prefix_sum")
+            valid_count, valid_prefix_sum = output.producer_meta
             torch.ops.ring.record_producer_seq_prefix_pack(
                 ring_payload,
                 tensor,
@@ -315,8 +317,7 @@ class HookPointV1(nn.Module):
             )
             return
         if spec.transport_type is TransportType.SEGMENTED_PACK:
-            starts = self._producer_tensor(output, 0, "segment_start")
-            ends = self._producer_tensor(output, 1, "segment_end")
+            starts, ends = output.producer_meta
             torch.ops.ring.record_producer_segmented_pack(
                 ring_payload,
                 tensor,
@@ -330,14 +331,89 @@ class HookPointV1(nn.Module):
         raise ValueError(f"Unsupported transport type {spec.transport_type!r}")
 
     @staticmethod
-    def _producer_tensor(output: HookOutput, index: int, name: str) -> torch.Tensor:
-        try:
-            value = output.producer_meta[index]
-        except IndexError as exc:
-            raise ValueError(f"record producer requires {name} tensor") from exc
-        if not isinstance(value, torch.Tensor):
-            raise TypeError(f"{name} must be a Tensor")
-        return value
+    def _validate_producer_metadata(
+        spec: TransportSpec,
+        output: HookOutput,
+    ) -> None:
+        transport_type = spec.transport_type
+        if transport_type is TransportType.IDENTITY:
+            names = ()
+        elif transport_type is TransportType.PREFIX_STRIP:
+            names = ("row_count",)
+        elif transport_type is TransportType.CHUNKED:
+            names = ("chunk_bytes",)
+        elif transport_type is TransportType.SEQ_PREFIX_PACK:
+            names = ("valid_count", "valid_prefix_sum")
+        elif transport_type is TransportType.SEGMENTED_PACK:
+            names = ("segment_start", "segment_end")
+        else:
+            raise ValueError(f"Unsupported transport type {transport_type!r}")
+
+        metadata = output.producer_meta
+        if len(metadata) < len(names):
+            raise ValueError(
+                f"record producer requires {names[len(metadata)]} tensor"
+            )
+        if len(metadata) > len(names):
+            raise ValueError(
+                f"{transport_type.value} expects {len(names)} producer metadata "
+                f"tensor(s), got {len(metadata)}"
+            )
+
+        payload = output.tensor
+        for name, value in zip(names, metadata):
+            if value.dtype is not torch.int64:
+                raise TypeError(f"{name} must have dtype int64")
+            if not value.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+            if value.device != payload.device:
+                raise ValueError(f"{name} must be on the payload device")
+
+        if transport_type is TransportType.IDENTITY:
+            return
+        if transport_type is TransportType.PREFIX_STRIP:
+            if metadata[0].numel() != 1:
+                raise ValueError("row_count must contain one element")
+            return
+
+        payload_bytes = int(payload.numel()) * int(payload.element_size())
+        if transport_type is TransportType.CHUNKED:
+            chunk_bytes = metadata[0]
+            if chunk_bytes.dim() != 1:
+                raise ValueError("chunk_bytes must be one-dimensional")
+            chunks = int(chunk_bytes.numel())
+            if chunks < 1:
+                raise ValueError("chunk_bytes must be non-empty")
+            if payload_bytes % chunks != 0:
+                raise ValueError("payload bytes must divide evenly into chunks")
+            return
+
+        if transport_type is TransportType.SEQ_PREFIX_PACK:
+            valid_count, valid_prefix_sum = metadata
+            if valid_count.dim() != 1 or valid_count.numel() == 0:
+                raise ValueError(
+                    "valid_count must be a non-empty one-dimensional tensor"
+                )
+            batch = int(valid_count.numel())
+            if valid_prefix_sum.dim() != 1 or valid_prefix_sum.numel() != batch + 1:
+                raise ValueError("valid_prefix_sum length must equal batch + 1")
+            if payload.dim() < 2 or payload.size(1) != batch:
+                raise ValueError("sequence-pack payload must be [S, B, ...]")
+            if payload_bytes % (batch * int(spec.feature_bytes)) != 0:
+                raise ValueError(
+                    "sequence-pack payload has incompatible feature bytes"
+                )
+            return
+
+        starts, ends = metadata
+        if starts.dim() != 1 or starts.numel() == 0:
+            raise ValueError(
+                "segment_start must be a non-empty one-dimensional tensor"
+            )
+        if ends.dim() != 1 or ends.numel() != starts.numel():
+            raise ValueError("segment_start/end lengths must match")
+        if payload_bytes % int(spec.feature_bytes) != 0:
+            raise ValueError("segmented-pack payload has incompatible feature bytes")
 
 
 __all__ = [

--- a/src/dmi/records.py
+++ b/src/dmi/records.py
@@ -1,0 +1,513 @@
+"""Integration-defined record formats and the opt-in record runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+from typing import Any, Generic, Protocol, Sequence, TypeVar, runtime_checkable
+
+import torch
+
+from .adapters.base import StepReservation
+from .hooks.dynamic import HookOutput, HookPointV1, HookRuntime, OutputStorage
+from .hooks.producer_plan import ProducerPlan, ProducerPlanEntry
+
+
+MetadataT = TypeVar("MetadataT")
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DYNAMIC_OUTPUT_ID_BASE = 1 << 16
+
+
+class RecordCellType(str, Enum):
+    """Cell types supported by the schema-driven record sink."""
+
+    STRING = "string"
+    INT32 = "int32"
+    INT64 = "int64"
+    FLOAT64 = "float64"
+    INT64_ARRAY = "int64_array"
+    TENSOR = "tensor"
+
+
+@dataclass(frozen=True, slots=True)
+class RecordColumn:
+    """One logical record column.
+
+    A tensor column expands to explicit dtype, shape, and bytes columns in the
+    physical table.  Non-tensor columns use only ``name``.
+    """
+
+    name: str
+    type: RecordCellType
+    dtype_column: str | None = None
+    shape_column: str | None = None
+    bytes_column: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.name, "column name")
+        if not isinstance(self.type, RecordCellType):
+            raise TypeError("RecordColumn.type must be a RecordCellType")
+        tensor_names = (self.dtype_column, self.shape_column, self.bytes_column)
+        if self.type is RecordCellType.TENSOR:
+            if any(name is None for name in tensor_names):
+                raise ValueError(
+                    "TENSOR columns require dtype_column, shape_column, and "
+                    "bytes_column"
+                )
+            for name in tensor_names:
+                _require_identifier(str(name), "tensor physical column name")
+            if len(set(tensor_names)) != 3:
+                raise ValueError("tensor physical column names must be distinct")
+        elif any(name is not None for name in tensor_names):
+            raise ValueError("physical tensor columns are valid only for TENSOR")
+
+
+@dataclass(frozen=True, slots=True)
+class RecordLayout:
+    """One named table layout accepted by a record schema."""
+
+    name: str
+    table: str
+    columns: tuple[RecordColumn, ...]
+    primary_key: tuple[str, ...] = ()
+    order_by: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.name, "layout name")
+        _require_table_identifier(self.table)
+        object.__setattr__(self, "columns", tuple(self.columns))
+        object.__setattr__(self, "primary_key", tuple(self.primary_key))
+        object.__setattr__(self, "order_by", tuple(self.order_by))
+        if not self.columns:
+            raise ValueError("RecordLayout requires at least one column")
+        if not all(isinstance(column, RecordColumn) for column in self.columns):
+            raise TypeError("RecordLayout.columns must contain RecordColumn values")
+        if not self.primary_key:
+            raise ValueError("RecordLayout.primary_key must not be empty")
+        if not self.order_by:
+            raise ValueError("RecordLayout.order_by must not be empty")
+        names = [column.name for column in self.columns]
+        if len(names) != len(set(names)):
+            raise ValueError("RecordLayout column names must be unique")
+        physical_names: set[str] = set()
+        for column in self.columns:
+            names_for_column = (
+                (
+                    str(column.dtype_column),
+                    str(column.shape_column),
+                    str(column.bytes_column),
+                )
+                if column.type is RecordCellType.TENSOR
+                else (column.name,)
+            )
+            for physical_name in names_for_column:
+                if physical_name in physical_names:
+                    raise ValueError(
+                        "RecordLayout physical column names must be unique"
+                    )
+                physical_names.add(physical_name)
+        keyable = {
+            column.name
+            for column in self.columns
+            if column.type is not RecordCellType.TENSOR
+        }
+        for key in (*self.primary_key, *self.order_by):
+            if key not in keyable:
+                raise ValueError(
+                    f"record key {key!r} must name a non-tensor logical column"
+                )
+
+
+@dataclass(frozen=True, slots=True)
+class RecordSchema:
+    """Immutable set of layouts copied into a schema-driven sink."""
+
+    layouts: tuple[RecordLayout, ...]
+    index_granularity: int = 8192
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "layouts", tuple(self.layouts))
+        if not self.layouts:
+            raise ValueError("RecordSchema requires at least one layout")
+        if not all(isinstance(layout, RecordLayout) for layout in self.layouts):
+            raise TypeError("RecordSchema.layouts must contain RecordLayout values")
+        if self.index_granularity <= 0:
+            raise ValueError("index_granularity must be positive")
+        layout_names = [layout.name for layout in self.layouts]
+        table_names = [layout.table for layout in self.layouts]
+        if len(layout_names) != len(set(layout_names)):
+            raise ValueError("RecordSchema layout names must be unique")
+        if len(table_names) != len(set(table_names)):
+            raise ValueError("RecordSchema table names must be unique")
+
+    def layout(self, name: str) -> RecordLayout:
+        for layout in self.layouts:
+            if layout.name == name:
+                return layout
+        raise KeyError(f"record layout {name!r} is not declared by this schema")
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadSlice:
+    """Materialize one cell from a byte range of the associated payload."""
+
+    offset_bytes: int = 0
+    nbytes: int | None = None
+    storage: OutputStorage = OutputStorage.TENSOR
+    dtype: torch.dtype | None = None
+    shape: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.offset_bytes < 0:
+            raise ValueError("PayloadSlice.offset_bytes must be non-negative")
+        if self.nbytes is not None and self.nbytes < 0:
+            raise ValueError("PayloadSlice.nbytes must be non-negative")
+        object.__setattr__(self, "shape", tuple(int(dim) for dim in self.shape))
+        if self.dtype is None:
+            raise ValueError("PayloadSlice requires dtype")
+        if not isinstance(self.storage, OutputStorage):
+            raise TypeError("PayloadSlice.storage must be an OutputStorage")
+        if self.storage is OutputStorage.TENSOR:
+            if sum(dim == -1 for dim in self.shape) > 1 or any(
+                dim < -1 for dim in self.shape
+            ):
+                raise ValueError("PayloadSlice.shape supports at most one -1")
+        elif self.shape:
+            raise ValueError("scalar PayloadSlice must not declare a shape")
+
+
+RecordCell = str | int | float | tuple[int, ...] | PayloadSlice
+
+
+@dataclass(frozen=True, slots=True)
+class RecordDescriptor:
+    """Pre-encoded rows associated with one FIFO payload or host record."""
+
+    layout: str
+    rows: tuple[tuple[RecordCell, ...], ...]
+    output_id: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.layout:
+            raise ValueError("RecordDescriptor.layout must not be empty")
+        object.__setattr__(
+            self,
+            "rows",
+            tuple(tuple(row) for row in self.rows),
+        )
+        if self.output_id is not None and self.output_id < 0:
+            raise ValueError("RecordDescriptor.output_id must be non-negative")
+
+    @property
+    def has_payload(self) -> bool:
+        return any(
+            isinstance(cell, PayloadSlice)
+            for row in self.rows
+            for cell in row
+        )
+
+
+@runtime_checkable
+class RecordFormat(Protocol[MetadataT]):
+    """Integration-owned conversion from semantic metadata to encoded rows."""
+
+    @property
+    def schema(self) -> RecordSchema:
+        """Schema containing every layout returned by :meth:`encode`."""
+
+    def encode(
+        self,
+        metadata: MetadataT,
+        entry: ProducerPlanEntry,
+    ) -> RecordDescriptor:
+        """Encode one metadata object before its producer is launched."""
+
+
+class RecordRuntime(Generic[MetadataT]):
+    """Non-owning facade over one ring's opt-in encoded-record path."""
+
+    def __init__(self, transport: Any, record_format: RecordFormat[MetadataT]) -> None:
+        if not isinstance(record_format, RecordFormat):
+            raise TypeError("record_format must implement RecordFormat")
+        if not isinstance(record_format.schema, RecordSchema):
+            raise TypeError("record_format.schema must be a RecordSchema")
+        self._transport = transport
+        self._format = record_format
+        self._transport.configure_record_schema(record_format.schema)
+        self._next_output_id = _DYNAMIC_OUTPUT_ID_BASE
+        self._output_name_to_id: dict[str, int] = {}
+        self._output_specs_by_name: dict[str, Any] = {}
+        self._bound_output_ids: set[int] = set()
+        self._bound_hooks: set[int] = set()
+
+    def bind_hook(
+        self,
+        hook: HookPointV1,
+        *,
+        hook_runtime: HookRuntime,
+        gate_tensor: torch.Tensor | None = None,
+        gate_value: int = 0,
+    ) -> None:
+        """Register outputs and bind one hook to this runtime."""
+
+        if not isinstance(hook, HookPointV1):
+            raise TypeError("hook must be a HookPointV1")
+        if not isinstance(hook_runtime, HookRuntime):
+            raise TypeError("hook_runtime must implement HookRuntime")
+        if id(hook) in self._bound_hooks:
+            raise RuntimeError("HookPointV1 is already bound to this runtime")
+        spec = hook.spec
+        if spec is None:
+            raise RuntimeError("HookPointV1 must have a HookSpecV1 before binding")
+        for output in spec.outputs:
+            existing = self._output_specs_by_name.get(output.name)
+            if existing is not None and existing != output:
+                raise ValueError(
+                    f"output name {output.name!r} is already bound with a "
+                    "different TransportSpec"
+                )
+        next_output_id = self._next_output_id
+        new_ids: dict[str, int] = {}
+        output_ids_list = []
+        for output in spec.outputs:
+            output_id = self._output_name_to_id.get(output.name)
+            if output_id is None:
+                output_id = next_output_id
+                next_output_id += 1
+                new_ids[output.name] = output_id
+            output_ids_list.append(output_id)
+        output_ids = tuple(output_ids_list)
+        hook._bind_record_runtime(
+            output_ids=output_ids,
+            ring_payload=self._transport._record_payload_tensor(),
+            hook_runtime=hook_runtime,
+            gate_tensor=gate_tensor,
+            gate_value=gate_value,
+        )
+        self._next_output_id = next_output_id
+        for output in spec.outputs:
+            if output.name in new_ids:
+                self._output_name_to_id[output.name] = new_ids[output.name]
+                self._output_specs_by_name[output.name] = output
+        self._bound_output_ids.update(output_ids)
+        self._bound_hooks.add(id(hook))
+
+    def emit_output(
+        self,
+        entry: ProducerPlanEntry,
+        metadata: MetadataT,
+        output: HookOutput,
+    ) -> StepReservation:
+        """Reserve, publish a descriptor, and prepare one eager producer.
+
+        For an oversized entry the transport has already flushed older work;
+        this method publishes the descriptor and completes the matching
+        CPU-direct submission.  The hook therefore skips its producer launch.
+        """
+
+        self._validate_entry_output(entry, output)
+        descriptor = self._encode(metadata, entry)
+        reservation = StepReservation(
+            self._transport.reserve_record(
+                entry.aligned_reservation_bytes,
+                entry.task_count,
+            )
+        )
+        self._transport.push_record_descriptors((descriptor,))
+        if reservation is StepReservation.OVERSIZED:
+            self._transport.submit_record_cpu_direct(output, entry)
+        return reservation
+
+    def prepare_replay(
+        self,
+        plan: ProducerPlan,
+        metadata: Sequence[MetadataT],
+    ) -> StepReservation:
+        """Bind fresh descriptors to a captured physical plan and reserve it."""
+
+        if not isinstance(plan, ProducerPlan):
+            raise TypeError("plan must be a ProducerPlan")
+        metadata_items = tuple(metadata)
+        if len(metadata_items) != len(plan.entries):
+            raise ValueError(
+                "replay metadata count must match producer plan entries: "
+                f"expected {len(plan.entries)}, got {len(metadata_items)}"
+            )
+        if not plan.entries:
+            return StepReservation.SKIPPED
+        descriptors = tuple(
+            self._encode(item, entry)
+            for item, entry in zip(metadata_items, plan.entries)
+        )
+        reservation = StepReservation(
+            self._transport.reserve_record(
+                plan.total_reservation_bytes,
+                plan.task_count,
+            )
+        )
+        if reservation is not StepReservation.OVERSIZED:
+            self._transport.push_record_descriptors(descriptors)
+        return reservation
+
+    def _encode(
+        self,
+        metadata: MetadataT,
+        entry: ProducerPlanEntry,
+    ) -> RecordDescriptor:
+        if entry.output_id not in self._bound_output_ids:
+            raise ValueError(
+                f"producer output_id {entry.output_id} is not bound to this runtime"
+            )
+        descriptor = self._format.encode(metadata, entry)
+        self._validate_descriptor(descriptor, expected_output_id=entry.output_id)
+        if descriptor.rows and not descriptor.has_payload:
+            raise ValueError("producer RecordDescriptor must contain a PayloadSlice")
+        self._validate_payload_slices(descriptor, entry)
+        return descriptor
+
+    def _validate_descriptor(
+        self,
+        descriptor: RecordDescriptor,
+        *,
+        expected_output_id: int | None,
+    ) -> None:
+        if not isinstance(descriptor, RecordDescriptor):
+            raise TypeError("RecordFormat.encode must return a RecordDescriptor")
+        if descriptor.output_id != expected_output_id:
+            raise ValueError(
+                "RecordDescriptor.output_id does not match its producer: "
+                f"expected {expected_output_id!r}, got {descriptor.output_id!r}"
+            )
+        layout = self._format.schema.layout(descriptor.layout)
+        for row_index, row in enumerate(descriptor.rows):
+            if len(row) != len(layout.columns):
+                raise ValueError(
+                    f"record row {row_index} has {len(row)} cells; "
+                    f"layout {layout.name!r} requires {len(layout.columns)}"
+                )
+            for column, value in zip(layout.columns, row):
+                _validate_cell(column, value)
+
+    @staticmethod
+    def _validate_entry_output(
+        entry: ProducerPlanEntry,
+        output: HookOutput,
+    ) -> None:
+        tensor = output.tensor
+        if tensor.dtype != entry.dtype:
+            raise ValueError(
+                f"producer dtype changed: expected {entry.dtype}, got {tensor.dtype}"
+            )
+        shape = tuple(int(dim) for dim in tensor.shape)
+        if shape != entry.input_shape:
+            raise ValueError(
+                f"producer input shape changed: expected {entry.input_shape}, got {shape}"
+            )
+
+    @staticmethod
+    def _validate_payload_slices(
+        descriptor: RecordDescriptor,
+        entry: ProducerPlanEntry,
+    ) -> None:
+        slices = [
+            cell
+            for row in descriptor.rows
+            for cell in row
+            if isinstance(cell, PayloadSlice)
+        ]
+        if sum(payload.nbytes is None for payload in slices) > 1:
+            raise ValueError(
+                "at most one PayloadSlice may consume the remaining actual payload"
+            )
+        for payload in slices:
+            if payload.storage is not entry.storage:
+                raise ValueError(
+                    "PayloadSlice storage does not match its producer plan entry"
+                )
+            if payload.dtype != entry.dtype:
+                raise ValueError(
+                    f"PayloadSlice dtype changed: expected {entry.dtype}, "
+                    f"got {payload.dtype}"
+                )
+            end = (
+                None
+                if payload.nbytes is None
+                else payload.offset_bytes + payload.nbytes
+            )
+            if payload.offset_bytes > entry.reservation_upper_bytes or (
+                end is not None and end > entry.reservation_upper_bytes
+            ):
+                raise ValueError("PayloadSlice exceeds producer reservation bound")
+
+
+def _require_identifier(value: str, label: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"invalid {label}: {value!r}")
+
+
+def _require_table_identifier(value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"invalid table identifier: {value!r}")
+
+
+def _validate_cell(column: RecordColumn, value: RecordCell) -> None:
+    cell_type = column.type
+    if cell_type is RecordCellType.STRING:
+        valid = isinstance(value, str)
+    elif cell_type is RecordCellType.INT32:
+        valid = (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and -(1 << 31) <= value < (1 << 31)
+        )
+    elif cell_type is RecordCellType.INT64:
+        valid = (
+            (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and -(1 << 63) <= value < (1 << 63)
+            )
+            or (
+                isinstance(value, PayloadSlice)
+                and value.storage is OutputStorage.SCALAR_INT
+            )
+        )
+    elif cell_type is RecordCellType.FLOAT64:
+        valid = (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ) or (
+            isinstance(value, PayloadSlice)
+            and value.storage is OutputStorage.SCALAR_FLOAT
+        )
+    elif cell_type is RecordCellType.INT64_ARRAY:
+        valid = isinstance(value, tuple) and all(
+            isinstance(item, int)
+            and not isinstance(item, bool)
+            and -(1 << 63) <= item < (1 << 63)
+            for item in value
+        )
+    else:
+        valid = (
+            isinstance(value, PayloadSlice)
+            and value.storage is OutputStorage.TENSOR
+        )
+    if not valid:
+        raise TypeError(
+            f"column {column.name!r} requires {cell_type.value}, "
+            f"got {type(value).__name__}"
+        )
+
+
+__all__ = [
+    "PayloadSlice",
+    "RecordCell",
+    "RecordCellType",
+    "RecordColumn",
+    "RecordDescriptor",
+    "RecordFormat",
+    "RecordLayout",
+    "RecordRuntime",
+    "RecordSchema",
+]

--- a/src/dmi/records.py
+++ b/src/dmi/records.py
@@ -11,7 +11,7 @@ from typing import Any, Generic, Protocol, Sequence, TypeVar, runtime_checkable
 import torch
 
 from .adapters.base import StepReservation
-from .hooks.dynamic import (
+from .hooks.record import (
     HookOutput,
     HookPointV1,
     HookRuntime,

--- a/src/dmi/records.py
+++ b/src/dmi/records.py
@@ -316,6 +316,8 @@ class RecordRuntime(Generic[MetadataT]):
         CPU-direct submission.  The hook therefore skips its producer launch.
         """
 
+        if self._transport.null_offload:
+            return StepReservation.SKIPPED
         self._validate_entry_output(entry, output)
         descriptor = self._encode(metadata, entry)
         reservation = StepReservation(
@@ -342,6 +344,8 @@ class RecordRuntime(Generic[MetadataT]):
                 f"expected {len(plan.entries)}, got {len(metadata_items)}"
             )
         if not plan.entries:
+            return StepReservation.SKIPPED
+        if self._transport.null_offload:
             return StepReservation.SKIPPED
         descriptors = tuple(
             self._encode(item, entry)

--- a/src/dmi/records.py
+++ b/src/dmi/records.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from math import prod
 import re
 from typing import Any, Generic, Protocol, Sequence, TypeVar, runtime_checkable
 
 import torch
 
 from .adapters.base import StepReservation
-from .hooks.dynamic import HookOutput, HookPointV1, HookRuntime, OutputStorage
+from .hooks.dynamic import (
+    HookOutput,
+    HookPointV1,
+    HookRuntime,
+    OutputStorage,
+    TransportType,
+)
 from .hooks.producer_plan import ProducerPlan, ProducerPlanEntry
 
 
@@ -240,6 +247,7 @@ class RecordRuntime(Generic[MetadataT]):
         self._output_specs_by_name: dict[str, Any] = {}
         self._bound_output_ids: set[int] = set()
         self._bound_hooks: set[int] = set()
+        self._device_gated_output_ids: set[int] = set()
 
     def bind_hook(
         self,
@@ -291,6 +299,8 @@ class RecordRuntime(Generic[MetadataT]):
                 self._output_name_to_id[output.name] = new_ids[output.name]
                 self._output_specs_by_name[output.name] = output
         self._bound_output_ids.update(output_ids)
+        if gate_tensor is not None:
+            self._device_gated_output_ids.update(output_ids)
         self._bound_hooks.add(id(hook))
 
     def emit_output(
@@ -309,10 +319,7 @@ class RecordRuntime(Generic[MetadataT]):
         self._validate_entry_output(entry, output)
         descriptor = self._encode(metadata, entry)
         reservation = StepReservation(
-            self._transport.reserve_record(
-                entry.aligned_reservation_bytes,
-                entry.task_count,
-            )
+            self._transport.reserve_record(self._reservation_items((entry,)))
         )
         self._transport.push_record_descriptors((descriptor,))
         if reservation is StepReservation.OVERSIZED:
@@ -341,14 +348,32 @@ class RecordRuntime(Generic[MetadataT]):
             for item, entry in zip(metadata_items, plan.entries)
         )
         reservation = StepReservation(
-            self._transport.reserve_record(
-                plan.total_reservation_bytes,
-                plan.task_count,
-            )
+            self._transport.reserve_record(self._reservation_items(plan.entries))
         )
         if reservation is not StepReservation.OVERSIZED:
             self._transport.push_record_descriptors(descriptors)
         return reservation
+
+    def _reservation_items(
+        self,
+        entries: Sequence[ProducerPlanEntry],
+    ) -> tuple[tuple[int, bool], ...]:
+        return tuple(
+            (entry.aligned_reservation_bytes, self._needs_reclaim(entry))
+            for entry in entries
+        )
+
+    def _needs_reclaim(self, entry: ProducerPlanEntry) -> bool:
+        tensor_bytes = (
+            prod(entry.input_shape)
+            * torch.empty((), dtype=entry.dtype).element_size()
+        )
+        tensor_aligned_bytes = (tensor_bytes + 15) & ~15
+        return not (
+            entry.transport_type is TransportType.IDENTITY
+            and entry.output_id not in self._device_gated_output_ids
+            and entry.aligned_reservation_bytes == tensor_aligned_bytes
+        )
 
     def _encode(
         self,

--- a/src/dmi/transport/native.py
+++ b/src/dmi/transport/native.py
@@ -27,6 +27,8 @@ _HOST_EXPORTS = frozenset(
 )
 _RING_EXPORTS = frozenset(
     {
+        "ClickHouseRecordSink",
+        "RecordSink",
         "RingConfig",
         "RingEngine",
         "ring_set_active_engine",

--- a/src/dmi/transport/ring.py
+++ b/src/dmi/transport/ring.py
@@ -415,7 +415,7 @@ class RingTransport:
     def _record_cpu_tensor(output: Any, entry: Any) -> torch.Tensor:
         """Apply the selected producer transformation for CPU-direct fallback."""
 
-        from ..hooks.dynamic import TransportType
+        from ..hooks.record import TransportType
 
         source = output.tensor.detach().cpu().contiguous()
         transport_type = entry.transport_type

--- a/src/dmi/transport/ring.py
+++ b/src/dmi/transport/ring.py
@@ -74,6 +74,60 @@ try:
     ) -> None:
         return None
 
+    @torch.library.register_fake("ring::record_producer")
+    def _record_producer_fake(
+        ring_payload: torch.Tensor,
+        tensor: torch.Tensor,
+        emit_gate: Optional[torch.Tensor] = None,
+        emit_value: int = 0,
+    ) -> None:
+        return None
+
+    @torch.library.register_fake("ring::record_producer_prefix")
+    def _record_producer_prefix_fake(
+        ring_payload: torch.Tensor,
+        tensor: torch.Tensor,
+        row_count: torch.Tensor,
+        row_bytes: int,
+        emit_gate: Optional[torch.Tensor] = None,
+        emit_value: int = 0,
+    ) -> None:
+        return None
+
+    @torch.library.register_fake("ring::record_producer_chunked")
+    def _record_producer_chunked_fake(
+        ring_payload: torch.Tensor,
+        tensor: torch.Tensor,
+        chunk_bytes: torch.Tensor,
+        emit_gate: Optional[torch.Tensor] = None,
+        emit_value: int = 0,
+    ) -> None:
+        return None
+
+    @torch.library.register_fake("ring::record_producer_seq_prefix_pack")
+    def _record_producer_seq_prefix_pack_fake(
+        ring_payload: torch.Tensor,
+        tensor: torch.Tensor,
+        valid_count: torch.Tensor,
+        valid_prefix_sum: torch.Tensor,
+        feature_bytes: int,
+        emit_gate: Optional[torch.Tensor] = None,
+        emit_value: int = 0,
+    ) -> None:
+        return None
+
+    @torch.library.register_fake("ring::record_producer_segmented_pack")
+    def _record_producer_segmented_pack_fake(
+        ring_payload: torch.Tensor,
+        tensor: torch.Tensor,
+        segment_start: torch.Tensor,
+        segment_end: torch.Tensor,
+        feature_bytes: int,
+        emit_gate: Optional[torch.Tensor] = None,
+        emit_value: int = 0,
+    ) -> None:
+        return None
+
     del _ne
 except Exception:
     pass
@@ -312,6 +366,120 @@ class RingTransport:
         CPU memory; it bypasses the ring and staging entirely.
         """
         self._ring_engine.submit_cpu_direct(cpu_tensor)
+
+    # ------------------------------------------------------------------
+    # Opt-in generic-record path.  None of these methods is used by the
+    # released inference adapters.
+
+    def _record_payload_tensor(self) -> torch.Tensor:
+        """Return the stable payload alias to the core ``RecordRuntime``."""
+
+        return self._ring_payload
+
+    def configure_record_schema(self, schema: Any) -> None:
+        """Install the immutable schema used to encode Python descriptors."""
+
+        if hasattr(self, "_record_schema"):
+            raise RuntimeError("record schema is already configured")
+        self._record_schema = schema
+
+    def reserve_record(self, upper_bytes: int, task_count: int) -> int:
+        """Reserve one encoded-record producer group."""
+
+        return int(self._ring_engine.reserve_record(upper_bytes, task_count))
+
+    def push_record_descriptors(self, descriptors: Any) -> None:
+        """Publish descriptors in the exact order of their producer tasks."""
+
+        self._ring_engine.push_record_descriptors(
+            tuple(descriptors), self._record_schema
+        )
+
+    def submit_record_cpu_direct(self, output: Any, entry: Any) -> None:
+        """Materialize one oversized physical output and submit it directly."""
+
+        cpu_tensor = self._record_cpu_tensor(output, entry)
+        self._ring_engine.submit_record_cpu_direct(
+            cpu_tensor,
+            int(cpu_tensor.numel()) * int(cpu_tensor.element_size()),
+        )
+
+    def flush_records_and_wait(self, timeout_s: float) -> None:
+        """Durably finish all generic-record work or raise its async error."""
+
+        completed = self._ring_engine.flush_records_and_wait(float(timeout_s))
+        if completed is False:
+            raise TimeoutError("timed out waiting for record ring completion")
+
+    @staticmethod
+    def _record_cpu_tensor(output: Any, entry: Any) -> torch.Tensor:
+        """Apply the selected producer transformation for CPU-direct fallback."""
+
+        from ..hooks.dynamic import TransportType
+
+        source = output.tensor.detach().cpu().contiguous()
+        transport_type = entry.transport_type
+        if transport_type is TransportType.IDENTITY:
+            return source
+
+        byte_source = source.view(torch.uint8).reshape(-1)
+        if transport_type is TransportType.PREFIX_STRIP:
+            row_count = int(output.producer_meta[0].detach().cpu().item())
+            row_bytes = int(entry.transport_args[0])
+            nbytes = min(byte_source.numel(), max(0, row_count) * row_bytes)
+            return byte_source[:nbytes].clone()
+
+        if transport_type is TransportType.CHUNKED:
+            counts = output.producer_meta[0].detach().cpu().reshape(-1)
+            chunks = int(counts.numel())
+            if chunks <= 0 or byte_source.numel() % chunks != 0:
+                raise ValueError("CHUNKED CPU fallback requires equal input chunks")
+            chunk_bytes = byte_source.numel() // chunks
+            pieces = []
+            for index, value in enumerate(counts.tolist()):
+                count = max(0, min(chunk_bytes, int(value)))
+                begin = index * chunk_bytes
+                pieces.append(byte_source[begin : begin + count])
+            return torch.cat(pieces).contiguous() if pieces else byte_source[:0].clone()
+
+        if transport_type is TransportType.SEQ_PREFIX_PACK:
+            if source.dim() < 2:
+                raise ValueError("SEQ_PREFIX_PACK requires [S, B, ...] input")
+            counts = output.producer_meta[0].detach().cpu().reshape(-1)
+            if source.size(1) != counts.numel():
+                raise ValueError("SEQ_PREFIX_PACK valid-count length mismatch")
+            pieces = []
+            for batch_index, value in enumerate(counts.tolist()):
+                count = max(0, min(source.size(0), int(value)))
+                if count:
+                    pieces.append(source[:count, batch_index, ...].contiguous())
+            if pieces:
+                return torch.cat(pieces, dim=0).contiguous()
+            return torch.empty(
+                (0, *tuple(source.shape[2:])),
+                dtype=source.dtype,
+            )
+
+        if transport_type is TransportType.SEGMENTED_PACK:
+            starts = output.producer_meta[0].detach().cpu().reshape(-1)
+            ends = output.producer_meta[1].detach().cpu().reshape(-1)
+            if starts.numel() == 0 or starts.numel() != ends.numel():
+                raise ValueError("SEGMENTED_PACK start/end length mismatch")
+            pieces = []
+            rows = source.size(0)
+            for start, end in zip(starts.tolist(), ends.tolist()):
+                begin = max(0, min(rows, int(start)))
+                finish = max(begin, min(rows, int(end)))
+                if finish > begin:
+                    pieces.append(source[begin:finish, ...].contiguous())
+            if pieces:
+                return torch.cat(pieces, dim=0).contiguous()
+            return torch.empty(
+                (0, *tuple(source.shape[1:])),
+                dtype=source.dtype,
+            )
+
+        raise ValueError(f"Unsupported transport type {transport_type!r}")
 
 
 

--- a/src/dmi/transport/ring.py
+++ b/src/dmi/transport/ring.py
@@ -383,10 +383,10 @@ class RingTransport:
             raise RuntimeError("record schema is already configured")
         self._record_schema = schema
 
-    def reserve_record(self, upper_bytes: int, task_count: int) -> int:
-        """Reserve one encoded-record producer group."""
+    def reserve_record(self, reservation_items: Any) -> int:
+        """Reserve ordered encoded-record producer entries."""
 
-        return int(self._ring_engine.reserve_record(upper_bytes, task_count))
+        return int(self._ring_engine.reserve_record(tuple(reservation_items)))
 
     def push_record_descriptors(self, descriptors: Any) -> None:
         """Publish descriptors in the exact order of their producer tasks."""

--- a/src/dmi/transport/ring.py
+++ b/src/dmi/transport/ring.py
@@ -405,11 +405,11 @@ class RingTransport:
         )
 
     def flush_records_and_wait(self, timeout_s: float) -> None:
-        """Durably finish all generic-record work or raise its async error."""
+        """Finish ring work and the configured sink durability boundary."""
 
         completed = self._ring_engine.flush_records_and_wait(float(timeout_s))
         if completed is False:
-            raise TimeoutError("timed out waiting for record ring completion")
+            raise TimeoutError("timed out waiting for durable record completion")
 
     @staticmethod
     def _record_cpu_tensor(output: Any, entry: Any) -> torch.Tensor:

--- a/src/dmi/transport/ring.py
+++ b/src/dmi/transport/ring.py
@@ -448,16 +448,34 @@ class RingTransport:
             counts = output.producer_meta[0].detach().cpu().reshape(-1)
             if source.size(1) != counts.numel():
                 raise ValueError("SEQ_PREFIX_PACK valid-count length mismatch")
+            prefix = output.producer_meta[1].detach().cpu().reshape(-1)
+            batch = int(counts.numel())
+            if prefix.numel() != batch + 1:
+                raise ValueError("SEQ_PREFIX_PACK prefix length must equal batch + 1")
+            feature_bytes = int(entry.transport_args[0])
+            physical_batch_bytes = batch * feature_bytes
+            if (
+                batch <= 0
+                or feature_bytes <= 0
+                or byte_source.numel() % physical_batch_bytes != 0
+            ):
+                raise ValueError("SEQ_PREFIX_PACK payload has incompatible feature bytes")
+            max_rows = byte_source.numel() // feature_bytes
+            total_rows = max(0, min(max_rows, int(prefix[-1].item())))
+            prefix_values = [int(value) for value in prefix.tolist()]
             pieces = []
-            for batch_index, value in enumerate(counts.tolist()):
-                count = max(0, min(source.size(0), int(value)))
-                if count:
-                    pieces.append(source[:count, batch_index, ...].contiguous())
-            if pieces:
-                return torch.cat(pieces, dim=0).contiguous()
-            return torch.empty(
-                (0, *tuple(source.shape[2:])),
-                dtype=source.dtype,
+            for row in range(total_rows):
+                sample = 0
+                while sample + 1 < batch and row >= prefix_values[sample + 1]:
+                    sample += 1
+                sample_row = row - prefix_values[sample]
+                source_row = sample_row * batch + sample
+                begin = source_row * feature_bytes
+                pieces.append(byte_source[begin : begin + feature_bytes])
+            return (
+                torch.cat(pieces).contiguous()
+                if pieces
+                else byte_source[:0].clone()
             )
 
         if transport_type is TransportType.SEGMENTED_PACK:
@@ -465,18 +483,25 @@ class RingTransport:
             ends = output.producer_meta[1].detach().cpu().reshape(-1)
             if starts.numel() == 0 or starts.numel() != ends.numel():
                 raise ValueError("SEGMENTED_PACK start/end length mismatch")
+            feature_bytes = int(entry.transport_args[0])
+            if feature_bytes <= 0 or byte_source.numel() % feature_bytes != 0:
+                raise ValueError("SEGMENTED_PACK payload has incompatible feature bytes")
+            input_rows = byte_source.numel() // feature_bytes
             pieces = []
-            rows = source.size(0)
             for start, end in zip(starts.tolist(), ends.tolist()):
-                begin = max(0, min(rows, int(start)))
-                finish = max(begin, min(rows, int(end)))
-                if finish > begin:
-                    pieces.append(source[begin:finish, ...].contiguous())
-            if pieces:
-                return torch.cat(pieces, dim=0).contiguous()
-            return torch.empty(
-                (0, *tuple(source.shape[1:])),
-                dtype=source.dtype,
+                first_row = max(0, min(input_rows, int(start)))
+                last_row = max(first_row, min(input_rows, int(end)))
+                for source_row in range(first_row, last_row):
+                    begin = source_row * feature_bytes
+                    pieces.append(byte_source[begin : begin + feature_bytes])
+                    if len(pieces) == input_rows:
+                        break
+                if len(pieces) == input_rows:
+                    break
+            return (
+                torch.cat(pieces).contiguous()
+                if pieces
+                else byte_source[:0].clone()
             )
 
         raise ValueError(f"Unsupported transport type {transport_type!r}")

--- a/tests/hf_compare_runner.py
+++ b/tests/hf_compare_runner.py
@@ -40,6 +40,8 @@ def main():
     cuda_graphs = os.environ.get("E2E_CUDA_GRAPHS", "0") == "1"
     db_host = os.environ.get("DMX_DB_HOST", "localhost")
     db_port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    db_database = os.environ.get("DMX_DB_DATABASE", "default")
+    db_table = os.environ.get("DMX_DB_TABLE", "offload")
     tp_size = int(os.environ.get("E2E_TP_SIZE", "1"))
 
     # Init distributed for TP
@@ -96,7 +98,7 @@ def main():
     if tp_rank == 0:
         ch_client = clickhouse_driver.Client(db_host, port=db_port)
         try:
-            ch_client.execute("DROP TABLE IF EXISTS default.offload")
+            ch_client.execute(f"DROP TABLE IF EXISTS {db_database}.{db_table}")
         except Exception:
             pass
     if tp_size > 1:
@@ -108,8 +110,8 @@ def main():
     ch_cfg.port = db_port
     ch_cfg.username = os.environ.get("DMX_DB_USER", "default")
     ch_cfg.password = os.environ.get("DMX_DB_PASSWORD", "")
-    ch_cfg.database = "default"
-    ch_cfg.table = "offload"
+    ch_cfg.database = db_database
+    ch_cfg.table = db_table
     ch_cfg.secure = False
     ch_cfg.client_side_compress = "none"
     ch_cfg.client_settings = None
@@ -206,7 +208,9 @@ def main():
     if tp_rank == 0:
         print("\n[compare] Comparing disk vs ClickHouse...", flush=True)
         from tests.compare_disk_vs_ch import read_clickhouse, compare
-        ch_data_all, total_rows = read_clickhouse(db_host, db_port)
+        ch_data_all, total_rows = read_clickhouse(
+            db_host, db_port, database=db_database, table=db_table
+        )
         passed, failed = compare(compare_dir, ch_data_all, total_rows)
 
         if failed > 0:

--- a/tests/native/ring/Makefile
+++ b/tests/native/ring/Makefile
@@ -54,11 +54,17 @@ NVCC_FLAGS := \
 
 PRODUCER_CU  := ../../../native/csrc/ring/producer.cu
 DRAIN_SRC    := ../../../native/csrc/ring/drain_thread.cpp
+P2P_SRC      := ../../../native/csrc/ring/p2p_thread.cpp
+RECORD_CONSUMER_SRC := ../../../native/csrc/ring/record_consumer.cpp
+RING_ENGINE_CU := ../../../native/csrc/ring/ring_engine.cu
+RING_ENGINE_PY_CU := ../../../native/csrc/ring/ring_engine_py.cu
 
 TARGETS := $(BUILD)/test_rings $(BUILD)/test_producer \
-           $(BUILD)/test_ring_engine $(BUILD)/test_null_mode
+           $(BUILD)/test_ring_engine $(BUILD)/test_null_mode \
+           $(BUILD)/test_record_consumer
 
-.PHONY: all test_rings test_producer test_ring_engine test_null_mode run clean FORCE
+.PHONY: all test_rings test_producer test_ring_engine test_null_mode \
+        test_record_consumer run clean FORCE
 
 all: $(TARGETS)
 
@@ -76,13 +82,20 @@ $(BUILD)/test_rings: test_rings.cu $(CUDA_CONFIG_STAMP) | $(BUILD)
 $(BUILD)/test_producer: test_producer.cu $(PRODUCER_CU) $(CUDA_CONFIG_STAMP) | $(BUILD)
 	$(CUDA_NVCC) $(NVCC_FLAGS) $(filter-out $(CUDA_CONFIG_STAMP),$^) -o $@
 
-$(BUILD)/test_ring_engine: test_ring_engine.cu $(PRODUCER_CU) $(DRAIN_SRC) $(CUDA_CONFIG_STAMP) | $(BUILD)
+$(BUILD)/test_ring_engine: test_ring_engine.cu $(PRODUCER_CU) $(DRAIN_SRC) \
+		$(P2P_SRC) $(RECORD_CONSUMER_SRC) $(RING_ENGINE_CU) \
+		$(RING_ENGINE_PY_CU) $(CUDA_CONFIG_STAMP) | $(BUILD)
 	$(CUDA_NVCC) $(NVCC_FLAGS) $(TORCH_INCLUDE_FLAGS) $(TORCH_LIB_FLAGS) \
-		$(TORCH_RPATH_FLAGS) -ltorch -ltorch_cpu -lc10 -lpthread \
-		$(filter-out $(CUDA_CONFIG_STAMP),$^) -o $@
+		$(filter-out $(CUDA_CONFIG_STAMP),$^) $(TORCH_RPATH_FLAGS) \
+		-ltorch -ltorch_cpu -ltorch_cuda -lc10 -lc10_cuda -lpthread -o $@
 
 $(BUILD)/test_null_mode: test_null_mode.cu $(PRODUCER_CU) $(CUDA_CONFIG_STAMP) | $(BUILD)
 	$(CUDA_NVCC) $(NVCC_FLAGS) $(filter-out $(CUDA_CONFIG_STAMP),$^) -o $@
+
+$(BUILD)/test_record_consumer: test_record_consumer.cpp $(RECORD_CONSUMER_SRC) $(CUDA_CONFIG_STAMP) | $(BUILD)
+	$(CUDA_NVCC) $(NVCC_FLAGS) $(TORCH_INCLUDE_FLAGS) $(TORCH_LIB_FLAGS) \
+		$(filter-out $(CUDA_CONFIG_STAMP),$^) $(TORCH_RPATH_FLAGS) \
+		-ltorch -ltorch_cpu -lc10 -lpthread -o $@
 
 test_rings: $(BUILD)/test_rings
 	$(BUILD)/test_rings
@@ -96,11 +109,15 @@ test_ring_engine: $(BUILD)/test_ring_engine
 test_null_mode: $(BUILD)/test_null_mode
 	$(BUILD)/test_null_mode
 
+test_record_consumer: $(BUILD)/test_record_consumer
+	$(BUILD)/test_record_consumer
+
 run: all
 	$(BUILD)/test_rings
 	$(BUILD)/test_producer
 	$(BUILD)/test_ring_engine
 	$(BUILD)/test_null_mode
+	$(BUILD)/test_record_consumer
 
 clean:
 	rm -rf $(BUILD)

--- a/tests/native/ring/Makefile
+++ b/tests/native/ring/Makefile
@@ -56,15 +56,17 @@ PRODUCER_CU  := ../../../native/csrc/ring/producer.cu
 DRAIN_SRC    := ../../../native/csrc/ring/drain_thread.cpp
 P2P_SRC      := ../../../native/csrc/ring/p2p_thread.cpp
 RECORD_CONSUMER_SRC := ../../../native/csrc/ring/record_consumer.cpp
+CLICKHOUSE_RECORD_SINK_SRC := ../../../native/csrc/clickhouse_record_sink.cpp
 RING_ENGINE_CU := ../../../native/csrc/ring/ring_engine.cu
 RING_ENGINE_PY_CU := ../../../native/csrc/ring/ring_engine_py.cu
 
 TARGETS := $(BUILD)/test_rings $(BUILD)/test_producer \
            $(BUILD)/test_ring_engine $(BUILD)/test_null_mode \
-           $(BUILD)/test_record_consumer
+           $(BUILD)/test_record_consumer \
+           $(BUILD)/test_clickhouse_record_sink
 
 .PHONY: all test_rings test_producer test_ring_engine test_null_mode \
-        test_record_consumer run clean FORCE
+        test_record_consumer test_clickhouse_record_sink run clean FORCE
 
 all: $(TARGETS)
 
@@ -97,6 +99,11 @@ $(BUILD)/test_record_consumer: test_record_consumer.cpp $(RECORD_CONSUMER_SRC) $
 		$(filter-out $(CUDA_CONFIG_STAMP),$^) $(TORCH_RPATH_FLAGS) \
 		-ltorch -ltorch_cpu -lc10 -lpthread -o $@
 
+$(BUILD)/test_clickhouse_record_sink: test_clickhouse_record_sink.cpp $(CLICKHOUSE_RECORD_SINK_SRC) $(CUDA_CONFIG_STAMP) | $(BUILD)
+	$(CUDA_NVCC) $(NVCC_FLAGS) $(TORCH_INCLUDE_FLAGS) $(TORCH_LIB_FLAGS) \
+		$(filter-out $(CUDA_CONFIG_STAMP),$^) $(TORCH_RPATH_FLAGS) \
+		-ltorch -ltorch_cpu -lc10 -lpthread -o $@
+
 test_rings: $(BUILD)/test_rings
 	$(BUILD)/test_rings
 
@@ -112,12 +119,16 @@ test_null_mode: $(BUILD)/test_null_mode
 test_record_consumer: $(BUILD)/test_record_consumer
 	$(BUILD)/test_record_consumer
 
+test_clickhouse_record_sink: $(BUILD)/test_clickhouse_record_sink
+	$(BUILD)/test_clickhouse_record_sink
+
 run: all
 	$(BUILD)/test_rings
 	$(BUILD)/test_producer
 	$(BUILD)/test_ring_engine
 	$(BUILD)/test_null_mode
 	$(BUILD)/test_record_consumer
+	$(BUILD)/test_clickhouse_record_sink
 
 clean:
 	rm -rf $(BUILD)

--- a/tests/native/ring/test_clickhouse_record_sink.cpp
+++ b/tests/native/ring/test_clickhouse_record_sink.cpp
@@ -1,0 +1,160 @@
+#include "clickhouse_record_sink.h"
+
+#include <ATen/ATen.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT(condition)                                                   \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n",                    \
+                         __FILE__, __LINE__, #condition);                    \
+            ++g_fail;                                                       \
+        } else {                                                            \
+            ++g_pass;                                                       \
+        }                                                                   \
+    } while (0)
+
+static ring::PayloadSlice tensor_slice(
+    std::uint64_t offset,
+    std::optional<std::uint64_t> length,
+    std::vector<std::int64_t> shape,
+    std::int32_t dynamic_dim = -1) {
+    ring::PayloadSlice slice;
+    slice.offset_bytes = offset;
+    slice.length_bytes = length;
+    slice.materialization = ring::PayloadMaterialization::TENSOR;
+    slice.dtype = static_cast<std::int32_t>(at::kFloat);
+    slice.logical_shape = std::move(shape);
+    slice.inferred_dynamic_dim = dynamic_dim;
+    return slice;
+}
+
+static ring::PayloadSlice scalar_slice(
+    std::uint64_t offset,
+    std::uint64_t length,
+    ring::PayloadMaterialization materialization,
+    at::ScalarType dtype) {
+    ring::PayloadSlice slice;
+    slice.offset_bytes = offset;
+    slice.length_bytes = length;
+    slice.materialization = materialization;
+    slice.dtype = static_cast<std::int32_t>(dtype);
+    return slice;
+}
+
+static void test_materializes_only_inside_clickhouse_adapter() {
+    std::printf("[ TEST ] ClickHouse adapter materializes raw envelopes\n");
+    std::vector<dmx_host::GenericRecordRow> rows;
+    std::vector<std::uint64_t> sizes;
+    int flushes = 0;
+    ring::RecordSink::Duration observed_timeout{0};
+    dmx_host::ClickHouseRecordSink sink(
+        [&](dmx_host::GenericRecordRow row, std::uint64_t size) {
+            rows.push_back(std::move(row));
+            sizes.push_back(size);
+        },
+        [&](ring::RecordSink::Duration timeout) {
+            ++flushes;
+            observed_timeout = timeout;
+            return true;
+        },
+        [] {});
+
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "layout_a";
+    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
+        std::string("first"), std::int32_t(7), std::int64_t(11), 2.5,
+        std::vector<std::int64_t>{3, 4},
+        tensor_slice(0, std::nullopt, {-1, 2}, 0)}}};
+    at::Tensor payload = at::tensor(
+        {1.f, 2.f, 3.f, 4.f, 5.f, 6.f},
+        at::TensorOptions().dtype(at::kFloat)).view(at::kByte).clone();
+    at::Tensor payload_alias = payload;
+
+    sink.submit(ring::RecordEnvelope{
+        std::move(descriptor), std::move(payload)});
+    payload_alias.zero_();
+
+    EXPECT(rows.size() == 1);
+    EXPECT(rows[0].layout == "layout_a");
+    EXPECT(std::get<std::string>(rows[0].cells[0]) == "first");
+    EXPECT(std::get<std::int32_t>(rows[0].cells[1]) == 7);
+    EXPECT(std::get<std::int64_t>(rows[0].cells[2]) == 11);
+    EXPECT(std::get<double>(rows[0].cells[3]) == 2.5);
+    EXPECT(std::get<std::vector<std::int64_t>>(rows[0].cells[4]) ==
+           std::vector<std::int64_t>({3, 4}));
+    const at::Tensor tensor = std::get<at::Tensor>(rows[0].cells[5]);
+    EXPECT(tensor.sizes().vec() == std::vector<std::int64_t>({3, 2}));
+    EXPECT(at::equal(
+        tensor,
+        at::tensor({1.f, 2.f, 3.f, 4.f, 5.f, 6.f}).reshape({3, 2})));
+    EXPECT(sizes == std::vector<std::uint64_t>({24}));
+    EXPECT(sink.flush_and_wait(std::chrono::milliseconds(37)));
+    EXPECT(flushes == 1);
+    EXPECT(observed_timeout == std::chrono::milliseconds(37));
+}
+
+static void test_scalar_materialization_and_failure_delegation() {
+    std::printf("[ TEST ] scalar materialization and sink failure delegation\n");
+    std::vector<dmx_host::GenericRecordRow> rows;
+    bool fail = false;
+    dmx_host::ClickHouseRecordSink sink(
+        [&](dmx_host::GenericRecordRow row, std::uint64_t) {
+            rows.push_back(std::move(row));
+        },
+        [](ring::RecordSink::Duration) { return true; },
+        [&] {
+            if (fail) throw std::runtime_error("host failure");
+        });
+
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "scalars";
+    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
+        scalar_slice(0, sizeof(float),
+                     ring::PayloadMaterialization::FLOAT_SCALAR, at::kFloat),
+        scalar_slice(8, sizeof(std::int64_t),
+                     ring::PayloadMaterialization::INT_SCALAR, at::kLong)}}};
+    at::Tensor payload = at::zeros(
+        {16}, at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+    const float floating = 3.25f;
+    const std::int64_t integer = 41;
+    std::memcpy(payload.data_ptr<std::uint8_t>(), &floating, sizeof(floating));
+    std::memcpy(payload.data_ptr<std::uint8_t>() + 8, &integer,
+                sizeof(integer));
+
+    sink.submit(ring::RecordEnvelope{
+        std::move(descriptor), std::move(payload)});
+    EXPECT(rows.size() == 1);
+    EXPECT(std::get<double>(rows[0].cells[0]) == 3.25);
+    EXPECT(std::get<std::int64_t>(rows[0].cells[1]) == 41);
+
+    fail = true;
+    bool rethrew = false;
+    try {
+        sink.rethrow_if_failed();
+    } catch (const std::runtime_error&) {
+        rethrew = true;
+    }
+    EXPECT(rethrew);
+}
+
+int main() {
+    setbuf(stdout, nullptr);
+    std::printf("test_clickhouse_record_sink\n");
+    test_materializes_only_inside_clickhouse_adapter();
+    test_scalar_materialization_and_failure_delegation();
+    std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/ring/test_clickhouse_record_sink.cpp
+++ b/tests/native/ring/test_clickhouse_record_sink.cpp
@@ -150,11 +150,41 @@ static void test_scalar_materialization_and_failure_delegation() {
     EXPECT(rethrew);
 }
 
+static void test_zero_dimensional_tensor_materialization() {
+    std::printf("[ TEST ] zero-dimensional tensor materialization\n");
+    std::vector<dmx_host::GenericRecordRow> rows;
+    std::vector<std::uint64_t> sizes;
+    dmx_host::ClickHouseRecordSink sink(
+        [&](dmx_host::GenericRecordRow row, std::uint64_t size) {
+            rows.push_back(std::move(row));
+            sizes.push_back(size);
+        },
+        [](ring::RecordSink::Duration) { return true; },
+        [] {});
+
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "zero_dimensional_tensor";
+    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
+        tensor_slice(0, sizeof(float), {})}}};
+    at::Tensor payload = at::tensor(
+        {3.5f}, at::TensorOptions().dtype(at::kFloat)).view(at::kByte).clone();
+
+    sink.submit(ring::RecordEnvelope{
+        std::move(descriptor), std::move(payload)});
+
+    EXPECT(rows.size() == 1);
+    const at::Tensor tensor = std::get<at::Tensor>(rows[0].cells[0]);
+    EXPECT(tensor.dim() == 0);
+    EXPECT(tensor.item<float>() == 3.5f);
+    EXPECT(sizes == std::vector<std::uint64_t>({sizeof(float)}));
+}
+
 int main() {
     setbuf(stdout, nullptr);
     std::printf("test_clickhouse_record_sink\n");
     test_materializes_only_inside_clickhouse_adapter();
     test_scalar_materialization_and_failure_delegation();
+    test_zero_dimensional_tensor_materialization();
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/native/ring/test_null_mode.cu
+++ b/tests/native/ring/test_null_mode.cu
@@ -86,6 +86,10 @@ static void test_all_variants_are_noops() {
     uint8_t* source = upload_bytes(256);
     int64_t* row_count = upload_counts({3});
     int64_t* chunk_counts = upload_counts({16, 32, 0, 8});
+    int64_t* valid_count = upload_counts({2, 1});
+    int64_t* valid_prefix = upload_counts({0, 2, 3});
+    int64_t* segment_start = upload_counts({0, 4});
+    int64_t* segment_end = upload_counts({2, 6});
     cudaStream_t stream{};
     CUDA_CHECK(cudaStreamCreate(&stream));
 
@@ -94,10 +98,26 @@ static void test_all_variants_are_noops() {
     ring::launch_producer_prefix(state, source, 256, row_count, 32, 0, stream);
     ring::launch_producer_chunked(state, source, 256, chunk_counts, 4, 0,
                                   stream);
+    ring::launch_record_producer_static(
+        state, source, 256, nullptr, 0, stream);
+    ring::launch_record_producer_prefix(
+        state, source, 256, row_count, 32, nullptr, 0, stream);
+    ring::launch_record_producer_chunked(
+        state, source, 256, chunk_counts, 4, nullptr, 0, stream);
+    ring::launch_record_producer_seq_prefix_pack(
+        state, source, 256, valid_count, valid_prefix, 2, 32,
+        nullptr, 0, stream);
+    ring::launch_record_producer_segmented_pack(
+        state, source, 256, segment_start, segment_end, 2, 32,
+        nullptr, 0, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     expect_empty(state);
 
     set_null_mode(false);
+    CUDA_CHECK(cudaFree(segment_end));
+    CUDA_CHECK(cudaFree(segment_start));
+    CUDA_CHECK(cudaFree(valid_prefix));
+    CUDA_CHECK(cudaFree(valid_count));
     CUDA_CHECK(cudaFree(chunk_counts));
     CUDA_CHECK(cudaFree(row_count));
     CUDA_CHECK(cudaFree(source));

--- a/tests/native/ring/test_producer.cu
+++ b/tests/native/ring/test_producer.cu
@@ -75,6 +75,13 @@ static int64_t* upload_counts(const std::vector<int64_t>& counts) {
     return device;
 }
 
+static int32_t* upload_gate(int32_t value) {
+    int32_t* device = nullptr;
+    CUDA_CHECK(cudaMalloc(&device, sizeof(value)));
+    CUDA_CHECK(cudaMemcpy(device, &value, sizeof(value), cudaMemcpyHostToDevice));
+    return device;
+}
+
 static std::vector<uint8_t> read_payload(const ring::RingState& state,
                                          const ring::TaskEntry& entry) {
     std::vector<uint8_t> result(entry.tensor_total_bytes);
@@ -276,6 +283,152 @@ static void test_serialized_static_launches() {
     }
 }
 
+static void test_record_chunked_compacts_payload_head() {
+    banner("record chunked producer advances by actual aligned bytes");
+    ring::AllocatedRing allocated(make_config());
+    allocated.init();
+    ring::RingState& state = allocated.state();
+
+    constexpr uint32_t chunks = 4;
+    constexpr uint64_t input_chunk = 64;
+    const std::vector<int64_t> selected = {16, 32, 0, 8};
+    const std::vector<uint8_t> source = pattern(chunks * input_chunk, 91);
+    uint8_t* device = upload(source);
+    int64_t* device_selected = upload_counts(selected);
+
+    ring::launch_record_producer_chunked(
+        state, device, source.size(), device_selected, chunks,
+        nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    constexpr uint64_t actual = 56;
+    expect_entry(state, 0, actual);
+    EXPECT(*state.payload_head == ring::align_up(actual, ring::PAYLOAD_ALIGN));
+
+    std::vector<uint8_t> expected;
+    for (uint32_t chunk = 0; chunk < chunks; ++chunk) {
+        const auto begin = source.begin() + chunk * input_chunk;
+        expected.insert(expected.end(), begin, begin + selected[chunk]);
+    }
+    EXPECT(read_payload(state, state.task_entries[0]) == expected);
+
+    CUDA_CHECK(cudaFree(device_selected));
+    CUDA_CHECK(cudaFree(device));
+}
+
+static void test_record_sequence_and_segmented_pack() {
+    banner("record row packers preserve declared row order");
+    ring::AllocatedRing allocated(make_config());
+    allocated.init();
+    ring::RingState& state = allocated.state();
+
+    // Source is [S=3, B=2, feature=4 bytes], one distinct byte pattern per row.
+    constexpr uint64_t feature_bytes = 4;
+    std::vector<uint8_t> source(3 * 2 * feature_bytes);
+    for (uint64_t row = 0; row < 6; ++row) {
+        std::fill(source.begin() + row * feature_bytes,
+                  source.begin() + (row + 1) * feature_bytes,
+                  static_cast<uint8_t>(10 + row));
+    }
+    uint8_t* device = upload(source);
+    int64_t* valid_count = upload_counts({2, 1});
+    int64_t* valid_prefix = upload_counts({0, 2, 3});
+    ring::launch_record_producer_seq_prefix_pack(
+        state, device, source.size(), valid_count, valid_prefix, 2,
+        feature_bytes, nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    // [sample0 token0, sample0 token1, sample1 token0] maps to source rows
+    // [0, 2, 1] in contiguous [S, B, ...] storage.
+    std::vector<uint8_t> expected_sequence;
+    for (uint64_t row : {uint64_t(0), uint64_t(2), uint64_t(1)}) {
+        expected_sequence.insert(
+            expected_sequence.end(), source.begin() + row * feature_bytes,
+            source.begin() + (row + 1) * feature_bytes);
+    }
+    expect_entry(state, 0, expected_sequence.size());
+    EXPECT(read_payload(state, state.task_entries[0]) == expected_sequence);
+
+    int64_t* starts = upload_counts({1, 4});
+    int64_t* ends = upload_counts({3, 6});
+    ring::launch_record_producer_segmented_pack(
+        state, device, source.size(), starts, ends, 2, feature_bytes,
+        nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    std::vector<uint8_t> expected_segments;
+    for (uint64_t row : {uint64_t(1), uint64_t(2), uint64_t(4), uint64_t(5)}) {
+        expected_segments.insert(
+            expected_segments.end(), source.begin() + row * feature_bytes,
+            source.begin() + (row + 1) * feature_bytes);
+    }
+    expect_entry(state, 1, expected_segments.size());
+    EXPECT(read_payload(state, state.task_entries[1]) == expected_segments);
+
+    CUDA_CHECK(cudaFree(ends));
+    CUDA_CHECK(cudaFree(starts));
+    CUDA_CHECK(cudaFree(valid_prefix));
+    CUDA_CHECK(cudaFree(valid_count));
+    CUDA_CHECK(cudaFree(device));
+}
+
+static void test_record_device_gate_publishes_zero_byte_entries() {
+    banner("false record gates publish zero-byte entries in FIFO order");
+    ring::AllocatedRing allocated(make_config());
+    allocated.init();
+    ring::RingState& state = allocated.state();
+    const std::vector<uint8_t> source = pattern(64, 123);
+    uint8_t* device = upload(source);
+    int32_t* gate = upload_gate(0);
+    constexpr uint64_t initial_payload_head = 32;
+    constexpr uint64_t initial_actual_bytes = 17;
+    *state.payload_head = initial_payload_head;
+    *state.actual_bytes_counter = initial_actual_bytes;
+    const std::vector<uint8_t> payload_before(state.payload_cap, 0xA5);
+    CUDA_CHECK(cudaMemcpy(state.payload_buf, payload_before.data(),
+                          payload_before.size(), cudaMemcpyHostToDevice));
+
+    ring::launch_record_producer_static(
+        state, device, source.size(), gate, 1);
+    ring::launch_record_producer_prefix(
+        state, device, source.size(), nullptr, 16, gate, 1);
+    ring::launch_record_producer_chunked(
+        state, device, source.size(), nullptr, 2, gate, 1);
+    ring::launch_record_producer_seq_prefix_pack(
+        state, device, source.size(), nullptr, nullptr, 2, 8, gate, 1);
+    ring::launch_record_producer_segmented_pack(
+        state, device, source.size(), nullptr, nullptr, 2, 8, gate, 1);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    constexpr uint64_t gated_variants = 5;
+    for (uint64_t sequence = 0; sequence < gated_variants; ++sequence) {
+        expect_entry(state, sequence, 0);
+    }
+    EXPECT(*state.task_head == gated_variants);
+    EXPECT(*state.payload_head == initial_payload_head);
+    EXPECT(*state.actual_bytes_counter == initial_actual_bytes);
+    std::vector<uint8_t> payload_after(state.payload_cap);
+    CUDA_CHECK(cudaMemcpy(payload_after.data(), state.payload_buf,
+                          payload_after.size(), cudaMemcpyDeviceToHost));
+    EXPECT(payload_after == payload_before);
+
+    const int32_t enabled = 1;
+    CUDA_CHECK(cudaMemcpy(gate, &enabled, sizeof(enabled),
+                          cudaMemcpyHostToDevice));
+    ring::launch_record_producer_static(
+        state, device, source.size(), gate, 1);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    expect_entry(state, gated_variants, source.size());
+    EXPECT(read_payload(state, state.task_entries[gated_variants]) == source);
+    EXPECT(*state.task_head == gated_variants + 1);
+    EXPECT(*state.payload_head == initial_payload_head +
+           ring::align_up(source.size(), ring::PAYLOAD_ALIGN));
+    EXPECT(*state.actual_bytes_counter == initial_actual_bytes + source.size());
+
+    CUDA_CHECK(cudaFree(gate));
+    CUDA_CHECK(cudaFree(device));
+}
+
 int main() {
     setbuf(stdout, nullptr);
     ring::set_ring_null_mode(false);
@@ -288,6 +441,9 @@ int main() {
     test_prefix_bounds();
     test_chunked_packed_copy();
     test_serialized_static_launches();
+    test_record_chunked_compacts_payload_head();
+    test_record_sequence_and_segmented_pack();
+    test_record_device_gate_publishes_zero_byte_entries();
 
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;

--- a/tests/native/ring/test_producer.cu
+++ b/tests/native/ring/test_producer.cu
@@ -316,14 +316,47 @@ static void test_record_chunked_compacts_payload_head() {
     CUDA_CHECK(cudaFree(device));
 }
 
+static void test_record_chunked_unaligned_boundaries() {
+    banner("record chunked producer copies unaligned chunk boundaries");
+    ring::AllocatedRing allocated(make_config());
+    allocated.init();
+    ring::RingState& state = allocated.state();
+
+    constexpr uint32_t chunks = 2;
+    constexpr uint64_t input_chunk = 33;
+    const std::vector<int64_t> selected = {17, 17};
+    const std::vector<uint8_t> source = pattern(chunks * input_chunk, 107);
+    std::vector<uint8_t> expected;
+    for (uint32_t chunk = 0; chunk < chunks; ++chunk) {
+        const auto begin = source.begin() + chunk * input_chunk;
+        expected.insert(expected.end(), begin, begin + selected[chunk]);
+    }
+
+    uint8_t* device = upload(source);
+    int64_t* device_selected = upload_counts(selected);
+    ring::launch_record_producer_chunked(
+        state, device, source.size(), device_selected, chunks,
+        nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    expect_entry(state, 0, expected.size());
+    EXPECT(read_payload(state, state.task_entries[0]) == expected);
+    EXPECT(*state.actual_bytes_counter == expected.size());
+    EXPECT(*state.payload_head ==
+           ring::align_up(expected.size(), ring::PAYLOAD_ALIGN));
+
+    CUDA_CHECK(cudaFree(device_selected));
+    CUDA_CHECK(cudaFree(device));
+}
+
 static void test_record_sequence_and_segmented_pack() {
     banner("record row packers preserve declared row order");
     ring::AllocatedRing allocated(make_config());
     allocated.init();
     ring::RingState& state = allocated.state();
 
-    // Source is [S=3, B=2, feature=4 bytes], one distinct byte pattern per row.
-    constexpr uint64_t feature_bytes = 4;
+    // Source is [S=3, B=2, feature=20 bytes], one distinct byte pattern per row.
+    constexpr uint64_t feature_bytes = 20;
     std::vector<uint8_t> source(3 * 2 * feature_bytes);
     for (uint64_t row = 0; row < 6; ++row) {
         std::fill(source.begin() + row * feature_bytes,
@@ -442,6 +475,7 @@ int main() {
     test_chunked_packed_copy();
     test_serialized_static_launches();
     test_record_chunked_compacts_payload_head();
+    test_record_chunked_unaligned_boundaries();
     test_record_sequence_and_segmented_pack();
     test_record_device_gate_publishes_zero_byte_entries();
 

--- a/tests/native/ring/test_record_consumer.cpp
+++ b/tests/native/ring/test_record_consumer.cpp
@@ -1,0 +1,186 @@
+#include "ring/record_consumer.h"
+
+#include <ATen/ATen.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT(condition)                                                   \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n",                    \
+                         __FILE__, __LINE__, #condition);                    \
+            ++g_fail;                                                       \
+        } else {                                                            \
+            ++g_pass;                                                       \
+        }                                                                   \
+    } while (0)
+
+static ring::PayloadSlice tensor_slice(uint64_t offset,
+                                       std::optional<uint64_t> length,
+                                       std::vector<int64_t> shape,
+                                       int32_t dynamic_dim = -1) {
+    ring::PayloadSlice slice;
+    slice.offset_bytes = offset;
+    slice.length_bytes = length;
+    slice.materialization = ring::PayloadMaterialization::TENSOR;
+    slice.dtype = static_cast<int32_t>(at::kFloat);
+    slice.logical_shape = std::move(shape);
+    slice.inferred_dynamic_dim = dynamic_dim;
+    return slice;
+}
+
+static at::Tensor byte_payload(const std::vector<float>& values) {
+    at::Tensor floats = at::tensor(values, at::TensorOptions().dtype(at::kFloat));
+    return floats.view(at::kByte).clone();
+}
+
+static ring::PayloadSlice scalar_slice(
+    uint64_t offset,
+    uint64_t length,
+    ring::PayloadMaterialization materialization,
+    at::ScalarType dtype) {
+    ring::PayloadSlice slice;
+    slice.offset_bytes = offset;
+    slice.length_bytes = length;
+    slice.materialization = materialization;
+    slice.dtype = static_cast<int32_t>(dtype);
+    return slice;
+}
+
+static void test_fifo_and_dynamic_tensor_materialization() {
+    std::printf("[ TEST ] record descriptor FIFO and dynamic tensor materialization\n");
+    std::vector<dmx_host::GenericRecordRow> submitted;
+    ring::RecordConsumer consumer(
+        [&](dmx_host::GenericRecordRow row, uint64_t) {
+            submitted.push_back(std::move(row));
+        });
+
+    ring::RecordDescriptor first;
+    first.layout = "layout_a";
+    first.rows = {{std::vector<ring::EncodedRecordCell>{
+        std::string("first"), int32_t(7), int64_t(11), 2.5,
+        std::vector<int64_t>{3, 4},
+        tensor_slice(0, std::nullopt, {-1, 2}, 0)}}};
+
+    ring::RecordDescriptor second;
+    second.layout = "layout_b";
+    second.rows = {{std::vector<ring::EncodedRecordCell>{
+        std::string("second"), tensor_slice(0, 8, {2})}}};
+
+    consumer.push_descriptors({first, second});
+    consumer.consume_payload(byte_payload({1, 2, 3, 4, 5, 6}));
+    consumer.consume_payload(byte_payload({9, 10}));
+    consumer.finish();
+
+    EXPECT(submitted.size() == 2);
+    EXPECT(submitted[0].layout == "layout_a");
+    EXPECT(submitted[1].layout == "layout_b");
+    EXPECT(std::get<std::string>(submitted[0].cells[0]) == "first");
+    EXPECT(std::get<int32_t>(submitted[0].cells[1]) == 7);
+    EXPECT(std::get<int64_t>(submitted[0].cells[2]) == 11);
+    EXPECT(std::get<double>(submitted[0].cells[3]) == 2.5);
+    const at::Tensor first_tensor =
+        std::get<at::Tensor>(submitted[0].cells[5]);
+    EXPECT(first_tensor.sizes().vec() == std::vector<int64_t>({3, 2}));
+    EXPECT(at::equal(first_tensor,
+                     at::tensor({1.f, 2.f, 3.f, 4.f, 5.f, 6.f})
+                         .reshape({3, 2})));
+    const at::Tensor second_tensor =
+        std::get<at::Tensor>(submitted[1].cells[1]);
+    EXPECT(at::equal(second_tensor, at::tensor({9.f, 10.f})));
+}
+
+static void test_zero_row_descriptor_consumes_zero_byte_task() {
+    std::printf("[ TEST ] zero-row descriptor consumes its zero-byte task\n");
+    std::vector<dmx_host::GenericRecordRow> submitted;
+    ring::RecordConsumer consumer(
+        [&](dmx_host::GenericRecordRow row, uint64_t) {
+            submitted.push_back(std::move(row));
+        });
+
+    ring::RecordDescriptor empty;
+    empty.layout = "filtered";
+    consumer.push_descriptor(std::move(empty));
+    consumer.consume_payload(at::empty(
+        {0}, at::TensorOptions().dtype(at::kByte).device(at::kCPU)));
+    consumer.finish();
+
+    EXPECT(submitted.empty());
+}
+
+static void test_scalar_materialization() {
+    std::printf("[ TEST ] floating and integer scalar materialization\n");
+    std::vector<dmx_host::GenericRecordRow> submitted;
+    ring::RecordConsumer consumer(
+        [&](dmx_host::GenericRecordRow row, uint64_t) {
+            submitted.push_back(std::move(row));
+        });
+
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "scalars";
+    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
+        scalar_slice(0, sizeof(float),
+                     ring::PayloadMaterialization::FLOAT_SCALAR, at::kFloat),
+        scalar_slice(8, sizeof(int64_t),
+                     ring::PayloadMaterialization::INT_SCALAR, at::kLong)}}};
+    consumer.push_descriptor(std::move(descriptor));
+
+    at::Tensor payload = at::zeros(
+        {16}, at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+    const float floating = 3.25f;
+    const int64_t integer = 41;
+    std::memcpy(payload.data_ptr<uint8_t>(), &floating, sizeof(floating));
+    std::memcpy(payload.data_ptr<uint8_t>() + 8, &integer, sizeof(integer));
+    consumer.consume_payload(payload);
+    consumer.finish();
+
+    EXPECT(submitted.size() == 1);
+    EXPECT(std::get<double>(submitted[0].cells[0]) == 3.25);
+    EXPECT(std::get<int64_t>(submitted[0].cells[1]) == 41);
+}
+
+static void test_exact_association_failures() {
+    std::printf("[ TEST ] descriptor/payload association failures\n");
+    ring::RecordConsumer missing(
+        [](dmx_host::GenericRecordRow, uint64_t) {});
+    bool missing_failed = false;
+    try {
+        missing.consume_payload(byte_payload({1}));
+    } catch (const std::runtime_error&) {
+        missing_failed = true;
+    }
+    EXPECT(missing_failed);
+
+    ring::RecordConsumer leftover(
+        [](dmx_host::GenericRecordRow, uint64_t) {});
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "leftover";
+    leftover.push_descriptor(std::move(descriptor));
+    bool leftover_failed = false;
+    try {
+        leftover.finish();
+    } catch (const std::runtime_error&) {
+        leftover_failed = true;
+    }
+    EXPECT(leftover_failed);
+}
+
+int main() {
+    setbuf(stdout, nullptr);
+    std::printf("test_record_consumer\n");
+    test_fifo_and_dynamic_tensor_materialization();
+    test_zero_row_descriptor_consumes_zero_byte_task();
+    test_scalar_materialization();
+    test_exact_association_failures();
+    std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/ring/test_record_consumer.cpp
+++ b/tests/native/ring/test_record_consumer.cpp
@@ -6,7 +6,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
-#include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -27,88 +27,80 @@ static int g_fail = 0;
         }                                                                   \
     } while (0)
 
-static ring::PayloadSlice tensor_slice(uint64_t offset,
-                                       std::optional<uint64_t> length,
-                                       std::vector<int64_t> shape,
-                                       int32_t dynamic_dim = -1) {
-    ring::PayloadSlice slice;
-    slice.offset_bytes = offset;
-    slice.length_bytes = length;
-    slice.materialization = ring::PayloadMaterialization::TENSOR;
-    slice.dtype = static_cast<int32_t>(at::kFloat);
-    slice.logical_shape = std::move(shape);
-    slice.inferred_dynamic_dim = dynamic_dim;
-    return slice;
-}
+class CapturingSink final : public ring::RecordSink {
+public:
+    void submit(ring::RecordEnvelope envelope) override {
+        submitted.push_back(std::move(envelope));
+    }
+
+    bool flush_and_wait(Duration timeout) override {
+        last_timeout = timeout;
+        ++flushes;
+        return true;
+    }
+
+    void rethrow_if_failed() const override {}
+
+    std::vector<ring::RecordEnvelope> submitted;
+    Duration last_timeout{0};
+    int flushes{0};
+};
+
+class FailingSink final : public ring::RecordSink {
+public:
+    void submit(ring::RecordEnvelope) override {
+        throw std::runtime_error("injected sink failure");
+    }
+
+    bool flush_and_wait(Duration) override { return true; }
+    void rethrow_if_failed() const override {}
+};
 
 static at::Tensor byte_payload(const std::vector<float>& values) {
-    at::Tensor floats = at::tensor(values, at::TensorOptions().dtype(at::kFloat));
-    return floats.view(at::kByte).clone();
+    return at::tensor(values, at::TensorOptions().dtype(at::kFloat))
+        .view(at::kByte)
+        .clone();
 }
 
-static ring::PayloadSlice scalar_slice(
-    uint64_t offset,
-    uint64_t length,
-    ring::PayloadMaterialization materialization,
-    at::ScalarType dtype) {
-    ring::PayloadSlice slice;
-    slice.offset_bytes = offset;
-    slice.length_bytes = length;
-    slice.materialization = materialization;
-    slice.dtype = static_cast<int32_t>(dtype);
-    return slice;
+static ring::RecordDescriptor descriptor(std::string layout,
+                                         std::string literal) {
+    ring::RecordDescriptor result;
+    result.layout = std::move(layout);
+    result.rows = {{std::vector<ring::EncodedRecordCell>{
+        std::move(literal), ring::PayloadSlice{}}}};
+    return result;
 }
 
-static void test_fifo_and_dynamic_tensor_materialization() {
-    std::printf("[ TEST ] record descriptor FIFO and dynamic tensor materialization\n");
-    std::vector<dmx_host::GenericRecordRow> submitted;
-    ring::RecordConsumer consumer(
-        [&](dmx_host::GenericRecordRow row, uint64_t) {
-            submitted.push_back(std::move(row));
-        });
+static void test_fifo_delivers_backend_neutral_envelopes() {
+    std::printf("[ TEST ] FIFO delivers raw descriptors and owned payloads\n");
+    auto sink = std::make_shared<CapturingSink>();
+    ring::RecordConsumer consumer(sink);
 
-    ring::RecordDescriptor first;
-    first.layout = "layout_a";
-    first.rows = {{std::vector<ring::EncodedRecordCell>{
-        std::string("first"), int32_t(7), int64_t(11), 2.5,
-        std::vector<int64_t>{3, 4},
-        tensor_slice(0, std::nullopt, {-1, 2}, 0)}}};
-
-    ring::RecordDescriptor second;
-    second.layout = "layout_b";
-    second.rows = {{std::vector<ring::EncodedRecordCell>{
-        std::string("second"), tensor_slice(0, 8, {2})}}};
-
-    consumer.push_descriptors({first, second});
-    consumer.consume_payload(byte_payload({1, 2, 3, 4, 5, 6}));
-    consumer.consume_payload(byte_payload({9, 10}));
+    consumer.push_descriptors({
+        descriptor("layout_a", "first"),
+        descriptor("layout_b", "second"),
+    });
+    consumer.consume_payload(byte_payload({1, 2}));
+    consumer.consume_payload(byte_payload({3, 4, 5}));
     consumer.finish();
 
-    EXPECT(submitted.size() == 2);
-    EXPECT(submitted[0].layout == "layout_a");
-    EXPECT(submitted[1].layout == "layout_b");
-    EXPECT(std::get<std::string>(submitted[0].cells[0]) == "first");
-    EXPECT(std::get<int32_t>(submitted[0].cells[1]) == 7);
-    EXPECT(std::get<int64_t>(submitted[0].cells[2]) == 11);
-    EXPECT(std::get<double>(submitted[0].cells[3]) == 2.5);
-    const at::Tensor first_tensor =
-        std::get<at::Tensor>(submitted[0].cells[5]);
-    EXPECT(first_tensor.sizes().vec() == std::vector<int64_t>({3, 2}));
-    EXPECT(at::equal(first_tensor,
-                     at::tensor({1.f, 2.f, 3.f, 4.f, 5.f, 6.f})
-                         .reshape({3, 2})));
-    const at::Tensor second_tensor =
-        std::get<at::Tensor>(submitted[1].cells[1]);
-    EXPECT(at::equal(second_tensor, at::tensor({9.f, 10.f})));
+    EXPECT(sink->submitted.size() == 2);
+    EXPECT(sink->submitted[0].descriptor.layout == "layout_a");
+    EXPECT(sink->submitted[1].descriptor.layout == "layout_b");
+    EXPECT(std::get<std::string>(
+               sink->submitted[0].descriptor.rows[0].cells[0]) == "first");
+    EXPECT(at::equal(
+        sink->submitted[0].payload.view(at::kFloat),
+        at::tensor({1.f, 2.f})));
+    EXPECT(at::equal(
+        sink->submitted[1].payload.view(at::kFloat),
+        at::tensor({3.f, 4.f, 5.f})));
 }
 
-static void test_zero_row_descriptor_consumes_zero_byte_task() {
+static void test_zero_row_descriptor_consumes_without_sink_submission() {
     std::printf("[ TEST ] zero-row descriptor consumes its zero-byte task\n");
-    std::vector<dmx_host::GenericRecordRow> submitted;
-    ring::RecordConsumer consumer(
-        [&](dmx_host::GenericRecordRow row, uint64_t) {
-            submitted.push_back(std::move(row));
-        });
+    auto sink = std::make_shared<CapturingSink>();
+    ring::RecordConsumer consumer(sink);
 
     ring::RecordDescriptor empty;
     empty.layout = "filtered";
@@ -117,44 +109,13 @@ static void test_zero_row_descriptor_consumes_zero_byte_task() {
         {0}, at::TensorOptions().dtype(at::kByte).device(at::kCPU)));
     consumer.finish();
 
-    EXPECT(submitted.empty());
-}
-
-static void test_scalar_materialization() {
-    std::printf("[ TEST ] floating and integer scalar materialization\n");
-    std::vector<dmx_host::GenericRecordRow> submitted;
-    ring::RecordConsumer consumer(
-        [&](dmx_host::GenericRecordRow row, uint64_t) {
-            submitted.push_back(std::move(row));
-        });
-
-    ring::RecordDescriptor descriptor;
-    descriptor.layout = "scalars";
-    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
-        scalar_slice(0, sizeof(float),
-                     ring::PayloadMaterialization::FLOAT_SCALAR, at::kFloat),
-        scalar_slice(8, sizeof(int64_t),
-                     ring::PayloadMaterialization::INT_SCALAR, at::kLong)}}};
-    consumer.push_descriptor(std::move(descriptor));
-
-    at::Tensor payload = at::zeros(
-        {16}, at::TensorOptions().dtype(at::kByte).device(at::kCPU));
-    const float floating = 3.25f;
-    const int64_t integer = 41;
-    std::memcpy(payload.data_ptr<uint8_t>(), &floating, sizeof(floating));
-    std::memcpy(payload.data_ptr<uint8_t>() + 8, &integer, sizeof(integer));
-    consumer.consume_payload(payload);
-    consumer.finish();
-
-    EXPECT(submitted.size() == 1);
-    EXPECT(std::get<double>(submitted[0].cells[0]) == 3.25);
-    EXPECT(std::get<int64_t>(submitted[0].cells[1]) == 41);
+    EXPECT(sink->submitted.empty());
 }
 
 static void test_exact_association_failures() {
     std::printf("[ TEST ] descriptor/payload association failures\n");
-    ring::RecordConsumer missing(
-        [](dmx_host::GenericRecordRow, uint64_t) {});
+    auto sink = std::make_shared<CapturingSink>();
+    ring::RecordConsumer missing(sink);
     bool missing_failed = false;
     try {
         missing.consume_payload(byte_payload({1}));
@@ -163,11 +124,10 @@ static void test_exact_association_failures() {
     }
     EXPECT(missing_failed);
 
-    ring::RecordConsumer leftover(
-        [](dmx_host::GenericRecordRow, uint64_t) {});
-    ring::RecordDescriptor descriptor;
-    descriptor.layout = "leftover";
-    leftover.push_descriptor(std::move(descriptor));
+    ring::RecordConsumer leftover(sink);
+    ring::RecordDescriptor pending;
+    pending.layout = "leftover";
+    leftover.push_descriptor(std::move(pending));
     bool leftover_failed = false;
     try {
         leftover.finish();
@@ -175,19 +135,22 @@ static void test_exact_association_failures() {
         leftover_failed = true;
     }
     EXPECT(leftover_failed);
+
+    ring::RecordConsumer unconfigured(nullptr);
+    unconfigured.push_descriptor(descriptor("events", "record"));
+    bool missing_sink_failed = false;
+    try {
+        unconfigured.consume_payload(byte_payload({1}));
+    } catch (const std::runtime_error&) {
+        missing_sink_failed = true;
+    }
+    EXPECT(missing_sink_failed);
 }
 
 static void test_submit_failure_precedes_durable_idle() {
     std::printf("[ TEST ] submit failure precedes durable idle\n");
-    ring::RecordConsumer consumer(
-        [](dmx_host::GenericRecordRow, uint64_t) {
-            throw std::runtime_error("injected submit failure");
-        });
-    ring::RecordDescriptor descriptor;
-    descriptor.layout = "submit_failure";
-    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
-        tensor_slice(0, sizeof(float), {1})}}};
-    consumer.push_descriptor(std::move(descriptor));
+    ring::RecordConsumer consumer(std::make_shared<FailingSink>());
+    consumer.push_descriptor(descriptor("submit_failure", "record"));
 
     constexpr int kWaiters = 64;
     std::atomic<int> ready{0};
@@ -232,9 +195,8 @@ static void test_submit_failure_precedes_durable_idle() {
 int main() {
     setbuf(stdout, nullptr);
     std::printf("test_record_consumer\n");
-    test_fifo_and_dynamic_tensor_materialization();
-    test_zero_row_descriptor_consumes_zero_byte_task();
-    test_scalar_materialization();
+    test_fifo_delivers_backend_neutral_envelopes();
+    test_zero_row_descriptor_consumes_without_sink_submission();
     test_exact_association_failures();
     test_submit_failure_precedes_durable_idle();
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);

--- a/tests/native/ring/test_record_consumer.cpp
+++ b/tests/native/ring/test_record_consumer.cpp
@@ -2,11 +2,14 @@
 
 #include <ATen/ATen.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -174,6 +177,58 @@ static void test_exact_association_failures() {
     EXPECT(leftover_failed);
 }
 
+static void test_submit_failure_precedes_durable_idle() {
+    std::printf("[ TEST ] submit failure precedes durable idle\n");
+    ring::RecordConsumer consumer(
+        [](dmx_host::GenericRecordRow, uint64_t) {
+            throw std::runtime_error("injected submit failure");
+        });
+    ring::RecordDescriptor descriptor;
+    descriptor.layout = "submit_failure";
+    descriptor.rows = {{std::vector<ring::EncodedRecordCell>{
+        tensor_slice(0, sizeof(float), {1})}}};
+    consumer.push_descriptor(std::move(descriptor));
+
+    constexpr int kWaiters = 64;
+    std::atomic<int> ready{0};
+    std::atomic<int> observed_failures{0};
+    std::atomic<int> false_successes{0};
+    std::atomic<int> timeouts{0};
+    std::vector<std::thread> waiters;
+    waiters.reserve(kWaiters);
+    for (int index = 0; index < kWaiters; ++index) {
+        waiters.emplace_back([&] {
+            ready.fetch_add(1, std::memory_order_release);
+            try {
+                if (!consumer.wait_until_idle(std::chrono::seconds(5))) {
+                    timeouts.fetch_add(1, std::memory_order_relaxed);
+                    return;
+                }
+                consumer.finish();
+                false_successes.fetch_add(1, std::memory_order_relaxed);
+            } catch (const std::runtime_error&) {
+                observed_failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != kWaiters) {
+        std::this_thread::yield();
+    }
+
+    bool consume_failed = false;
+    try {
+        consumer.consume_payload(byte_payload({1}));
+    } catch (const std::runtime_error&) {
+        consume_failed = true;
+    }
+    for (auto& waiter : waiters) waiter.join();
+
+    EXPECT(consume_failed);
+    EXPECT(observed_failures.load(std::memory_order_relaxed) == kWaiters);
+    EXPECT(false_successes.load(std::memory_order_relaxed) == 0);
+    EXPECT(timeouts.load(std::memory_order_relaxed) == 0);
+}
+
 int main() {
     setbuf(stdout, nullptr);
     std::printf("test_record_consumer\n");
@@ -181,6 +236,7 @@ int main() {
     test_zero_row_descriptor_consumes_zero_byte_task();
     test_scalar_materialization();
     test_exact_association_failures();
+    test_submit_failure_precedes_durable_idle();
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/native/ring/test_ring_engine.cu
+++ b/tests/native/ring/test_ring_engine.cu
@@ -4,7 +4,10 @@
 #include "ring/pinned_staging.h"
 #include "ring/producer.cuh"
 #include "ring/ring_alloc.h"
+#include "ring/ring_engine_py.h"
 
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <cuda_runtime.h>
 
 #include <atomic>
@@ -20,6 +23,11 @@
 
 static int g_pass = 0;
 static int g_fail = 0;
+
+// RingEnginePy's diagnostic hooks are irrelevant to this focused native
+// executable; the extension supplies their real definitions.
+void ring_diag_reset_host_counters() {}
+void ring_diag_print_host_counters() {}
 
 #define CUDA_CHECK(expr)                                                    \
     do {                                                                    \
@@ -243,6 +251,142 @@ static void test_zero_byte_delivery() {
     harness.release(task);
 }
 
+static void test_record_reservation_reclaims_after_group_completion() {
+    banner("record reservation reclaims only after every grouped task is ready");
+    DrainHarness harness(make_config());
+
+    constexpr uint64_t row_bytes = 32;
+    const std::vector<uint8_t> dynamic_source = pattern(256, 111);
+    const std::vector<uint8_t> fixed_source = pattern(64, 137);
+    uint8_t* dynamic_device = upload(dynamic_source, harness.stream);
+    uint8_t* fixed_device = upload(fixed_source, harness.stream);
+    int64_t row_count = 1;
+    int64_t* device_count = nullptr;
+    CUDA_CHECK(cudaMalloc(&device_count, sizeof(row_count)));
+    CUDA_CHECK(cudaMemcpyAsync(device_count, &row_count, sizeof(row_count),
+                               cudaMemcpyHostToDevice, harness.stream));
+
+    const uint64_t upper =
+        ring::align_up(dynamic_source.size(), ring::PAYLOAD_ALIGN) +
+        ring::align_up(fixed_source.size(), ring::PAYLOAD_ALIGN);
+    harness.drain->reserve_record(upper, 2);
+
+    ring::launch_record_producer_prefix(
+        harness.allocated.state(), dynamic_device, dynamic_source.size(),
+        device_count, row_bytes, nullptr, 0, harness.stream);
+    ring::DrainTask first = harness.flush_one();
+    EXPECT(first.tensor_total_bytes == row_bytes);
+    EXPECT(harness.drain->cpu_payload_head() == upper);
+    EXPECT(harness.drain->pending_record_reservations() == 1);
+    EXPECT(harness.drain->reclaimed_record_bytes() == 0);
+    harness.release(first);
+
+    ring::launch_record_producer_static(
+        harness.allocated.state(), fixed_device, fixed_source.size(),
+        nullptr, 0, harness.stream);
+    ring::DrainTask second = harness.flush_one();
+    const uint64_t actual_aligned =
+        ring::align_up(row_bytes, ring::PAYLOAD_ALIGN) +
+        ring::align_up(fixed_source.size(), ring::PAYLOAD_ALIGN);
+    EXPECT(second.tensor_total_bytes == fixed_source.size());
+    EXPECT(harness.drain->pending_record_reservations() == 0);
+    EXPECT(harness.drain->cpu_payload_head() == actual_aligned);
+    EXPECT(harness.drain->cpu_payload_tail_committed() == actual_aligned);
+    EXPECT(harness.drain->reclaimed_record_bytes() == upper - actual_aligned);
+    harness.drain->rethrow_record_reclaim_failure();
+    harness.release(second);
+
+    CUDA_CHECK(cudaFree(device_count));
+    CUDA_CHECK(cudaFree(fixed_device));
+    CUDA_CHECK(cudaFree(dynamic_device));
+}
+
+static void test_false_gated_record_reclaims_its_full_reservation() {
+    banner("false-gated record publishes and reclaims a zero-byte task");
+    DrainHarness harness(make_config());
+
+    const std::vector<uint8_t> source = pattern(64, 173);
+    uint8_t* device = upload(source, harness.stream);
+    int32_t* gate = nullptr;
+    const int32_t disabled = 0;
+    CUDA_CHECK(cudaMalloc(&gate, sizeof(disabled)));
+    CUDA_CHECK(cudaMemcpyAsync(gate, &disabled, sizeof(disabled),
+                               cudaMemcpyHostToDevice, harness.stream));
+
+    const uint64_t reserved =
+        ring::align_up(source.size(), ring::PAYLOAD_ALIGN);
+    harness.drain->reserve_record(reserved, 1);
+    ring::launch_record_producer_static(
+        harness.allocated.state(), device, source.size(), gate, 1,
+        harness.stream);
+    ring::DrainTask task = harness.flush_one();
+
+    EXPECT(task.tensor_total_bytes == 0);
+    EXPECT(task.alloc_bytes == 0);
+    EXPECT(harness.drain->pending_record_reservations() == 0);
+    EXPECT(harness.drain->cpu_payload_head() == 0);
+    EXPECT(harness.drain->cpu_payload_tail_committed() == 0);
+    EXPECT(harness.drain->reclaimed_record_bytes() == reserved);
+    harness.drain->rethrow_record_reclaim_failure();
+    harness.release(task);
+
+    CUDA_CHECK(cudaFree(gate));
+    CUDA_CHECK(cudaFree(device));
+}
+
+static void test_timed_drain_flush_uses_request_generations() {
+    banner("timed drain flush does not reuse another request generation");
+    ring::RingConfig cfg = make_config(512);
+    cfg.pinned_staging_bytes = 256;
+    DrainHarness harness(cfg);
+
+    const std::vector<uint8_t> first_source = pattern(256, 191);
+    uint8_t* first_device = upload(first_source, harness.stream);
+    harness.drain->reserve(first_source.size(), 1);
+    ring::launch_producer_static(
+        harness.allocated.state(), first_device, first_source.size(), 0,
+        harness.stream);
+    ring::DrainTask first = harness.flush_one();
+
+    // Keep the first task's staging allocation outstanding so the next flush
+    // generation has a deterministic wait point inside the drain worker.
+    const std::vector<uint8_t> second_source = pattern(64, 211);
+    uint8_t* second_device = upload(second_source, harness.stream);
+    harness.drain->reserve(second_source.size(), 1);
+    ring::launch_producer_static(
+        harness.allocated.state(), second_device, second_source.size(), 0,
+        harness.stream);
+    CUDA_CHECK(cudaStreamSynchronize(harness.stream));
+
+    const bool blocked_generation_completed =
+        harness.drain->force_flush_and_wait_until(
+            std::chrono::steady_clock::now() +
+            std::chrono::milliseconds(25));
+    EXPECT(!blocked_generation_completed);
+
+    harness.release(first);
+    bool next_generation_completed =
+        harness.drain->force_flush_and_wait_until(
+            std::chrono::steady_clock::now() + std::chrono::seconds(2));
+    EXPECT(next_generation_completed);
+    if (!next_generation_completed) {
+        harness.drain->force_flush_and_wait();
+    }
+
+    const uint64_t count = harness.drain->wait_for_tasks();
+    EXPECT(count == 1);
+    std::vector<ring::DrainTask> tasks;
+    harness.drain->pop_tasks(count, tasks);
+    EXPECT(tasks.size() == 1);
+    if (!tasks.empty()) {
+        EXPECT(task_bytes(tasks.front()) == second_source);
+        harness.release(tasks.front());
+    }
+
+    CUDA_CHECK(cudaFree(second_device));
+    CUDA_CHECK(cudaFree(first_device));
+}
+
 struct BlockingCallbackState {
     std::atomic<bool> entered{false};
     std::atomic<bool> release{false};
@@ -325,6 +469,75 @@ static void test_drain_worker_binds_owner_device() {
     EXPECT(stopped_without_waiting_for_device_zero);
 }
 
+static void test_record_flush_bounds_current_stream_prefix_wait() {
+    banner("record flush bounds its exact current-stream prefix wait");
+
+    const c10::cuda::CUDAStream test_stream =
+        c10::cuda::getStreamFromPool();
+    c10::cuda::CUDAStreamGuard stream_guard(test_stream);
+
+    ring_py::RingConfig cfg;
+    cfg.task_ring_entries = 16;
+    cfg.payload_ring_bytes = 4096;
+    cfg.pinned_staging_bytes = 4096;
+    cfg.drain_poll_timeout_us = 100;
+    ring_py::RingEnginePy engine(cfg, ring_py::RecordSubmitFn{});
+    engine.init();
+    engine.start();
+
+    BlockingCallbackState callback;
+    cudaStream_t stream = test_stream.stream();
+    CUDA_CHECK(cudaLaunchHostFunc(stream, blocking_host_callback, &callback));
+
+    const auto callback_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!callback.entered.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < callback_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool callback_entered =
+        callback.entered.load(std::memory_order_acquire);
+    EXPECT(callback_entered);
+
+    bool completed = true;
+    bool threw = false;
+    std::chrono::steady_clock::duration elapsed{};
+    if (callback_entered) {
+        std::atomic<bool> flush_returned{false};
+        std::thread watchdog([&] {
+            const auto watchdog_deadline =
+                std::chrono::steady_clock::now() +
+                std::chrono::milliseconds(500);
+            while (!flush_returned.load(std::memory_order_acquire) &&
+                   std::chrono::steady_clock::now() < watchdog_deadline) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            callback.release.store(true, std::memory_order_release);
+        });
+
+        const auto started = std::chrono::steady_clock::now();
+        try {
+            completed = engine.flush_records_and_wait(20);
+        } catch (...) {
+            threw = true;
+        }
+        elapsed = std::chrono::steady_clock::now() - started;
+        flush_returned.store(true, std::memory_order_release);
+        callback.release.store(true, std::memory_order_release);
+        watchdog.join();
+    } else {
+        callback.release.store(true, std::memory_order_release);
+    }
+
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    EXPECT(!threw);
+    if (!threw && callback_entered) {
+        EXPECT(!completed);
+        EXPECT(elapsed < std::chrono::milliseconds(250));
+    }
+    engine.stop();
+}
+
 int main() {
     setbuf(stdout, nullptr);
     ring::set_ring_null_mode(false);
@@ -335,7 +548,11 @@ int main() {
     test_prefix_force_flush();
     test_repeated_wrap_delivery();
     test_zero_byte_delivery();
+    test_record_reservation_reclaims_after_group_completion();
+    test_false_gated_record_reclaims_its_full_reservation();
+    test_timed_drain_flush_uses_request_generations();
     test_drain_worker_binds_owner_device();
+    test_record_flush_bounds_current_stream_prefix_wait();
 
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;

--- a/tests/native/ring/test_ring_engine.cu
+++ b/tests/native/ring/test_ring_engine.cu
@@ -5,6 +5,7 @@
 #include "ring/producer.cuh"
 #include "ring/ring_alloc.h"
 #include "ring/ring_engine_py.h"
+#include "ring/record_sink.h"
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -23,6 +24,24 @@
 
 static int g_pass = 0;
 static int g_fail = 0;
+
+class TrackingRecordSink final : public ring::RecordSink {
+public:
+    void submit(ring::RecordEnvelope) override { ++submissions; }
+
+    bool flush_and_wait(Duration timeout) override {
+        observed_timeout = timeout;
+        ++flushes;
+        return true;
+    }
+
+    void rethrow_if_failed() const override { ++failure_checks; }
+
+    std::atomic<int> submissions{0};
+    std::atomic<int> flushes{0};
+    mutable std::atomic<int> failure_checks{0};
+    Duration observed_timeout{0};
+};
 
 // RingEnginePy's diagnostic hooks are irrelevant to this focused native
 // executable; the extension supplies their real definitions.
@@ -486,7 +505,8 @@ static void test_record_flush_bounds_current_stream_prefix_wait() {
     cfg.payload_ring_bytes = 4096;
     cfg.pinned_staging_bytes = 4096;
     cfg.drain_poll_timeout_us = 100;
-    ring_py::RingEnginePy engine(cfg, ring_py::RecordSubmitFn{});
+    ring_py::RingEnginePy engine(
+        cfg, std::shared_ptr<ring::RecordSink>{});
     engine.init();
     engine.start();
 
@@ -543,6 +563,30 @@ static void test_record_flush_bounds_current_stream_prefix_wait() {
     engine.stop();
 }
 
+static void test_record_flush_reaches_sink_durability_boundary() {
+    banner("record flush reaches the configured sink boundary");
+
+    ring_py::RingConfig cfg;
+    cfg.task_ring_entries = 16;
+    cfg.payload_ring_bytes = 4096;
+    cfg.pinned_staging_bytes = 4096;
+    cfg.drain_poll_timeout_us = 100;
+    auto sink = std::make_shared<TrackingRecordSink>();
+    ring_py::RingEnginePy engine(cfg, sink);
+    engine.init();
+    engine.start();
+
+    const bool completed = engine.flush_records_and_wait(1000);
+
+    EXPECT(completed);
+    EXPECT(sink->submissions.load(std::memory_order_acquire) == 0);
+    EXPECT(sink->flushes.load(std::memory_order_acquire) == 1);
+    EXPECT(sink->failure_checks.load(std::memory_order_acquire) == 2);
+    EXPECT(sink->observed_timeout > std::chrono::milliseconds(0));
+    EXPECT(sink->observed_timeout <= std::chrono::milliseconds(1000));
+    engine.stop();
+}
+
 int main() {
     setbuf(stdout, nullptr);
     ring::set_ring_null_mode(false);
@@ -558,6 +602,7 @@ int main() {
     test_timed_drain_flush_uses_request_generations();
     test_drain_worker_binds_owner_device();
     test_record_flush_bounds_current_stream_prefix_wait();
+    test_record_flush_reaches_sink_durability_boundary();
 
     std::printf("Results: %d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;

--- a/tests/native/ring/test_ring_engine.cu
+++ b/tests/native/ring/test_ring_engine.cu
@@ -251,8 +251,8 @@ static void test_zero_byte_delivery() {
     harness.release(task);
 }
 
-static void test_record_reservation_reclaims_after_group_completion() {
-    banner("record reservation reclaims only after every grouped task is ready");
+static void test_record_reservation_reclaims_per_entry() {
+    banner("record reservation reclaims each possibly-short task independently");
     DrainHarness harness(make_config());
 
     constexpr uint64_t row_bytes = 32;
@@ -266,10 +266,15 @@ static void test_record_reservation_reclaims_after_group_completion() {
     CUDA_CHECK(cudaMemcpyAsync(device_count, &row_count, sizeof(row_count),
                                cudaMemcpyHostToDevice, harness.stream));
 
-    const uint64_t upper =
-        ring::align_up(dynamic_source.size(), ring::PAYLOAD_ALIGN) +
+    const uint64_t dynamic_upper =
+        ring::align_up(dynamic_source.size(), ring::PAYLOAD_ALIGN);
+    const uint64_t fixed_bytes =
         ring::align_up(fixed_source.size(), ring::PAYLOAD_ALIGN);
-    harness.drain->reserve_record(upper, 2);
+    const uint64_t upper = dynamic_upper + fixed_bytes;
+    harness.drain->reserve_record({
+        {dynamic_upper, true},
+        {fixed_bytes, false},
+    });
 
     ring::launch_record_producer_prefix(
         harness.allocated.state(), dynamic_device, dynamic_source.size(),
@@ -277,22 +282,21 @@ static void test_record_reservation_reclaims_after_group_completion() {
     ring::DrainTask first = harness.flush_one();
     EXPECT(first.tensor_total_bytes == row_bytes);
     EXPECT(harness.drain->cpu_payload_head() == upper);
-    EXPECT(harness.drain->pending_record_reservations() == 1);
-    EXPECT(harness.drain->reclaimed_record_bytes() == 0);
+    EXPECT(harness.drain->pending_record_reclaims() == 0);
+    harness.drain->apply_pending_record_reclaims();
+    const uint64_t actual_aligned =
+        ring::align_up(row_bytes, ring::PAYLOAD_ALIGN) + fixed_bytes;
+    EXPECT(harness.drain->cpu_payload_head() == actual_aligned);
     harness.release(first);
 
     ring::launch_record_producer_static(
         harness.allocated.state(), fixed_device, fixed_source.size(),
         nullptr, 0, harness.stream);
     ring::DrainTask second = harness.flush_one();
-    const uint64_t actual_aligned =
-        ring::align_up(row_bytes, ring::PAYLOAD_ALIGN) +
-        ring::align_up(fixed_source.size(), ring::PAYLOAD_ALIGN);
     EXPECT(second.tensor_total_bytes == fixed_source.size());
-    EXPECT(harness.drain->pending_record_reservations() == 0);
+    EXPECT(harness.drain->pending_record_reclaims() == 0);
     EXPECT(harness.drain->cpu_payload_head() == actual_aligned);
     EXPECT(harness.drain->cpu_payload_tail_committed() == actual_aligned);
-    EXPECT(harness.drain->reclaimed_record_bytes() == upper - actual_aligned);
     harness.drain->rethrow_record_reclaim_failure();
     harness.release(second);
 
@@ -315,7 +319,7 @@ static void test_false_gated_record_reclaims_its_full_reservation() {
 
     const uint64_t reserved =
         ring::align_up(source.size(), ring::PAYLOAD_ALIGN);
-    harness.drain->reserve_record(reserved, 1);
+    harness.drain->reserve_record({{reserved, true}});
     ring::launch_record_producer_static(
         harness.allocated.state(), device, source.size(), gate, 1,
         harness.stream);
@@ -323,10 +327,11 @@ static void test_false_gated_record_reclaims_its_full_reservation() {
 
     EXPECT(task.tensor_total_bytes == 0);
     EXPECT(task.alloc_bytes == 0);
-    EXPECT(harness.drain->pending_record_reservations() == 0);
+    EXPECT(harness.drain->pending_record_reclaims() == 0);
+    EXPECT(harness.drain->cpu_payload_head() == reserved);
+    harness.drain->apply_pending_record_reclaims();
     EXPECT(harness.drain->cpu_payload_head() == 0);
     EXPECT(harness.drain->cpu_payload_tail_committed() == 0);
-    EXPECT(harness.drain->reclaimed_record_bytes() == reserved);
     harness.drain->rethrow_record_reclaim_failure();
     harness.release(task);
 
@@ -548,7 +553,7 @@ int main() {
     test_prefix_force_flush();
     test_repeated_wrap_delivery();
     test_zero_byte_delivery();
-    test_record_reservation_reclaims_after_group_completion();
+    test_record_reservation_reclaims_per_entry();
     test_false_gated_record_reclaims_its_full_reservation();
     test_timed_drain_flush_uses_request_generations();
     test_drain_worker_binds_owner_device();

--- a/tests/native/test_durable_flush.cpp
+++ b/tests/native/test_durable_flush.cpp
@@ -1,0 +1,109 @@
+#include "pipelined_engine.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct Item {
+  std::uint64_t value = 0;
+  std::uint64_t size() const { return sizeof(value); }
+};
+
+using Engine = dmx_host::PipelinedEngine<Item, std::uint64_t, 1>;
+
+Engine::StageConfig MakeBufferedStage(std::vector<std::uint64_t>* observed,
+                                      std::mutex* observed_mu) {
+  Engine::StageConfig stage;
+  stage.name = "sink";
+  stage.parallelism = 2;
+  stage.input_queue.min_batch_items.reset();
+  stage.input_queue.min_batch_size = 1U << 20;
+  stage.input_queue.max_linger.reset();
+  stage.process_fn = [observed, observed_mu](
+      std::vector<Item> batch, Engine::QueueT*)
+      -> std::optional<std::vector<Item>> {
+    std::lock_guard<std::mutex> lock(*observed_mu);
+    for (const auto& item : batch) observed->push_back(item.value);
+    return std::vector<Item>{};
+  };
+  return stage;
+}
+
+void CheckNonterminalDurableFlush() {
+  std::vector<std::uint64_t> observed;
+  std::mutex observed_mu;
+  Engine engine(
+      std::array<Engine::StageConfig, 1>{
+          MakeBufferedStage(&observed, &observed_mu)});
+  engine.start();
+
+  engine.submit_items({Item{1}, Item{2}, Item{3}});
+  assert(engine.flush_and_wait(Engine::Duration(1.0)));
+  {
+    std::lock_guard<std::mutex> lock(observed_mu);
+    assert(observed.size() == 3);
+  }
+
+  // A successful flush is nonterminal: later submission and another flush
+  // must use the same workers and queue.
+  engine.submit_items({Item{4}});
+  assert(engine.flush_and_wait(Engine::Duration(1.0)));
+  {
+    std::lock_guard<std::mutex> lock(observed_mu);
+    assert(observed.size() == 4);
+  }
+  assert(engine.stop(true, Engine::Duration(1.0)));
+}
+
+void CheckWorkerFailureReachesFlushCaller() {
+  Engine::StageConfig stage;
+  stage.name = "failing_sink";
+  stage.parallelism = 1;
+  stage.process_fn = [](std::vector<Item>, Engine::QueueT*)
+      -> std::optional<std::vector<Item>> {
+    throw std::runtime_error("injected durable sink failure");
+  };
+
+  Engine engine(std::array<Engine::StageConfig, 1>{std::move(stage)});
+  engine.start();
+  engine.submit_items({Item{1}});
+  bool raised = false;
+  try {
+    (void)engine.flush_and_wait(Engine::Duration(1.0));
+  } catch (const std::runtime_error&) {
+    raised = true;
+  }
+  assert(raised);
+  assert(!engine.failures().empty());
+}
+
+void CheckDeadline() {
+  Engine::StageConfig stage;
+  stage.name = "slow_sink";
+  stage.parallelism = 1;
+  stage.process_fn = [](std::vector<Item>, Engine::QueueT*)
+      -> std::optional<std::vector<Item>> {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    return std::vector<Item>{};
+  };
+
+  Engine engine(std::array<Engine::StageConfig, 1>{std::move(stage)});
+  engine.start();
+  engine.submit_items({Item{1}});
+  assert(!engine.flush_and_wait(Engine::Duration(0.001)));
+}
+
+}  // namespace
+
+int main() {
+  CheckNonterminalDurableFlush();
+  CheckWorkerFailureReachesFlushCaller();
+  CheckDeadline();
+  return 0;
+}

--- a/tests/test_actual_byte_reclaim.py
+++ b/tests/test_actual_byte_reclaim.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from dmi.hooks.dynamic import HookOutput, TransportSpec, TransportType
+from dmi.hooks.record import HookOutput, TransportSpec, TransportType
 from dmi.hooks.producer_plan import ProducerPlanBuilder
 from dmi.transport.ring import RingTransport
 

--- a/tests/test_actual_byte_reclaim.py
+++ b/tests/test_actual_byte_reclaim.py
@@ -33,18 +33,19 @@ def test_dynamic_plan_reserves_upper_bound_not_current_device_count():
     assert entry.task_count == 1
 
 
-def test_record_transport_delegates_one_upper_bound_reservation_group():
+def test_record_transport_delegates_ordered_per_entry_reservations():
     calls = []
 
     class _Ring:
         def payload_tensor(self):
             return torch.empty(0, dtype=torch.uint8)
 
-        def reserve_record(self, nbytes, tasks):
-            calls.append((nbytes, tasks))
+        def reserve_record(self, items):
+            calls.append(items)
             return 0
 
     transport = RingTransport(_Ring())
 
-    assert transport.reserve_record(256, 1) == 0
-    assert calls == [(256, 1)]
+    items = ((64, False), (256, True))
+    assert transport.reserve_record(items) == 0
+    assert calls == [items]

--- a/tests/test_actual_byte_reclaim.py
+++ b/tests/test_actual_byte_reclaim.py
@@ -1,0 +1,50 @@
+"""Reservation-side contract for dynamic actual-byte reclamation."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dmi.hooks.dynamic import HookOutput, TransportSpec, TransportType
+from dmi.hooks.producer_plan import ProducerPlanBuilder
+from dmi.transport.ring import RingTransport
+
+pytestmark = pytest.mark.cpu
+
+
+def test_dynamic_plan_reserves_upper_bound_not_current_device_count():
+    output = HookOutput(
+        torch.empty(64, dtype=torch.float32),
+        (torch.tensor([8, 16, 0, 4], dtype=torch.int64),),
+    )
+    entry = ProducerPlanBuilder().record_output(
+        output_id=1 << 16,
+        output_spec=TransportSpec(
+            "packed",
+            transport_type=TransportType.CHUNKED,
+            reservation_upper_bytes=256,
+            output_shape=(-1,),
+        ),
+        output=output,
+    )
+
+    assert entry.reservation_upper_bytes == 256
+    assert entry.aligned_reservation_bytes == 256
+    assert entry.task_count == 1
+
+
+def test_record_transport_delegates_one_upper_bound_reservation_group():
+    calls = []
+
+    class _Ring:
+        def payload_tensor(self):
+            return torch.empty(0, dtype=torch.uint8)
+
+        def reserve_record(self, nbytes, tasks):
+            calls.append((nbytes, tasks))
+            return 0
+
+    transport = RingTransport(_Ring())
+
+    assert transport.reserve_record(256, 1) == 0
+    assert calls == [(256, 1)]

--- a/tests/test_clickhouse_record_storage.py
+++ b/tests/test_clickhouse_record_storage.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+import uuid
+
+import pytest
+import torch
+
+from tests._requirements import require_clickhouse, require_native_backend
+
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.native_backend,
+    require_clickhouse(),
+    require_native_backend(),
+]
+
+
+@contextmanager
+def _engine_table_cleanup(engine, client, tables, *, graceful):
+    def finish():
+        if not engine.stop(graceful, 10.0):
+            raise AssertionError("ClickHouse test engine did not stop within 10s")
+
+        drop_failures = []
+        for table in tables:
+            try:
+                client.execute(f"DROP TABLE IF EXISTS `{table}`")
+            except Exception as exc:
+                drop_failures.append((table, exc))
+        if len(drop_failures) == 1:
+            raise drop_failures[0][1]
+        if drop_failures:
+            detail = "; ".join(
+                f"{table}: {error}" for table, error in drop_failures
+            )
+            raise RuntimeError(f"failed to drop ClickHouse test tables: {detail}") from (
+                drop_failures[0][1]
+            )
+
+    try:
+        yield
+    except BaseException as body_error:
+        try:
+            finish()
+        except BaseException as cleanup_error:
+            raise body_error from cleanup_error
+        raise
+    else:
+        finish()
+
+
+def test_schema_driven_rows_round_trip_with_tensor_expansion():
+    clickhouse_driver = pytest.importorskip("clickhouse_driver")
+    from dmi.api.v1 import RecordCellType, RecordColumn, RecordLayout, RecordSchema
+    from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
+
+    tensor_table = f"dmi_record_tensor_{uuid.uuid4().hex[:12]}"
+    schema = RecordSchema(
+        (
+            RecordLayout(
+                name="tensor",
+                table=tensor_table,
+                columns=(
+                    RecordColumn("run", RecordCellType.STRING),
+                    RecordColumn("rank", RecordCellType.INT32),
+                    RecordColumn("step", RecordCellType.INT64),
+                    RecordColumn("score", RecordCellType.FLOAT64),
+                    RecordColumn("extent", RecordCellType.INT64_ARRAY),
+                    RecordColumn(
+                        "payload",
+                        RecordCellType.TENSOR,
+                        dtype_column="payload_dtype",
+                        shape_column="payload_shape",
+                        bytes_column="payload_bytes",
+                    ),
+                ),
+                primary_key=("run", "rank", "step"),
+                order_by=("run", "rank", "step"),
+            ),
+        ),
+        index_granularity=1024,
+    )
+
+    host = os.environ.get("DMX_DB_HOST", "127.0.0.1")
+    port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    client = clickhouse_driver.Client(host=host, port=port)
+    config = ClickHouseClientConfig()
+    config.host = host
+    config.port = port
+    config.database = "default"
+    stage = StageConfig.clickhouse_records(config, schema, parallelism=2)
+    engine = DMXHostEngine(stage)
+    payload = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    with _engine_table_cleanup(engine, client, (tensor_table,), graceful=True):
+        engine.start()
+        assert engine.wait_until_ready(10.0)
+        engine.submit_record(
+            "tensor",
+            ["run-a", 2, 11, 1.5, [2, 3], payload],
+            ["string", "int32", "int64", "float64", "int64_array", "tensor"],
+            nbytes=payload.nbytes,
+        )
+        assert engine.flush_and_wait(10.0)
+
+        tensor_rows = client.execute(
+            f"SELECT run, rank, step, score, extent, payload_dtype, payload_shape, "
+            f"hex(payload_bytes) FROM `{tensor_table}`"
+        )
+        assert len(tensor_rows) == 1
+        tensor_row = tensor_rows[0]
+        assert tensor_row[:7] == (
+            "run-a", 2, 11, 1.5, [2, 3], "torch.float", [2, 3]
+        )
+        assert tensor_row[7] == payload.numpy().tobytes().hex().upper()
+
+
+@pytest.mark.parametrize(
+    ("table_definition", "expected_failure"),
+    (
+        pytest.param(
+            "(`event_id` Int64, `run` String, `score` Float64) "
+            "ENGINE = MergeTree PRIMARY KEY (`run`) "
+            "ORDER BY (`run`, `event_id`) "
+            "SETTINGS index_granularity = 1024",
+            "columns/types",
+            id="physical-column-order",
+        ),
+        pytest.param(
+            "(`run` String, `event_id` UInt64, `score` Float64) "
+            "ENGINE = MergeTree PRIMARY KEY (`run`) "
+            "ORDER BY (`run`, `event_id`) "
+            "SETTINGS index_granularity = 1024",
+            "columns/types",
+            id="columns-and-types",
+        ),
+        pytest.param(
+            "(`run` String, `event_id` Int64, `score` Float64) "
+            "ENGINE = MergeTree PRIMARY KEY (`run`, `event_id`) "
+            "ORDER BY (`run`, `event_id`) "
+            "SETTINGS index_granularity = 1024",
+            "primary key",
+            id="primary-key",
+        ),
+        pytest.param(
+            "(`run` String, `event_id` Int64, `score` Float64) "
+            "ENGINE = MergeTree PRIMARY KEY (`run`) "
+            "ORDER BY (`run`, `score`, `event_id`) "
+            "SETTINGS index_granularity = 1024",
+            "ORDER BY",
+            id="order-by",
+        ),
+        pytest.param(
+            "(`run` String, `event_id` Int64, `score` Float64) "
+            "ENGINE = MergeTree PRIMARY KEY (`run`) "
+            "ORDER BY (`run`, `event_id`) "
+            "SETTINGS index_granularity = 2048",
+            "index_granularity",
+            id="index-granularity",
+        ),
+    ),
+)
+def test_schema_driven_stage_rejects_live_table_mismatch_before_ready(
+    table_definition, expected_failure
+):
+    clickhouse_driver = pytest.importorskip("clickhouse_driver")
+    from dmi.api.v1 import RecordCellType, RecordColumn, RecordLayout, RecordSchema
+    from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
+
+    table = f"dmi_record_mismatch_{uuid.uuid4().hex[:12]}"
+    host = os.environ.get("DMX_DB_HOST", "127.0.0.1")
+    port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    client = clickhouse_driver.Client(host=host, port=port)
+
+    schema = RecordSchema(
+        (
+            RecordLayout(
+                name="event",
+                table=table,
+                columns=(
+                    RecordColumn("run", RecordCellType.STRING),
+                    RecordColumn("event_id", RecordCellType.INT64),
+                    RecordColumn("score", RecordCellType.FLOAT64),
+                ),
+                primary_key=("run",),
+                order_by=("run", "event_id"),
+            ),
+        ),
+        index_granularity=1024,
+    )
+    config = ClickHouseClientConfig()
+    config.host = host
+    config.port = port
+    config.database = "default"
+    engine = DMXHostEngine(
+        StageConfig.clickhouse_records(config, schema, parallelism=1)
+    )
+
+    with _engine_table_cleanup(engine, client, (table,), graceful=False):
+        client.execute(f"CREATE TABLE `{table}` {table_definition}")
+        engine.start()
+        assert not engine.wait_until_ready(10.0)
+        assert engine.clickhouse_metrics().ready_workers == 0
+        failures = engine.failures()
+        assert failures
+        assert expected_failure in failures[0].exc_what
+
+
+def test_schema_driven_stage_revalidates_after_same_process_table_recreation():
+    clickhouse_driver = pytest.importorskip("clickhouse_driver")
+    from dmi.api.v1 import RecordCellType, RecordColumn, RecordLayout, RecordSchema
+    from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
+
+    table = f"dmi_record_recreated_{uuid.uuid4().hex[:12]}"
+    host = os.environ.get("DMX_DB_HOST", "127.0.0.1")
+    port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    client = clickhouse_driver.Client(host=host, port=port)
+    config = ClickHouseClientConfig()
+    config.host = host
+    config.port = port
+    config.database = "default"
+
+    def schema_for(cell_type):
+        return RecordSchema(
+            (
+                RecordLayout(
+                    name="event",
+                    table=table,
+                    columns=(RecordColumn("event_id", cell_type),),
+                    primary_key=("event_id",),
+                    order_by=("event_id",),
+                ),
+            ),
+            index_granularity=1024,
+        )
+
+    first = DMXHostEngine(
+        StageConfig.clickhouse_records(
+            config, schema_for(RecordCellType.INT64), parallelism=1
+        )
+    )
+    with _engine_table_cleanup(first, client, (table,), graceful=True):
+        first.start()
+        assert first.wait_until_ready(10.0)
+
+    second = DMXHostEngine(
+        StageConfig.clickhouse_records(
+            config, schema_for(RecordCellType.INT32), parallelism=1
+        )
+    )
+    with _engine_table_cleanup(second, client, (table,), graceful=True):
+        second.start()
+        assert second.wait_until_ready(10.0)
+        assert client.execute(f"DESCRIBE TABLE `{table}`")[0][:2] == (
+            "event_id",
+            "Int32",
+        )

--- a/tests/test_cpu_native_build.py
+++ b/tests/test_cpu_native_build.py
@@ -66,6 +66,212 @@ def test_clickhouse_stage_has_bounded_batching_defaults():
 
 
 @pytest.mark.native_backend
+def test_schema_driven_stage_is_additive_and_uses_bounded_batching_defaults():
+    from dmi.api.v1 import RecordCellType, RecordColumn, RecordLayout, RecordSchema
+    from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
+
+    schema = RecordSchema(
+        (
+            RecordLayout(
+                name="event",
+                table="event_records",
+                columns=(RecordColumn("event_id", RecordCellType.INT64),),
+                primary_key=("event_id",),
+                order_by=("event_id",),
+            ),
+        )
+    )
+    config = ClickHouseClientConfig()
+    assert not hasattr(config, "record_schema")
+
+    stage = StageConfig.clickhouse_records(config, schema)
+    queue = stage.input_queue
+    assert stage.name == "clickhouse_records"
+    assert queue.min_batch_items is None
+    assert queue.min_batch_size == 16 * 1024**2
+    assert queue.max_linger_s == pytest.approx(0.05)
+    assert queue.max_batch_items == 10_000
+    assert queue.high_watermark_items == 20_000
+    assert queue.high_watermark_size == 512 * 1024**2
+
+    engine = DMXHostEngine(stage)
+    assert callable(engine.submit_record)
+    assert callable(engine.flush_and_wait)
+
+
+@pytest.mark.native_backend
+def test_record_host_schema_identity_is_exact_but_layout_order_is_irrelevant():
+    from dmi.api.v1 import RecordCellType, RecordColumn, RecordLayout, RecordSchema
+    from dmi.transport import native
+    from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
+
+    event_layout = RecordLayout(
+        name="event",
+        table="event_records",
+        columns=(
+            RecordColumn("run", RecordCellType.STRING),
+            RecordColumn("event_id", RecordCellType.INT64),
+            RecordColumn("score", RecordCellType.FLOAT64),
+        ),
+        primary_key=("run", "event_id"),
+        order_by=("run", "event_id"),
+    )
+    tensor_layout = RecordLayout(
+        name="tensor",
+        table="tensor_records",
+        columns=(
+            RecordColumn("run", RecordCellType.STRING),
+            RecordColumn(
+                "payload",
+                RecordCellType.TENSOR,
+                dtype_column="payload_dtype",
+                shape_column="payload_shape",
+                bytes_column="payload_bytes",
+            ),
+        ),
+        primary_key=("run",),
+        order_by=("run",),
+    )
+    schema = RecordSchema((event_layout, tensor_layout), index_granularity=1024)
+    reordered_schema = RecordSchema(
+        (tensor_layout, event_layout), index_granularity=1024
+    )
+
+    def event_variant(
+        *,
+        name=event_layout.name,
+        table=event_layout.table,
+        columns=event_layout.columns,
+        primary_key=event_layout.primary_key,
+        order_by=event_layout.order_by,
+    ):
+        return RecordLayout(
+            name=name,
+            table=table,
+            columns=columns,
+            primary_key=primary_key,
+            order_by=order_by,
+        )
+
+    def tensor_variant(*, dtype="payload_dtype", shape="payload_shape", bytes_="payload_bytes"):
+        return RecordLayout(
+            name="tensor",
+            table="tensor_records",
+            columns=(
+                RecordColumn("run", RecordCellType.STRING),
+                RecordColumn(
+                    "payload",
+                    RecordCellType.TENSOR,
+                    dtype_column=dtype,
+                    shape_column=shape,
+                    bytes_column=bytes_,
+                ),
+            ),
+            primary_key=("run",),
+            order_by=("run",),
+        )
+
+    identity_mismatches = {
+        "layout set": RecordSchema((event_layout,), index_granularity=1024),
+        "layout name": RecordSchema(
+            (event_variant(name="other_event"), tensor_layout),
+            index_granularity=1024,
+        ),
+        "target table": RecordSchema(
+            (event_variant(table="other_event_records"), tensor_layout),
+            index_granularity=1024,
+        ),
+        "logical column order": RecordSchema(
+            (
+                event_variant(
+                    columns=(
+                        event_layout.columns[0],
+                        event_layout.columns[2],
+                        event_layout.columns[1],
+                    )
+                ),
+                tensor_layout,
+            ),
+            index_granularity=1024,
+        ),
+        "logical column name": RecordSchema(
+            (
+                event_variant(
+                    columns=(
+                        event_layout.columns[0],
+                        event_layout.columns[1],
+                        RecordColumn("metric", RecordCellType.FLOAT64),
+                    )
+                ),
+                tensor_layout,
+            ),
+            index_granularity=1024,
+        ),
+        "logical column type": RecordSchema(
+            (
+                event_variant(
+                    columns=(
+                        event_layout.columns[0],
+                        event_layout.columns[1],
+                        RecordColumn("score", RecordCellType.INT64),
+                    )
+                ),
+                tensor_layout,
+            ),
+            index_granularity=1024,
+        ),
+        "tensor dtype column": RecordSchema(
+            (event_layout, tensor_variant(dtype="other_dtype")),
+            index_granularity=1024,
+        ),
+        "tensor shape column": RecordSchema(
+            (event_layout, tensor_variant(shape="other_shape")),
+            index_granularity=1024,
+        ),
+        "tensor bytes column": RecordSchema(
+            (event_layout, tensor_variant(bytes_="other_bytes")),
+            index_granularity=1024,
+        ),
+        "primary key order": RecordSchema(
+            (
+                event_variant(primary_key=("event_id", "run")),
+                tensor_layout,
+            ),
+            index_granularity=1024,
+        ),
+        "ordering key order": RecordSchema(
+            (
+                event_variant(order_by=("event_id", "run")),
+                tensor_layout,
+            ),
+            index_granularity=1024,
+        ),
+        "index granularity": RecordSchema(
+            (event_layout, tensor_layout), index_granularity=2048
+        ),
+    }
+
+    host = DMXHostEngine(
+        StageConfig.clickhouse_records(ClickHouseClientConfig(), schema)
+    )
+    backend = native._load_host_extension()
+    backend._validate_record_host_schema(host, reordered_schema)
+    for field, mismatched_schema in identity_mismatches.items():
+        try:
+            backend._validate_record_host_schema(host, mismatched_schema)
+        except ValueError as error:
+            assert "does not match" in str(error)
+        else:
+            pytest.fail(f"schema identity omitted {field}")
+
+    legacy_host = DMXHostEngine(
+        StageConfig.clickhouse_insert(ClickHouseClientConfig())
+    )
+    with pytest.raises(RuntimeError, match="schema-driven record stage"):
+        backend._validate_record_host_schema(legacy_host, schema)
+
+
+@pytest.mark.native_backend
 def test_clickhouse_client_exposes_socket_timeouts_and_worker_metrics():
     from dmi.transport.native import ClickHouseClientConfig, DMXHostEngine, StageConfig
 

--- a/tests/test_dynamic_hooks.py
+++ b/tests/test_dynamic_hooks.py
@@ -1,0 +1,150 @@
+"""CPU contract tests for the additive dynamic hook path."""
+
+from __future__ import annotations
+
+from types import MethodType
+
+import pytest
+import torch
+
+from dmi.adapters.base import StepReservation
+from dmi.hooks.dynamic import (
+    HookOutput,
+    HookPointV1,
+    HookSpecV1,
+    TransportSpec,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+class _Runtime:
+    def __init__(self, *, eligible=True, reservation=None):
+        self.eligible = eligible
+        self.reservation = reservation
+        self.prepared = []
+
+    def should_emit(self, hook):
+        return self.eligible
+
+    def prepare_output(self, **kwargs):
+        self.prepared.append(kwargs)
+        return self.reservation
+
+
+def _bind_for_cpu(hook, runtime):
+    hook._output_ids = tuple(range(100, 100 + len(hook.spec.outputs)))
+    hook._ring_payload = torch.empty(0, dtype=torch.uint8)
+    hook._hook_runtime = runtime
+    dispatched = []
+    hook._dispatch = MethodType(
+        lambda self, spec, output: dispatched.append((spec, output)), hook
+    )
+    return dispatched
+
+
+def test_ineligible_hook_skips_preprocessing_and_outputs():
+    calls = []
+    spec = HookSpecV1(
+        "hidden",
+        (TransportSpec("summary"),),
+        preprocess=lambda x: calls.append(x) or x,
+    )
+    hook = HookPointV1(spec)
+    runtime = _Runtime(eligible=False)
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    assert hook(torch.ones(2)) is None
+    assert calls == []
+    assert runtime.prepared == []
+    assert dispatched == []
+
+
+def test_preprocessing_outputs_preserve_declared_order():
+    spec = HookSpecV1(
+        "split",
+        (TransportSpec("left"), TransportSpec("right")),
+        preprocess=lambda x: (x + 1, x + 2),
+    )
+    hook = HookPointV1(spec)
+    runtime = _Runtime()
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    hook(torch.tensor([3.0]))
+
+    assert [item["output_id"] for item in runtime.prepared] == [100, 101]
+    assert [item["output_index"] for item in runtime.prepared] == [0, 1]
+    assert [output.tensor.item() for _, output in dispatched] == [4.0, 5.0]
+
+
+def test_reserved_output_dispatches():
+    hook = HookPointV1(HookSpecV1("reserved", (TransportSpec("value"),)))
+    runtime = _Runtime(reservation=StepReservation.RESERVED)
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    hook(torch.ones(1))
+
+    assert len(runtime.prepared) == 1
+    assert len(dispatched) == 1
+
+
+def test_oversized_output_skips_producer_dispatch():
+    hook = HookPointV1(HookSpecV1("oversized", (TransportSpec("value"),)))
+    runtime = _Runtime(reservation=StepReservation.OVERSIZED)
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    hook(torch.ones(1))
+
+    assert len(runtime.prepared) == 1
+    assert dispatched == []
+
+
+def test_no_preprocessing_requires_one_input_per_output():
+    hook = HookPointV1(HookSpecV1("pair", (TransportSpec("a"),)))
+    _bind_for_cpu(hook, _Runtime())
+
+    with pytest.raises(ValueError, match="one input per declared output"):
+        hook(torch.ones(1), torch.ones(1))
+
+
+def test_hook_output_preserves_device_side_producer_metadata():
+    meta = torch.tensor([2], dtype=torch.int64)
+    output = HookOutput(torch.ones(4), (meta,))
+    hook = HookPointV1(HookSpecV1("packed", (TransportSpec("value"),)))
+    runtime = _Runtime()
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    hook(output)
+
+    assert runtime.prepared[0]["output"] is output
+    assert dispatched[0][1].producer_meta == (meta,)
+
+
+def test_wrong_preprocess_arity_fails_before_dispatch():
+    hook = HookPointV1(
+        HookSpecV1(
+            "wrong",
+            (TransportSpec("a"), TransportSpec("b")),
+            preprocess=lambda x: (x,),
+        )
+    )
+    dispatched = _bind_for_cpu(hook, _Runtime())
+
+    with pytest.raises(ValueError, match="expected 2 outputs"):
+        hook(torch.ones(1))
+    assert dispatched == []
+
+
+def test_record_gate_requires_exact_int32_contract():
+    hook = HookPointV1(HookSpecV1("gated", (TransportSpec("value"),)))
+    runtime = _Runtime()
+    ring_payload = torch.empty(0, dtype=torch.uint8)
+
+    with pytest.raises(TypeError, match="must use int32"):
+        hook._bind_record_runtime(
+            output_ids=(100,),
+            ring_payload=ring_payload,
+            hook_runtime=runtime,
+            gate_tensor=torch.ones((), dtype=torch.int64),
+            gate_value=1,
+        )

--- a/tests/test_engine_runtime_api.py
+++ b/tests/test_engine_runtime_api.py
@@ -197,6 +197,154 @@ def test_ring_runtime_api_requires_an_enabled_transport():
         engine.ring_capacities()
     with pytest.raises(RuntimeError, match="Ring transport is not enabled"):
         engine.set_capture_enabled(True)
+    with pytest.raises(RuntimeError, match="Ring transport is not enabled"):
+        engine.create_record_runtime(object())
+    with pytest.raises(RuntimeError, match="Ring transport is not enabled"):
+        engine.flush_and_wait()
+
+
+def test_create_record_runtime_is_additive_and_uses_active_transport(monkeypatch):
+    from dmi.records import (
+        RecordCellType,
+        RecordColumn,
+        RecordLayout,
+        RecordSchema,
+    )
+
+    engine, _old_transport, old_ring = _engine_with_fake_ring()
+    ring_config = object()
+    engine._ring_config = ring_config
+    host_engine = object()
+    engine._host_engine = host_engine
+    new_ring = _FakeRingEngine()
+    activated = []
+    deactivated = []
+    created = []
+    validated = []
+
+    class _Format:
+        schema = RecordSchema(
+            (
+                RecordLayout(
+                    "events",
+                    "events",
+                    (RecordColumn("event_id", RecordCellType.INT64),),
+                    primary_key=("event_id",),
+                    order_by=("event_id",),
+                ),
+            )
+        )
+
+        def encode(self, metadata, entry):
+            raise AssertionError("encoding is not part of runtime construction")
+
+    class _FakeTransport:
+        def __init__(self, native_ring):
+            self._ring_engine = native_ring
+            self._ring_payload = native_ring.payload_tensor()
+            self.null_offload = False
+            self.force_eager = False
+
+        def _record_payload_tensor(self):
+            return self._ring_payload
+
+        def configure_record_schema(self, schema):
+            self._record_schema = schema
+
+    class _Factory:
+        @staticmethod
+        def create_record(config, host):
+            created.append((config, host))
+            return new_ring
+
+    fake_transport_module = ModuleType("dmi.transport.ring")
+    fake_transport_module.RingTransport = _FakeTransport
+    fake_transport_module.activate = activated.append
+    fake_transport_module.deactivate = lambda: deactivated.append(True)
+    fake_native_module = ModuleType("dmi.transport.native")
+    fake_native_module.RingEngine = _Factory
+    fake_native_module._load_extension = lambda: SimpleNamespace(
+        _validate_record_host_schema=lambda host, schema: (
+            validated.append((host, schema, old_ring.stop_calls))
+        )
+    )
+    monkeypatch.setitem(sys.modules, "dmi.transport.ring", fake_transport_module)
+    monkeypatch.setitem(sys.modules, "dmi.transport.native", fake_native_module)
+
+    engine.create_record_runtime(_Format())
+
+    assert engine._ring_transport._record_schema.layout("events").table == "events"
+    assert validated == [(host_engine, _Format.schema, 0)]
+    assert old_ring.stop_calls == 1
+    assert deactivated == [True]
+    assert created == [(ring_config, host_engine)]
+    assert new_ring.init_calls == 1
+    assert new_ring.start_calls == 1
+    assert activated == [engine._ring_transport]
+    assert engine._record_mode is True
+
+
+def test_record_schema_mismatch_fails_before_replacing_active_ring(monkeypatch):
+    from dmi.records import (
+        RecordCellType,
+        RecordColumn,
+        RecordLayout,
+        RecordSchema,
+    )
+
+    engine, old_transport, old_ring = _engine_with_fake_ring()
+    engine._ring_config = object()
+    engine._host_engine = object()
+
+    class _Format:
+        schema = RecordSchema(
+            (
+                RecordLayout(
+                    "events",
+                    "events",
+                    (RecordColumn("event_id", RecordCellType.INT64),),
+                    primary_key=("event_id",),
+                    order_by=("event_id",),
+                ),
+            )
+        )
+
+        def encode(self, metadata, entry):
+            raise AssertionError("encoding is not part of runtime construction")
+
+    def reject_schema(_host, _schema):
+        assert old_ring.stop_calls == 0
+        raise ValueError("record runtime schema does not match")
+
+    fake_native_module = ModuleType("dmi.transport.native")
+    fake_native_module._load_extension = lambda: SimpleNamespace(
+        _validate_record_host_schema=reject_schema
+    )
+    fake_native_module.RingEngine = SimpleNamespace(
+        create_record=lambda *_args: pytest.fail(
+            "record ring must not be created after a schema mismatch"
+        )
+    )
+    monkeypatch.setitem(sys.modules, "dmi.transport.native", fake_native_module)
+
+    with pytest.raises(ValueError, match="schema does not match"):
+        engine.create_record_runtime(_Format())
+
+    assert old_ring.stop_calls == 0
+    assert engine._ring_engine is old_ring
+    assert engine._ring_transport is old_transport
+    assert engine._record_mode is False
+
+
+def test_flush_and_wait_forwards_one_checked_deadline():
+    engine, transport, _ring_engine = _engine_with_fake_ring()
+    calls = []
+    transport.flush_records_and_wait = calls.append
+    engine._record_mode = True
+
+    engine.flush_and_wait(17.25)
+
+    assert calls == [17.25]
 
 
 def test_plain_dmi_import_does_not_load_native_or_transport_modules():

--- a/tests/test_integration_api_v1.py
+++ b/tests/test_integration_api_v1.py
@@ -53,6 +53,26 @@ _NON_HOOK_EXPORTS = {
     "HostEngineConfig",
     "deactivate_ring_transport",
     "HookPoint",
+    "HookPointV1",
+    "HookSpecV1",
+    "HookOutput",
+    "HookRuntime",
+    "TransportSpec",
+    "TransportType",
+    "OutputStorage",
+    "RecordType",
+    "ProducerPlanEntry",
+    "ProducerPlan",
+    "ProducerPlanBuilder",
+    "PayloadSlice",
+    "RecordCell",
+    "RecordCellType",
+    "RecordColumn",
+    "RecordDescriptor",
+    "RecordFormat",
+    "RecordLayout",
+    "RecordRuntime",
+    "RecordSchema",
     "HookSpec",
     "HookRowBasis",
     "ModelShapeConfig",
@@ -107,7 +127,10 @@ def test_v1_reexports_existing_objects_and_state() -> None:
     from dmi import engine
     from dmi.hooks import dispatch
     from dmi.hooks import point
+    from dmi.hooks import dynamic
+    from dmi.hooks import producer_plan
     from dmi.hooks import specs
+    from dmi import records
     from dmi.storage import internals
     from dmi.hooks import selection
     from dmi.adapters import types
@@ -124,6 +147,28 @@ def test_v1_reexports_existing_objects_and_state() -> None:
     assert v1.CaptureSchedule is config.CaptureSchedule
     assert v1.HostEngineConfig is engine.HostEngineConfig
     assert v1.HookPoint is point.HookPoint
+    assert v1.HookPointV1 is dynamic.HookPointV1
+    assert v1.HookSpecV1 is dynamic.HookSpecV1
+    assert v1.HookOutput is dynamic.HookOutput
+    assert v1.HookRuntime is dynamic.HookRuntime
+    assert v1.TransportSpec is dynamic.TransportSpec
+    assert v1.TransportType is dynamic.TransportType
+    assert v1.OutputStorage is dynamic.OutputStorage
+    assert v1.RecordType is dynamic.RecordType
+    assert v1.ProducerPlanEntry is producer_plan.ProducerPlanEntry
+    assert v1.ProducerPlan is producer_plan.ProducerPlan
+    assert v1.ProducerPlanBuilder is producer_plan.ProducerPlanBuilder
+    assert v1.PayloadSlice is records.PayloadSlice
+    assert v1.RecordCell is records.RecordCell
+    assert v1.RecordCellType is records.RecordCellType
+    assert v1.RecordColumn is records.RecordColumn
+    assert v1.RecordDescriptor is records.RecordDescriptor
+    assert v1.RecordFormat is records.RecordFormat
+    assert v1.RecordLayout is records.RecordLayout
+    assert v1.RecordRuntime is records.RecordRuntime
+    assert v1.RecordSchema is records.RecordSchema
+    assert not hasattr(v1.RecordRuntime, "record_format")
+    assert not hasattr(v1.ProducerPlanBuilder, "reset")
     assert v1.HookSpec is specs.HookSpec
     assert v1.HookRowBasis is specs.HookRowBasis
     assert v1.ModelShapeConfig is specs.ModelShapeConfig
@@ -189,10 +234,15 @@ def test_v1_public_surface_is_documented() -> None:
     assert missing == []
     member_names = {
         "active_hook_specs",
+        "bind_hook",
         "capture_enabled",
         "commit_step",
+        "create_record_runtime",
+        "emit_output",
+        "flush_and_wait",
         "model_shape",
         "plan_step",
+        "prepare_replay",
         "ring_capacities",
         "set_capture_enabled",
     }

--- a/tests/test_integration_api_v1.py
+++ b/tests/test_integration_api_v1.py
@@ -127,7 +127,7 @@ def test_v1_reexports_existing_objects_and_state() -> None:
     from dmi import engine
     from dmi.hooks import dispatch
     from dmi.hooks import point
-    from dmi.hooks import dynamic
+    from dmi.hooks import record
     from dmi.hooks import producer_plan
     from dmi.hooks import specs
     from dmi import records
@@ -147,14 +147,14 @@ def test_v1_reexports_existing_objects_and_state() -> None:
     assert v1.CaptureSchedule is config.CaptureSchedule
     assert v1.HostEngineConfig is engine.HostEngineConfig
     assert v1.HookPoint is point.HookPoint
-    assert v1.HookPointV1 is dynamic.HookPointV1
-    assert v1.HookSpecV1 is dynamic.HookSpecV1
-    assert v1.HookOutput is dynamic.HookOutput
-    assert v1.HookRuntime is dynamic.HookRuntime
-    assert v1.TransportSpec is dynamic.TransportSpec
-    assert v1.TransportType is dynamic.TransportType
-    assert v1.OutputStorage is dynamic.OutputStorage
-    assert v1.RecordType is dynamic.RecordType
+    assert v1.HookPointV1 is record.HookPointV1
+    assert v1.HookSpecV1 is record.HookSpecV1
+    assert v1.HookOutput is record.HookOutput
+    assert v1.HookRuntime is record.HookRuntime
+    assert v1.TransportSpec is record.TransportSpec
+    assert v1.TransportType is record.TransportType
+    assert v1.OutputStorage is record.OutputStorage
+    assert v1.RecordType is record.RecordType
     assert v1.ProducerPlanEntry is producer_plan.ProducerPlanEntry
     assert v1.ProducerPlan is producer_plan.ProducerPlan
     assert v1.ProducerPlanBuilder is producer_plan.ProducerPlanBuilder

--- a/tests/test_monitoring_engine_shutdown.py
+++ b/tests/test_monitoring_engine_shutdown.py
@@ -36,7 +36,7 @@ def test_ring_transport_maps_native_timeout_to_timeout_error():
         flush_records_and_wait=lambda timeout_s: False
     )
 
-    with pytest.raises(TimeoutError, match="record ring completion"):
+    with pytest.raises(TimeoutError, match="durable record completion"):
         transport.flush_records_and_wait(0.25)
 
 
@@ -48,22 +48,16 @@ def test_flush_and_wait_rejects_nonpositive_deadline():
         engine.flush_and_wait(0)
 
 
-def test_flush_and_wait_uses_remaining_deadline_for_host_durability(monkeypatch):
+def test_flush_and_wait_uses_one_native_deadline_and_does_not_flush_host_twice():
     calls = []
-    monotonic_times = iter((100.0, 101.75, 102.0))
-    monkeypatch.setattr(
-        "dmi.engine.time.monotonic", lambda: next(monotonic_times)
-    )
 
     class _Transport:
         def flush_records_and_wait(self, timeout_s):
-            calls.append(("ring", timeout_s))
-            return True
+            calls.append(("record_sink", timeout_s))
 
     class _Host:
-        def flush_and_wait(self, timeout_s):
-            calls.append(("host", timeout_s))
-            return True
+        def flush_and_wait(self, timeout_s):  # pragma: no cover - must not run
+            calls.append(("legacy_host", timeout_s))
 
     engine = MonitoringEngine(enable_ring_transport=False)
     engine._ring_transport = _Transport()
@@ -72,72 +66,7 @@ def test_flush_and_wait_uses_remaining_deadline_for_host_durability(monkeypatch)
 
     engine.flush_and_wait(5.0)
 
-    assert calls[0] == ("ring", 5.0)
-    assert calls[1][0] == "host"
-    assert calls[1][1] == pytest.approx(3.25)
-
-
-def test_flush_and_wait_rejects_host_success_after_caller_deadline(monkeypatch):
-    monotonic_times = iter((100.0, 101.0, 105.01))
-    monkeypatch.setattr(
-        "dmi.engine.time.monotonic", lambda: next(monotonic_times)
-    )
-
-    class _Transport:
-        def flush_records_and_wait(self, timeout_s):
-            return True
-
-    class _Host:
-        def flush_and_wait(self, timeout_s):
-            assert timeout_s == pytest.approx(4.0)
-            return True
-
-    engine = MonitoringEngine(enable_ring_transport=False)
-    engine._ring_transport = _Transport()
-    engine._host_engine = _Host()
-    engine._record_mode = True
-
-    with pytest.raises(TimeoutError, match="durable record flush timed out"):
-        engine.flush_and_wait(5.0)
-
-
-def test_flush_and_wait_raises_when_host_reports_timeout():
-    class _Transport:
-        def flush_records_and_wait(self, timeout_s):
-            return True
-
-    class _Host:
-        def flush_and_wait(self, timeout_s):
-            return False
-
-    engine = MonitoringEngine(enable_ring_transport=False)
-    engine._ring_transport = _Transport()
-    engine._host_engine = _Host()
-    engine._record_mode = True
-
-    with pytest.raises(TimeoutError, match="durable record flush timed out"):
-        engine.flush_and_wait(1.0)
-
-
-def test_flush_and_wait_preserves_host_exception():
-    failure = RuntimeError("host insert failed")
-
-    class _Transport:
-        def flush_records_and_wait(self, timeout_s):
-            return True
-
-    class _Host:
-        def flush_and_wait(self, timeout_s):
-            raise failure
-
-    engine = MonitoringEngine(enable_ring_transport=False)
-    engine._ring_transport = _Transport()
-    engine._host_engine = _Host()
-    engine._record_mode = True
-
-    with pytest.raises(RuntimeError) as raised:
-        engine.flush_and_wait(1.0)
-    assert raised.value is failure
+    assert calls == [("record_sink", 5.0)]
 
 
 def test_close_remains_best_effort_when_native_stop_fails(monkeypatch):

--- a/tests/test_monitoring_engine_shutdown.py
+++ b/tests/test_monitoring_engine_shutdown.py
@@ -1,0 +1,155 @@
+"""Checked completion remains separate from best-effort engine close."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from dmi.engine import MonitoringEngine
+
+pytestmark = pytest.mark.cpu
+
+
+def test_flush_and_wait_preserves_transport_async_error():
+    calls = []
+
+    class _Transport:
+        def flush_records_and_wait(self, timeout_s):
+            calls.append(timeout_s)
+            raise RuntimeError("record insert failed")
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = _Transport()
+    engine._record_mode = True
+
+    with pytest.raises(RuntimeError, match="record insert failed"):
+        engine.flush_and_wait(4.5)
+    assert calls == [4.5]
+
+
+def test_ring_transport_maps_native_timeout_to_timeout_error():
+    from dmi.transport.ring import RingTransport
+
+    transport = RingTransport.__new__(RingTransport)
+    transport._ring_engine = SimpleNamespace(
+        flush_records_and_wait=lambda timeout_s: False
+    )
+
+    with pytest.raises(TimeoutError, match="record ring completion"):
+        transport.flush_records_and_wait(0.25)
+
+
+def test_flush_and_wait_rejects_nonpositive_deadline():
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = SimpleNamespace()
+    engine._record_mode = True
+    with pytest.raises(ValueError, match="must be positive"):
+        engine.flush_and_wait(0)
+
+
+def test_flush_and_wait_uses_remaining_deadline_for_host_durability(monkeypatch):
+    calls = []
+    monotonic_times = iter((100.0, 101.75, 102.0))
+    monkeypatch.setattr(
+        "dmi.engine.time.monotonic", lambda: next(monotonic_times)
+    )
+
+    class _Transport:
+        def flush_records_and_wait(self, timeout_s):
+            calls.append(("ring", timeout_s))
+            return True
+
+    class _Host:
+        def flush_and_wait(self, timeout_s):
+            calls.append(("host", timeout_s))
+            return True
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = _Transport()
+    engine._host_engine = _Host()
+    engine._record_mode = True
+
+    engine.flush_and_wait(5.0)
+
+    assert calls[0] == ("ring", 5.0)
+    assert calls[1][0] == "host"
+    assert calls[1][1] == pytest.approx(3.25)
+
+
+def test_flush_and_wait_rejects_host_success_after_caller_deadline(monkeypatch):
+    monotonic_times = iter((100.0, 101.0, 105.01))
+    monkeypatch.setattr(
+        "dmi.engine.time.monotonic", lambda: next(monotonic_times)
+    )
+
+    class _Transport:
+        def flush_records_and_wait(self, timeout_s):
+            return True
+
+    class _Host:
+        def flush_and_wait(self, timeout_s):
+            assert timeout_s == pytest.approx(4.0)
+            return True
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = _Transport()
+    engine._host_engine = _Host()
+    engine._record_mode = True
+
+    with pytest.raises(TimeoutError, match="durable record flush timed out"):
+        engine.flush_and_wait(5.0)
+
+
+def test_flush_and_wait_raises_when_host_reports_timeout():
+    class _Transport:
+        def flush_records_and_wait(self, timeout_s):
+            return True
+
+    class _Host:
+        def flush_and_wait(self, timeout_s):
+            return False
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = _Transport()
+    engine._host_engine = _Host()
+    engine._record_mode = True
+
+    with pytest.raises(TimeoutError, match="durable record flush timed out"):
+        engine.flush_and_wait(1.0)
+
+
+def test_flush_and_wait_preserves_host_exception():
+    failure = RuntimeError("host insert failed")
+
+    class _Transport:
+        def flush_records_and_wait(self, timeout_s):
+            return True
+
+    class _Host:
+        def flush_and_wait(self, timeout_s):
+            raise failure
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = _Transport()
+    engine._host_engine = _Host()
+    engine._record_mode = True
+
+    with pytest.raises(RuntimeError) as raised:
+        engine.flush_and_wait(1.0)
+    assert raised.value is failure
+
+
+def test_close_remains_best_effort_when_native_stop_fails(monkeypatch):
+    class _Ring:
+        def stop(self):
+            raise RuntimeError("stop failed")
+
+    engine = MonitoringEngine(enable_ring_transport=False)
+    engine._ring_transport = SimpleNamespace(null_offload=False, force_eager=False)
+    engine._ring_engine = _Ring()
+
+    monkeypatch.setattr("dmi.engine._ring_module", lambda: SimpleNamespace(deactivate=lambda: None))
+    engine.close()
+    assert engine._ring_transport is None
+    assert engine._ring_engine is None

--- a/tests/test_native_durable_flush.py
+++ b/tests/test_native_durable_flush.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+@pytest.mark.cpu
+def test_native_nonterminal_flush_deadline_and_async_failure(tmp_path):
+    compiler = shutil.which("g++") or shutil.which("c++")
+    if compiler is None:
+        pytest.skip("a C++17 compiler is required")
+
+    root = Path(__file__).resolve().parents[1]
+    source = root / "tests" / "native" / "test_durable_flush.cpp"
+    executable = tmp_path / "test_durable_flush"
+    compile_result = subprocess.run(
+        [
+            compiler,
+            "-std=c++17",
+            "-O0",
+            "-pthread",
+            f"-I{root / 'native' / 'csrc'}",
+            str(source),
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert compile_result.returncode == 0, (
+        compile_result.stdout + compile_result.stderr
+    )
+
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr

--- a/tests/test_producer_chunked_schema.py
+++ b/tests/test_producer_chunked_schema.py
@@ -39,6 +39,20 @@ def test_producer_chunked_op_registered():
     assert torch.ops.ring.producer_chunked.default is not None
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "record_producer",
+        "record_producer_prefix",
+        "record_producer_chunked",
+        "record_producer_seq_prefix_pack",
+        "record_producer_segmented_pack",
+    ],
+)
+def test_additive_record_producer_ops_registered(name):
+    assert getattr(torch.ops.ring, name).default is not None
+
+
 def test_hook_point_strip_attrs_default_to_static():
     """HookPoint instances default to the static path."""
     from dmi.hooks.point import HookPoint
@@ -81,6 +95,36 @@ def test_producer_chunked_smoke():
     x = torch.zeros(64, dtype=torch.float32, device="cuda")
     chunk_bytes = torch.tensor([16, 32, 0, 8], dtype=torch.int64, device="cuda")
     torch.ops.ring.producer_chunked(ring_payload, x, chunk_bytes, 0, 0)
+
+
+@pytest.mark.gpu
+def test_record_producer_ops_smoke_without_active_engine():
+    """New schemas accept their physical arguments without changing legacy ops."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    ring_payload = torch.zeros(1024, dtype=torch.uint8, device="cuda")
+    x = torch.zeros((4, 2, 8), dtype=torch.float32, device="cuda")
+    gate = torch.tensor([1], dtype=torch.int32, device="cuda")
+    row_count = torch.tensor([2], dtype=torch.int64, device="cuda")
+    chunk_bytes = torch.tensor([128, 128], dtype=torch.int64, device="cuda")
+    valid_count = torch.tensor([3, 2], dtype=torch.int64, device="cuda")
+    valid_prefix = torch.tensor([0, 3, 5], dtype=torch.int64, device="cuda")
+    starts = torch.tensor([0, 2], dtype=torch.int64, device="cuda")
+    ends = torch.tensor([2, 4], dtype=torch.int64, device="cuda")
+
+    torch.ops.ring.record_producer(ring_payload, x, gate, 1)
+    torch.ops.ring.record_producer_prefix(
+        ring_payload, x, row_count, 64, gate, 1
+    )
+    torch.ops.ring.record_producer_chunked(
+        ring_payload, x, chunk_bytes, gate, 1
+    )
+    torch.ops.ring.record_producer_seq_prefix_pack(
+        ring_payload, x, valid_count, valid_prefix, 32, gate, 1
+    )
+    torch.ops.ring.record_producer_segmented_pack(
+        ring_payload, x, starts, ends, 64, gate, 1
+    )
 
 
 @pytest.mark.gpu

--- a/tests/test_producer_plan.py
+++ b/tests/test_producer_plan.py
@@ -1,0 +1,90 @@
+"""Tests for ordered, framework-neutral producer plans."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dmi.hooks.dynamic import HookOutput, TransportSpec, TransportType
+from dmi.hooks.producer_plan import ProducerPlanBuilder
+
+pytestmark = pytest.mark.cpu
+
+
+def test_builder_preserves_order_and_derives_totals():
+    builder = ProducerPlanBuilder()
+    first = builder.record_output(
+        output_id=100,
+        output_spec=TransportSpec("a"),
+        output=HookOutput(torch.empty(3, dtype=torch.float32)),
+    )
+    second = builder.record_output(
+        output_id=101,
+        output_spec=TransportSpec(
+            "b",
+            transport_type=TransportType.CHUNKED,
+            reservation_upper_bytes=33,
+            output_shape=(-1,),
+        ),
+        output=HookOutput(
+            torch.empty(8, dtype=torch.float16),
+            (torch.tensor([8, 8], dtype=torch.int64),),
+        ),
+    )
+
+    plan = builder.build()
+
+    assert plan.entries == (first, second)
+    assert plan.total_reservation_bytes == 16 + 48
+    assert plan.task_count == 2
+    assert first.input_shape == (3,)
+    assert second.output_shape == (-1,)
+
+
+def test_plan_compatibility_reports_first_structural_difference():
+    left = ProducerPlanBuilder()
+    right = ProducerPlanBuilder()
+    left.record_output(
+        output_id=100,
+        output_spec=TransportSpec("x"),
+        output=HookOutput(torch.empty(2)),
+    )
+    right.record_output(
+        output_id=100,
+        output_spec=TransportSpec("x"),
+        output=HookOutput(torch.empty(3)),
+    )
+
+    with pytest.raises(ValueError, match="entry 0"):
+        left.build().assert_compatible(right.build())
+
+
+def test_identity_bound_cannot_be_smaller_than_input():
+    builder = ProducerPlanBuilder()
+    with pytest.raises(ValueError, match="cannot be smaller"):
+        builder.record_output(
+            output_id=100,
+            output_spec=TransportSpec("x", reservation_upper_bytes=1),
+            output=HookOutput(torch.empty(2, dtype=torch.float32)),
+        )
+
+
+def test_plan_contains_no_framework_semantic_coordinates():
+    entry = ProducerPlanBuilder().record_output(
+        output_id=100,
+        output_spec=TransportSpec("x"),
+        output=HookOutput(torch.empty(1)),
+    )
+    forbidden = {
+        "model_id",
+        "layer_no",
+        "dataset_id",
+        "sample_id",
+        "tp_rank",
+        "dp_rank",
+        "ep_rank",
+        "pp_rank",
+        "attempt_id",
+        "invocation_id",
+    }
+    assert forbidden.isdisjoint(entry.__dataclass_fields__)

--- a/tests/test_producer_plan.py
+++ b/tests/test_producer_plan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from dmi.hooks.dynamic import HookOutput, TransportSpec, TransportType
+from dmi.hooks.record import HookOutput, TransportSpec, TransportType
 from dmi.hooks.producer_plan import ProducerPlanBuilder
 
 pytestmark = pytest.mark.cpu

--- a/tests/test_record_cpu_direct.py
+++ b/tests/test_record_cpu_direct.py
@@ -1,0 +1,82 @@
+"""CPU-direct record transformations must match CUDA producer bytes."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dmi.hooks.record import HookOutput, TransportSpec, TransportType
+from dmi.hooks.producer_plan import ProducerPlanBuilder
+from dmi.transport.ring import RingTransport
+
+
+pytestmark = pytest.mark.cpu
+
+
+def _entry(
+    output: HookOutput,
+    *,
+    transport_type: TransportType,
+    feature_bytes: int,
+):
+    return ProducerPlanBuilder().record_output(
+        output_id=1 << 16,
+        output_spec=TransportSpec(
+            "packed",
+            transport_type=transport_type,
+            feature_bytes=feature_bytes,
+        ),
+        output=output,
+    )
+
+
+def test_seq_prefix_cpu_direct_uses_flattened_feature_bytes() -> None:
+    source = torch.arange(8, dtype=torch.float32).reshape(2, 2, 2)
+    output = HookOutput(
+        source,
+        (
+            torch.tensor([1, 2], dtype=torch.int64),
+            torch.tensor([0, 1, 3], dtype=torch.int64),
+        ),
+    )
+    entry = _entry(
+        output,
+        transport_type=TransportType.SEQ_PREFIX_PACK,
+        feature_bytes=4,
+    )
+
+    actual = RingTransport._record_cpu_tensor(output, entry)
+    expected = (
+        torch.tensor([0, 1, 3], dtype=torch.float32)
+        .view(torch.uint8)
+        .reshape(-1)
+    )
+
+    assert actual.dtype is torch.uint8
+    assert torch.equal(actual, expected)
+
+
+def test_segmented_cpu_direct_uses_flattened_feature_bytes() -> None:
+    source = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    output = HookOutput(
+        source,
+        (
+            torch.tensor([0], dtype=torch.int64),
+            torch.tensor([2], dtype=torch.int64),
+        ),
+    )
+    entry = _entry(
+        output,
+        transport_type=TransportType.SEGMENTED_PACK,
+        feature_bytes=4,
+    )
+
+    actual = RingTransport._record_cpu_tensor(output, entry)
+    expected = (
+        torch.tensor([0, 1], dtype=torch.float32)
+        .view(torch.uint8)
+        .reshape(-1)
+    )
+
+    assert actual.dtype is torch.uint8
+    assert torch.equal(actual, expected)

--- a/tests/test_record_format.py
+++ b/tests/test_record_format.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from dmi.hooks.dynamic import OutputStorage
+from dmi.hooks.record import OutputStorage
 from dmi.records import (
     PayloadSlice,
     RecordCellType,

--- a/tests/test_record_format.py
+++ b/tests/test_record_format.py
@@ -1,0 +1,105 @@
+"""Validation tests for integration-defined record schemas and descriptors."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dmi.hooks.dynamic import OutputStorage
+from dmi.records import (
+    PayloadSlice,
+    RecordCellType,
+    RecordColumn,
+    RecordDescriptor,
+    RecordLayout,
+    RecordSchema,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+def test_tensor_column_requires_explicit_physical_columns():
+    with pytest.raises(ValueError, match="require dtype_column"):
+        RecordColumn("payload", RecordCellType.TENSOR)
+
+    column = RecordColumn(
+        "payload",
+        RecordCellType.TENSOR,
+        dtype_column="payload_dtype",
+        shape_column="payload_shape",
+        bytes_column="payload_bytes",
+    )
+    assert column.bytes_column == "payload_bytes"
+
+
+def test_layout_rejects_colliding_physical_column_names():
+    with pytest.raises(ValueError, match="physical column names"):
+        RecordLayout(
+            "collision",
+            "collision",
+            (
+                RecordColumn("payload_dtype", RecordCellType.STRING),
+                RecordColumn(
+                    "payload",
+                    RecordCellType.TENSOR,
+                    "payload_dtype",
+                    "payload_shape",
+                    "payload_bytes",
+                ),
+            ),
+            primary_key=("payload_dtype",),
+            order_by=("payload_dtype",),
+        )
+
+
+def test_schema_has_named_immutable_layouts():
+    layout = RecordLayout(
+        "tensor_rows",
+        "tensor_rows",
+        (
+            RecordColumn("record_id", RecordCellType.INT64),
+            RecordColumn(
+                "payload",
+                RecordCellType.TENSOR,
+                "payload_dtype",
+                "payload_shape",
+                "payload_bytes",
+            ),
+        ),
+        primary_key=("record_id",),
+        order_by=("record_id",),
+    )
+    schema = RecordSchema((layout,))
+
+    assert schema.layout("tensor_rows") is layout
+    with pytest.raises(KeyError):
+        schema.layout("missing")
+
+
+def test_payload_slice_accepts_one_inferred_dimension():
+    payload = PayloadSlice(dtype=torch.float32, shape=(-1, 8))
+    descriptor = RecordDescriptor(
+        "tensor_rows",
+        ((1, payload),),
+        output_id=100,
+    )
+    assert descriptor.has_payload
+
+    with pytest.raises(ValueError, match="at most one -1"):
+        PayloadSlice(dtype=torch.float32, shape=(-1, -1))
+
+
+def test_descriptor_accepts_zero_rows():
+    descriptor = RecordDescriptor("tensor_rows", (), output_id=100)
+
+    assert descriptor.rows == ()
+    assert not descriptor.has_payload
+
+
+def test_scalar_payload_slice_has_no_tensor_shape():
+    with pytest.raises(ValueError, match="must not declare a shape"):
+        PayloadSlice(
+            storage=OutputStorage.SCALAR_FLOAT,
+            dtype=torch.float32,
+            shape=(1,),
+        )

--- a/tests/test_record_hooks.py
+++ b/tests/test_record_hooks.py
@@ -1,4 +1,4 @@
-"""CPU contract tests for the additive dynamic hook path."""
+"""CPU contract tests for the additive record-hook path."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 from dmi.adapters.base import StepReservation
-from dmi.hooks.dynamic import (
+from dmi.hooks.record import (
     HookOutput,
     HookPointV1,
     HookSpecV1,

--- a/tests/test_record_hooks.py
+++ b/tests/test_record_hooks.py
@@ -13,7 +13,9 @@ from dmi.hooks.record import (
     HookPointV1,
     HookSpecV1,
     TransportSpec,
+    TransportType,
 )
+from dmi.hooks import set_monitoring_debug
 
 pytestmark = pytest.mark.cpu
 
@@ -118,6 +120,134 @@ def test_hook_output_preserves_device_side_producer_metadata():
 
     assert runtime.prepared[0]["output"] is output
     assert dispatched[0][1].producer_meta == (meta,)
+
+
+@pytest.mark.parametrize(
+    ("spec", "output", "error"),
+    (
+        (
+            TransportSpec("identity"),
+            HookOutput(
+                torch.ones(4),
+                (torch.ones(1, dtype=torch.int64),),
+            ),
+            "identity expects 0 producer metadata tensor",
+        ),
+        (
+            TransportSpec(
+                "prefix", transport_type=TransportType.PREFIX_STRIP, row_bytes=4
+            ),
+            HookOutput(torch.ones(4)),
+            "requires row_count tensor",
+        ),
+        (
+            TransportSpec(
+                "prefix", transport_type=TransportType.PREFIX_STRIP, row_bytes=4
+            ),
+            HookOutput(torch.ones(4), (torch.ones(1),)),
+            "row_count must have dtype int64",
+        ),
+        (
+            TransportSpec(
+                "prefix", transport_type=TransportType.PREFIX_STRIP, row_bytes=4
+            ),
+            HookOutput(
+                torch.ones(4),
+                (torch.ones(1, dtype=torch.int64, device="meta"),),
+            ),
+            "row_count must be on the payload device",
+        ),
+        (
+            TransportSpec("chunked", transport_type=TransportType.CHUNKED),
+            HookOutput(
+                torch.ones(4),
+                (torch.ones((1, 2), dtype=torch.int64),),
+            ),
+            "chunk_bytes must be one-dimensional",
+        ),
+        (
+            TransportSpec("chunked", transport_type=TransportType.CHUNKED),
+            HookOutput(
+                torch.ones(3),
+                (torch.ones(5, dtype=torch.int64),),
+            ),
+            "payload bytes must divide evenly into chunks",
+        ),
+        (
+            TransportSpec(
+                "sequence",
+                transport_type=TransportType.SEQ_PREFIX_PACK,
+                feature_bytes=4,
+            ),
+            HookOutput(
+                torch.ones((2, 2)),
+                (
+                    torch.ones(2, dtype=torch.int64),
+                    torch.ones(2, dtype=torch.int64),
+                ),
+            ),
+            r"valid_prefix_sum length must equal batch \+ 1",
+        ),
+        (
+            TransportSpec(
+                "segmented",
+                transport_type=TransportType.SEGMENTED_PACK,
+                feature_bytes=4,
+            ),
+            HookOutput(
+                torch.ones(4),
+                (
+                    torch.ones(2, dtype=torch.int64),
+                    torch.ones(1, dtype=torch.int64),
+                ),
+            ),
+            "segment_start/end lengths must match",
+        ),
+    ),
+)
+def test_invalid_producer_metadata_fails_before_runtime_preparation(
+    spec, output, error
+):
+    hook = HookPointV1(HookSpecV1("invalid_metadata", (spec,)))
+    runtime = _Runtime()
+    dispatched = _bind_for_cpu(hook, runtime)
+
+    set_monitoring_debug(True)
+    try:
+        with pytest.raises((TypeError, ValueError), match=error):
+            hook(output)
+    finally:
+        set_monitoring_debug(False)
+
+    assert runtime.prepared == []
+    assert dispatched == []
+
+
+def test_producer_metadata_validation_is_skipped_outside_debug_mode():
+    spec = TransportSpec(
+        "prefix", transport_type=TransportType.PREFIX_STRIP, row_bytes=4
+    )
+    hook = HookPointV1(HookSpecV1("production_metadata", (spec,)))
+    runtime = _Runtime()
+    dispatched = _bind_for_cpu(hook, runtime)
+    output = HookOutput(
+        torch.ones(4),
+        (torch.ones(1, dtype=torch.int64),),
+    )
+    validator_calls = []
+    hook._validate_producer_metadata = MethodType(
+        lambda self, output_spec, hook_output: validator_calls.append(
+            (output_spec, hook_output)
+        ),
+        hook,
+    )
+
+    set_monitoring_debug(False)
+    hook(output)
+
+    assert validator_calls == []
+    assert len(runtime.prepared) == 1
+    assert len(dispatched) == 1
 
 
 def test_wrong_preprocess_arity_fails_before_dispatch():

--- a/tests/test_record_ring_clickhouse_e2e.py
+++ b/tests/test_record_ring_clickhouse_e2e.py
@@ -1,0 +1,189 @@
+"""Generic record-runtime E2E through the CUDA ring and ClickHouse."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import torch
+
+from tests._requirements import (
+    require_clickhouse,
+    require_cuda,
+    require_native_backend,
+)
+
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.e2e,
+    pytest.mark.clickhouse,
+    pytest.mark.native_backend,
+    require_cuda(),
+    require_clickhouse(),
+    require_native_backend(),
+]
+
+_TABLE_PREFIX = "dmi_phase2_record_ring_e2e"
+
+
+class _TensorRecordFormat:
+    def __init__(self, schema):
+        self.schema = schema
+
+    def encode(self, metadata, entry):
+        from dmi.api.v1 import PayloadSlice, RecordDescriptor
+
+        run_id, record_id = metadata
+        return RecordDescriptor(
+            "tensor_record",
+            ((
+                run_id,
+                record_id,
+                PayloadSlice(dtype=entry.dtype, shape=entry.output_shape),
+            ),),
+            output_id=entry.output_id,
+        )
+
+
+class _EagerHookRuntime:
+    def __init__(self, runtime, metadata):
+        self._runtime = runtime
+        self._metadata = metadata
+
+    def should_emit(self, hook):
+        return True
+
+    def prepare_output(
+        self,
+        *,
+        hook,
+        output_index,
+        output_id,
+        output_spec,
+        output,
+    ):
+        from dmi.api.v1 import ProducerPlanBuilder
+
+        entry = ProducerPlanBuilder().record_output(
+            output_id=output_id,
+            output_spec=output_spec,
+            output=output,
+        )
+        return self._runtime.emit_output(entry, self._metadata, output)
+
+
+def test_record_producer_ring_descriptor_and_clickhouse_readback():
+    clickhouse_driver = pytest.importorskip("clickhouse_driver")
+    from dmi.api.v1 import (
+        ClickHouseClientConfig,
+        DMXHostEngine,
+        HookPointV1,
+        HookSpecV1,
+        MonitoringEngine,
+        RecordCellType,
+        RecordColumn,
+        RecordLayout,
+        RecordSchema,
+        RingConfig,
+        StageConfig,
+        TransportSpec,
+    )
+
+    db_host = os.environ.get("DMX_DB_HOST", "127.0.0.1")
+    db_port = int(os.environ.get("DMX_DB_PORT", "9000"))
+    database = os.environ.get("DMX_DB_DATABASE", "default")
+    quoted_database = database.replace("`", "``")
+    table = f"{_TABLE_PREFIX}_{uuid.uuid4().hex[:12]}"
+    qualified_table = f"`{quoted_database}`.`{table}`"
+    admin = clickhouse_driver.Client(host=db_host, port=db_port)
+    admin.execute(f"CREATE DATABASE IF NOT EXISTS `{quoted_database}`")
+
+    schema = RecordSchema(
+        (
+            RecordLayout(
+                name="tensor_record",
+                table=table,
+                columns=(
+                    RecordColumn("run_id", RecordCellType.STRING),
+                    RecordColumn("record_id", RecordCellType.INT64),
+                    RecordColumn(
+                        "payload",
+                        RecordCellType.TENSOR,
+                        dtype_column="payload_dtype",
+                        shape_column="payload_shape",
+                        bytes_column="payload_bytes",
+                    ),
+                ),
+                primary_key=("run_id", "record_id"),
+                order_by=("run_id", "record_id"),
+            ),
+        ),
+        index_granularity=1024,
+    )
+
+    clickhouse_config = ClickHouseClientConfig()
+    clickhouse_config.host = db_host
+    clickhouse_config.port = db_port
+    clickhouse_config.database = database
+    clickhouse_config.create_database_if_missing = True
+    clickhouse_config.drop_existing_database = False
+    host = DMXHostEngine(
+        StageConfig.clickhouse_records(
+            clickhouse_config,
+            schema,
+            parallelism=1,
+            name="phase2_record_ring_e2e",
+        )
+    )
+
+    ring_config = RingConfig()
+    ring_config.task_ring_entries = 64
+    ring_config.payload_ring_bytes = 1024 * 1024
+    ring_config.pinned_staging_bytes = 1024 * 1024
+
+    engine = None
+    try:
+        engine = MonitoringEngine(
+            model_id="phase2-generic-record-e2e",
+            host_engine=host,
+            ring_config=ring_config,
+        )
+        assert host.wait_until_ready(10.0)
+
+        runtime = engine.create_record_runtime(_TensorRecordFormat(schema))
+        hook = HookPointV1(
+            HookSpecV1("phase2_tensor", (TransportSpec("payload"),))
+        )
+        hook_runtime = _EagerHookRuntime(runtime, ("run-a", 7))
+        runtime.bind_hook(hook, hook_runtime=hook_runtime)
+
+        expected = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        hook(expected.cuda())
+        engine.flush_and_wait(30.0)
+
+        client = clickhouse_driver.Client(
+            host=db_host,
+            port=db_port,
+            database=database,
+        )
+        rows = client.execute(
+            f"SELECT run_id, record_id, payload_dtype, payload_shape, "
+            f"hex(payload_bytes) FROM `{table}`"
+        )
+        assert rows == [(
+            "run-a",
+            7,
+            "torch.float",
+            [3, 4],
+            expected.numpy().tobytes().hex().upper(),
+        )]
+    finally:
+        try:
+            if engine is not None:
+                engine.close()
+            else:
+                host.stop(False, 10.0)
+        finally:
+            admin.execute(f"DROP TABLE IF EXISTS {qualified_table}")

--- a/tests/test_record_ring_clickhouse_e2e.py
+++ b/tests/test_record_ring_clickhouse_e2e.py
@@ -159,8 +159,16 @@ def test_record_producer_ring_descriptor_and_clickhouse_readback():
         hook_runtime = _EagerHookRuntime(runtime, ("run-a", 7))
         runtime.bind_hook(hook, hook_runtime=hook_runtime)
 
+        scalar_hook = HookPointV1(
+            HookSpecV1("phase2_scalar_tensor", (TransportSpec("scalar_payload"),))
+        )
+        scalar_hook_runtime = _EagerHookRuntime(runtime, ("run-a", 8))
+        runtime.bind_hook(scalar_hook, hook_runtime=scalar_hook_runtime)
+
         expected = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        expected_scalar = torch.tensor(3.5, dtype=torch.float32)
         hook(expected.cuda())
+        scalar_hook(expected_scalar.cuda())
         engine.flush_and_wait(30.0)
 
         client = clickhouse_driver.Client(
@@ -170,15 +178,24 @@ def test_record_producer_ring_descriptor_and_clickhouse_readback():
         )
         rows = client.execute(
             f"SELECT run_id, record_id, payload_dtype, payload_shape, "
-            f"hex(payload_bytes) FROM `{table}`"
+            f"hex(payload_bytes) FROM `{table}` ORDER BY run_id, record_id"
         )
-        assert rows == [(
-            "run-a",
-            7,
-            "torch.float",
-            [3, 4],
-            expected.numpy().tobytes().hex().upper(),
-        )]
+        assert rows == [
+            (
+                "run-a",
+                7,
+                "torch.float",
+                [3, 4],
+                expected.numpy().tobytes().hex().upper(),
+            ),
+            (
+                "run-a",
+                8,
+                "torch.float",
+                [],
+                expected_scalar.numpy().tobytes().hex().upper(),
+            ),
+        ]
     finally:
         try:
             if engine is not None:

--- a/tests/test_record_runtime.py
+++ b/tests/test_record_runtime.py
@@ -1,0 +1,273 @@
+"""RecordRuntime ordering and customization tests using a fake transport."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from dmi.adapters.base import StepReservation
+from dmi.hooks.dynamic import HookOutput, HookPointV1, HookSpecV1, TransportSpec
+from dmi.hooks.producer_plan import ProducerPlan, ProducerPlanBuilder
+from dmi.records import (
+    PayloadSlice,
+    RecordCellType,
+    RecordColumn,
+    RecordDescriptor,
+    RecordLayout,
+    RecordRuntime,
+    RecordSchema,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+class _Transport:
+    def __init__(self, result=StepReservation.RESERVED):
+        self.result = result
+        self.events = []
+        self.payload = torch.empty(0, dtype=torch.uint8)
+
+    def _record_payload_tensor(self):
+        return self.payload
+
+    def configure_record_schema(self, schema):
+        self.schema = schema
+
+    def reserve_record(self, nbytes, tasks):
+        self.events.append(("reserve", nbytes, tasks))
+        return int(self.result)
+
+    def push_record_descriptors(self, descriptors):
+        self.events.append(("descriptors", tuple(descriptors)))
+
+    def submit_record_cpu_direct(self, output, entry):
+        self.events.append(("direct", output, entry))
+
+class _Format:
+    def __init__(self, layout_name="tensor_rows"):
+        self.schema = RecordSchema(
+            (
+                RecordLayout(
+                    layout_name,
+                    layout_name,
+                    (
+                        RecordColumn("tag", RecordCellType.STRING),
+                        RecordColumn(
+                            "payload",
+                            RecordCellType.TENSOR,
+                            "payload_dtype",
+                            "payload_shape",
+                            "payload_bytes",
+                        ),
+                    ),
+                    primary_key=("tag",),
+                    order_by=("tag",),
+                ),
+            )
+        )
+
+    def encode(self, metadata, entry):
+        return RecordDescriptor(
+            "tensor_rows",
+            ((str(metadata), PayloadSlice(dtype=entry.dtype, shape=entry.output_shape)),),
+            output_id=entry.output_id,
+        )
+
+
+class _EmptyFormat(_Format):
+    def encode(self, metadata, entry):
+        return RecordDescriptor(
+            "tensor_rows",
+            (),
+            output_id=entry.output_id,
+        )
+
+
+class _PayloadFreeProducerFormat:
+    schema = RecordSchema(
+        (
+            RecordLayout(
+                "metadata_rows",
+                "metadata_rows",
+                (RecordColumn("tag", RecordCellType.STRING),),
+                primary_key=("tag",),
+                order_by=("tag",),
+            ),
+        )
+    )
+
+    def encode(self, metadata, entry):
+        return RecordDescriptor(
+            "metadata_rows",
+            ((str(metadata),),),
+            output_id=entry.output_id,
+        )
+
+
+class _HookRuntime:
+    def should_emit(self, hook):
+        return True
+
+    def prepare_output(self, **kwargs):
+        return None
+
+
+def _runtime_and_entry(
+    *,
+    reservation=StepReservation.RESERVED,
+    record_format=None,
+):
+    transport = _Transport(reservation)
+    runtime = RecordRuntime(transport, record_format or _Format())
+    hook = HookPointV1(HookSpecV1("hook", (TransportSpec("out"),)))
+    runtime.bind_hook(hook, hook_runtime=_HookRuntime())
+    output = HookOutput(torch.arange(4, dtype=torch.float32))
+    entry = ProducerPlanBuilder().record_output(
+        output_id=hook._output_ids[0],
+        output_spec=hook.spec.outputs[0],
+        output=output,
+    )
+    return runtime, transport, output, entry
+
+
+def test_eager_descriptor_is_published_after_reservation_before_producer():
+    runtime, transport, output, entry = _runtime_and_entry()
+
+    result = runtime.emit_output(entry, "batch-7", output)
+
+    assert result is StepReservation.RESERVED
+    assert transport.events[0] == ("reserve", 16, 1)
+    assert transport.events[1][0] == "descriptors"
+    assert len(transport.events) == 2
+
+
+def test_oversized_eager_output_publishes_then_submits_directly():
+    runtime, transport, output, entry = _runtime_and_entry(
+        reservation=StepReservation.OVERSIZED
+    )
+
+    result = runtime.emit_output(entry, "batch-7", output)
+
+    assert result is StepReservation.OVERSIZED
+    assert [event[0] for event in transport.events] == [
+        "reserve",
+        "descriptors",
+        "direct",
+    ]
+
+
+def test_replay_encodes_complete_batch_before_descriptor_publication():
+    runtime, transport, output, entry = _runtime_and_entry()
+    result = runtime.prepare_replay(ProducerPlan((entry,)), ("fresh",))
+
+    assert result is StepReservation.RESERVED
+    assert transport.events[0] == ("reserve", 16, 1)
+    descriptor = transport.events[1][1][0]
+    assert descriptor.rows[0][0] == "fresh"
+
+
+def test_replay_publishes_one_empty_descriptor_per_producer_occurrence():
+    runtime, transport, _output, entry = _runtime_and_entry(
+        record_format=_EmptyFormat()
+    )
+
+    result = runtime.prepare_replay(
+        ProducerPlan((entry, entry)),
+        ("first", "second"),
+    )
+
+    assert result is StepReservation.RESERVED
+    assert transport.events[0] == ("reserve", 32, 2)
+    descriptors = transport.events[1][1]
+    assert len(descriptors) == 2
+    assert all(descriptor.rows == () for descriptor in descriptors)
+
+
+def test_nonempty_producer_descriptor_requires_payload_slice():
+    runtime, transport, output, entry = _runtime_and_entry(
+        record_format=_PayloadFreeProducerFormat()
+    )
+
+    with pytest.raises(ValueError, match="must contain a PayloadSlice"):
+        runtime.emit_output(entry, "batch-7", output)
+
+    assert transport.events == []
+
+
+def test_two_independent_formats_do_not_share_schema_or_output_registry():
+    class _OtherFormat:
+        def __init__(self):
+            self.schema = RecordSchema(
+                (
+                    RecordLayout(
+                        "other_rows",
+                        "other_rows",
+                        (
+                            RecordColumn("value", RecordCellType.INT64),
+                            RecordColumn(
+                                "data",
+                                RecordCellType.TENSOR,
+                                "data_dtype",
+                                "data_shape",
+                                "data_bytes",
+                            ),
+                        ),
+                        primary_key=("value",),
+                        order_by=("value",),
+                    ),
+                )
+            )
+
+        def encode(self, metadata, entry):
+            return RecordDescriptor(
+                "other_rows",
+                ((
+                    int(metadata),
+                    PayloadSlice(dtype=entry.dtype, shape=entry.output_shape),
+                ),),
+                output_id=entry.output_id,
+            )
+
+    transport_a = _Transport()
+    transport_b = _Transport()
+    format_a = _Format()
+    format_b = _OtherFormat()
+    runtime_a = RecordRuntime(transport_a, format_a)
+    runtime_b = RecordRuntime(transport_b, format_b)
+    hook_a = HookPointV1(HookSpecV1("a", (TransportSpec("out"),)))
+    hook_b = HookPointV1(HookSpecV1("b", (TransportSpec("out"),)))
+
+    runtime_a.bind_hook(hook_a, hook_runtime=_HookRuntime())
+    runtime_b.bind_hook(hook_b, hook_runtime=_HookRuntime())
+
+    output = HookOutput(torch.ones(1))
+    entry_a = ProducerPlanBuilder().record_output(
+        output_id=hook_a._output_ids[0],
+        output_spec=hook_a.spec.outputs[0],
+        output=output,
+    )
+    entry_b = ProducerPlanBuilder().record_output(
+        output_id=hook_b._output_ids[0],
+        output_spec=hook_b.spec.outputs[0],
+        output=output,
+    )
+    runtime_a.emit_output(entry_a, "one", output)
+    runtime_b.emit_output(entry_b, 2, output)
+
+    assert hook_a._output_ids == hook_b._output_ids == (1 << 16,)
+    assert transport_a.schema.layouts[0].name == "tensor_rows"
+    assert transport_b.schema.layouts[0].name == "other_rows"
+    assert transport_a.schema is format_a.schema
+    assert transport_b.schema is format_b.schema
+
+
+def test_binding_reuses_private_output_id_for_same_declared_name():
+    transport = _Transport()
+    runtime = RecordRuntime(transport, _Format())
+    first = HookPointV1(HookSpecV1("first", (TransportSpec("shared"),)))
+    second = HookPointV1(HookSpecV1("second", (TransportSpec("shared"),)))
+
+    runtime.bind_hook(first, hook_runtime=_HookRuntime())
+    runtime.bind_hook(second, hook_runtime=_HookRuntime())
+
+    assert first._output_ids == second._output_ids == (1 << 16,)

--- a/tests/test_record_runtime.py
+++ b/tests/test_record_runtime.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from dmi.adapters.base import StepReservation
-from dmi.hooks.dynamic import (
+from dmi.hooks.record import (
     HookOutput,
     HookPointV1,
     HookSpecV1,

--- a/tests/test_record_runtime.py
+++ b/tests/test_record_runtime.py
@@ -32,6 +32,8 @@ class _Transport:
         self.result = result
         self.events = []
         self.payload = torch.empty(0, dtype=torch.uint8)
+        self.null_offload = False
+        self.pending_tasks = 0
 
     def _record_payload_tensor(self):
         return self.payload
@@ -41,6 +43,7 @@ class _Transport:
 
     def reserve_record(self, items):
         self.events.append(("reserve", tuple(items)))
+        self.pending_tasks += len(items)
         return int(self.result)
 
     def push_record_descriptors(self, descriptors):
@@ -48,6 +51,11 @@ class _Transport:
 
     def submit_record_cpu_direct(self, output, entry):
         self.events.append(("direct", output, entry))
+
+    def flush_records_and_wait(self, timeout_s):
+        self.events.append(("flush", timeout_s))
+        if self.pending_tasks:
+            raise TimeoutError("unmatched reserved record tasks")
 
 class _Format:
     def __init__(self, layout_name="tensor_rows"):
@@ -170,6 +178,25 @@ def test_replay_encodes_complete_batch_before_descriptor_publication():
     assert transport.events[0] == ("reserve", ((16, False),))
     descriptor = transport.events[1][1][0]
     assert descriptor.rows[0][0] == "fresh"
+
+
+def test_capture_disabled_skips_eager_and_replay_until_reenabled():
+    runtime, transport, output, entry = _runtime_and_entry()
+    plan = ProducerPlan((entry,))
+    transport.null_offload = True
+
+    assert runtime.emit_output(entry, "eager-disabled", output) is StepReservation.SKIPPED
+    assert runtime.prepare_replay(plan, ("replay-disabled",)) is StepReservation.SKIPPED
+    transport.flush_records_and_wait(0.25)
+    assert transport.events == [("flush", 0.25)]
+
+    transport.null_offload = False
+    assert runtime.emit_output(entry, "enabled", output) is StepReservation.RESERVED
+    assert [event[0] for event in transport.events] == [
+        "flush",
+        "reserve",
+        "descriptors",
+    ]
 
 
 def test_replay_publishes_one_empty_descriptor_per_producer_occurrence():

--- a/tests/test_record_runtime.py
+++ b/tests/test_record_runtime.py
@@ -6,7 +6,13 @@ import pytest
 import torch
 
 from dmi.adapters.base import StepReservation
-from dmi.hooks.dynamic import HookOutput, HookPointV1, HookSpecV1, TransportSpec
+from dmi.hooks.dynamic import (
+    HookOutput,
+    HookPointV1,
+    HookSpecV1,
+    TransportSpec,
+    TransportType,
+)
 from dmi.hooks.producer_plan import ProducerPlan, ProducerPlanBuilder
 from dmi.records import (
     PayloadSlice,
@@ -33,8 +39,8 @@ class _Transport:
     def configure_record_schema(self, schema):
         self.schema = schema
 
-    def reserve_record(self, nbytes, tasks):
-        self.events.append(("reserve", nbytes, tasks))
+    def reserve_record(self, items):
+        self.events.append(("reserve", tuple(items)))
         return int(self.result)
 
     def push_record_descriptors(self, descriptors):
@@ -136,7 +142,7 @@ def test_eager_descriptor_is_published_after_reservation_before_producer():
     result = runtime.emit_output(entry, "batch-7", output)
 
     assert result is StepReservation.RESERVED
-    assert transport.events[0] == ("reserve", 16, 1)
+    assert transport.events[0] == ("reserve", ((16, False),))
     assert transport.events[1][0] == "descriptors"
     assert len(transport.events) == 2
 
@@ -161,7 +167,7 @@ def test_replay_encodes_complete_batch_before_descriptor_publication():
     result = runtime.prepare_replay(ProducerPlan((entry,)), ("fresh",))
 
     assert result is StepReservation.RESERVED
-    assert transport.events[0] == ("reserve", 16, 1)
+    assert transport.events[0] == ("reserve", ((16, False),))
     descriptor = transport.events[1][1][0]
     assert descriptor.rows[0][0] == "fresh"
 
@@ -177,7 +183,10 @@ def test_replay_publishes_one_empty_descriptor_per_producer_occurrence():
     )
 
     assert result is StepReservation.RESERVED
-    assert transport.events[0] == ("reserve", 32, 2)
+    assert transport.events[0] == (
+        "reserve",
+        ((16, False), (16, False)),
+    )
     descriptors = transport.events[1][1]
     assert len(descriptors) == 2
     assert all(descriptor.rows == () for descriptor in descriptors)
@@ -192,6 +201,32 @@ def test_nonempty_producer_descriptor_requires_payload_slice():
         runtime.emit_output(entry, "batch-7", output)
 
     assert transport.events == []
+
+
+def test_dynamic_producer_is_individually_marked_for_reclaim():
+    transport = _Transport()
+    runtime = RecordRuntime(transport, _Format())
+    spec = TransportSpec(
+        "out",
+        transport_type=TransportType.CHUNKED,
+        reservation_upper_bytes=64,
+        output_shape=(-1,),
+    )
+    hook = HookPointV1(HookSpecV1("hook", (spec,)))
+    runtime.bind_hook(hook, hook_runtime=_HookRuntime())
+    output = HookOutput(
+        torch.arange(4, dtype=torch.float32),
+        (torch.tensor(16, dtype=torch.int64),),
+    )
+    entry = ProducerPlanBuilder().record_output(
+        output_id=hook._output_ids[0],
+        output_spec=spec,
+        output=output,
+    )
+
+    runtime.emit_output(entry, "dynamic", output)
+
+    assert transport.events[0] == ("reserve", ((64, True),))
 
 
 def test_two_independent_formats_do_not_share_schema_or_output_registry():

--- a/tests/test_record_schema.py
+++ b/tests/test_record_schema.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from dmi.api.v1 import (
+    RecordCellType,
+    RecordColumn,
+    RecordLayout,
+    RecordSchema,
+)
+
+
+def _metadata_layout(name: str = "metadata", table: str = "metadata_records"):
+    return RecordLayout(
+        name=name,
+        table=table,
+        columns=(
+            RecordColumn("name", RecordCellType.STRING),
+            RecordColumn("rank", RecordCellType.INT32),
+            RecordColumn("step", RecordCellType.INT64),
+            RecordColumn("score", RecordCellType.FLOAT64),
+            RecordColumn("extent", RecordCellType.INT64_ARRAY),
+        ),
+        primary_key=("name", "rank", "step"),
+        order_by=("name", "rank", "step"),
+    )
+
+
+def test_schema_accepts_independent_metadata_and_tensor_layouts():
+    tensor_layout = RecordLayout(
+        name="payload",
+        table="payload_records",
+        columns=(
+            RecordColumn("record_id", RecordCellType.INT64),
+            RecordColumn(
+                "payload",
+                RecordCellType.TENSOR,
+                dtype_column="payload_dtype",
+                shape_column="payload_shape",
+                bytes_column="payload_bytes",
+            ),
+        ),
+        primary_key=("record_id",),
+        order_by=("record_id",),
+    )
+    schema = RecordSchema((_metadata_layout(), tensor_layout), index_granularity=4096)
+
+    assert schema.layout("metadata") is schema.layouts[0]
+    assert schema.layout("payload") is tensor_layout
+    assert schema.index_granularity == 4096
+
+
+def test_tensor_column_requires_all_physical_column_names():
+    with pytest.raises(ValueError, match="require dtype_column"):
+        RecordColumn("payload", RecordCellType.TENSOR)
+
+
+def test_layout_rejects_missing_or_undeclared_keys():
+    with pytest.raises(ValueError, match="primary_key"):
+        RecordLayout(
+            name="missing_keys",
+            table="missing_keys",
+            columns=(RecordColumn("value", RecordCellType.INT64),),
+        )
+
+    with pytest.raises(ValueError, match="table identifier"):
+        RecordLayout(
+            name="qualified_table",
+            table="other_database.records",
+            columns=(RecordColumn("value", RecordCellType.INT64),),
+            primary_key=("value",),
+            order_by=("value",),
+        )
+
+    with pytest.raises(ValueError, match="must name"):
+        RecordLayout(
+            name="bad_key",
+            table="bad_key",
+            columns=(RecordColumn("value", RecordCellType.INT64),),
+            primary_key=("absent",),
+            order_by=("value",),
+        )
+
+
+def test_schema_rejects_duplicate_layout_or_table_identity():
+    layout = _metadata_layout()
+    with pytest.raises(ValueError, match="layout names"):
+        RecordSchema((layout, _metadata_layout(table="other_table")))
+    with pytest.raises(ValueError, match="table names"):
+        RecordSchema((layout, _metadata_layout(name="other_layout")))

--- a/tests/test_ring_transport_no_framework_strings.py
+++ b/tests/test_ring_transport_no_framework_strings.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.cpu
 SOURCE_ROOT = Path(__file__).resolve().parent.parent / "src" / "dmi"
 CORE_MODULES = (
     SOURCE_ROOT / "hooks" / "specs.py",
-    SOURCE_ROOT / "hooks" / "dynamic.py",
+    SOURCE_ROOT / "hooks" / "record.py",
     SOURCE_ROOT / "hooks" / "producer_plan.py",
     SOURCE_ROOT / "records.py",
     SOURCE_ROOT / "transport" / "ring.py",

--- a/tests/test_ring_transport_no_framework_strings.py
+++ b/tests/test_ring_transport_no_framework_strings.py
@@ -30,6 +30,9 @@ pytestmark = pytest.mark.cpu
 SOURCE_ROOT = Path(__file__).resolve().parent.parent / "src" / "dmi"
 CORE_MODULES = (
     SOURCE_ROOT / "hooks" / "specs.py",
+    SOURCE_ROOT / "hooks" / "dynamic.py",
+    SOURCE_ROOT / "hooks" / "producer_plan.py",
+    SOURCE_ROOT / "records.py",
     SOURCE_ROOT / "transport" / "ring.py",
 )
 HOOK_SPECS = CORE_MODULES[0]


### PR DESCRIPTION
## Summary

Add an explicit, opt-in record offload path for external DMI integrations. Integrations define their own hooks, record schemas, and descriptor encoding, while DMI core owns capture, transport, payload association, flushing, and schema-driven storage.

## What changed

- Add `HookPointV1` and ordered producer plans for integration-defined outputs.
- Add `RecordFormat`, `RecordSchema`, `RecordDescriptor`, and `RecordRuntime`.
- Extend the CUDA ring transport with tensor and scalar producers defined by those plans.
- Associate ordered payload tasks with integration-provided record descriptors.
- Support oversized CPU-direct fallback without changing the normal ring path.
- Add schema-driven ClickHouse tables and typed record insertion.
- Add checked, nonterminal durable flushing through the native host pipeline.
- Track reclaimable reservations per task; exact-size tasks bypass reclaim tracking.
- Export and document the additive surface through `dmi.api.v1`.

## Compatibility

The new path is selected only through explicit record-runtime and record-storage construction.

Existing behavior remains unchanged for:

- `MonitoringEngine` and the legacy ring setup
- fixed `HookPoint` definitions and presets
- the existing eight-cell inference record format
- Hugging Face integration
- the released vLLM integration

DMI core contains no Megatron-specific fields, schemas, selectors, or runtime policy.

## Validation

- Fixed CUDA 12.8 native builds: PASS
- Pre-rename focused Python regression: 72 passed, 6 deselected
- Final-head rename-focused Python regression: 44 passed
- Host-native regression: 49 passed
- CUDA native ring regression: 673 assertions passed, 0 failed
- Direct ClickHouse storage tests: 7 passed
- Generic ring-to-ClickHouse E2E: 1 passed
- Final-head existing HF/vLLM compatibility E2E: 7/7 cases passed

The compatibility matrix covered HF eager TP1/TP2 and vLLM eager TP1/PP1, TP2/PP1, TP1/PP2, plus vLLM CUDA Graph TP1/TP2.

## Scope

This PR adds only the framework-neutral core contract. Framework adapters, framework-owned schemas and metadata, orchestration, and model-specific hook placement remain in their integration repositories.
