### PR TITLE
DMI-configurator: apply layer ranges at runtime, estimate payload cost, and make it launchable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 PYTHON ?= python
 
-.PHONY: all native host clean check check-compile test test-all test-cpu test-host test-package
+.PHONY: all native host clean check check-compile test test-all test-cpu test-host test-package ui
 
 NATIVE_DIR ?= $(CURDIR)/native
+
+# DMI-configurator. Runs straight from the checkout -- no install needed.
+# Point it somewhere else with: make ui MODEL=./my-model
+MODEL ?= examples/model_descriptors/llama3-8b.yaml
 
 all: native
 
@@ -14,6 +18,9 @@ host:
 
 clean:
 	$(MAKE) -C $(NATIVE_DIR) clean
+
+ui:
+	PYTHONPATH=$(CURDIR)/src $(PYTHON) -m dmi.cli ui $(MODEL)
 
 test: test-cpu
 

--- a/README.md
+++ b/README.md
@@ -117,20 +117,27 @@ Full setup, additional results, and how to reproduce:
 ## Configure a capture visually
 
 DMI-configurator turns a model plus a few clicks into a validated capture
-configuration, and estimates what it will cost before you run anything. From a
-checkout, with no install:
+configuration, and estimates what it will cost before you run anything. It
+needs the optional web dependencies once:
+
+```bash
+pip install -e ".[ui]"
+```
+
+After that, from a checkout:
 
 ```bash
 make ui
 ```
 
 That opens a browser on <http://127.0.0.1:8000>. Point it at your own model
-with `make ui MODEL=./Qwen3-8B`.
+with `make ui MODEL=./Qwen3-8B`. `make ui` runs from the source tree without
+installing DMI itself, but the `[ui]` extra is required either way — the
+server raises a `RuntimeError` naming this command if it is missing.
 
-Installed, it is a normal command:
+With DMI installed, it is a normal command:
 
 ```bash
-pip install -e ".[ui]"
 dmi ui ./Qwen3-8B
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,31 @@ at much lower request rates.
 Full setup, additional results, and how to reproduce:
 [`docs/benchmarks.md`](docs/benchmarks.md).
 
+## Configure a capture visually
+
+DMI-configurator turns a model plus a few clicks into a validated capture
+configuration, and estimates what it will cost before you run anything. From a
+checkout, with no install:
+
+```bash
+make ui
+```
+
+That opens a browser on <http://127.0.0.1:8000>. Point it at your own model
+with `make ui MODEL=./Qwen3-8B`.
+
+Installed, it is a normal command:
+
+```bash
+pip install -e ".[ui]"
+dmi ui ./Qwen3-8B
+```
+
+`dmi ui` accepts a model directory, a `config.json`, a Hugging Face model id,
+or a DMI descriptor YAML, and picks the descriptor out of the current directory
+when there is exactly one. See
+[the configurator plan](docs/dmi-configurator-plan.md) for the design.
+
 ## Get started
 
 Start with the [core installation guide](docs/install.md), then choose the

--- a/docs/capture-policy-review.md
+++ b/docs/capture-policy-review.md
@@ -1,6 +1,10 @@
 # Optimization policy capture plan: design review
 
-Status: Review of a proposed design; no implementation accepted
+Status: Review of a proposed design; no policy implementation accepted
+
+Baseline: verified against `main` at `cb4e490`. See the addendum at the end for
+what `feat/dmi-configurator` -- merged into this branch after the review was
+written -- already resolves.
 
 This document reviews a proposed design that would make optimization policy a
 first-class part of the capture plan. The proposal introduces user-facing
@@ -245,3 +249,54 @@ Ship **Balanced** and **Custom** first. Hold **Fastest** until `drop` exists —
 it currently promises "never blocks" over a transport that only blocks. Hold
 **Complete** until accounting exists, not until backpressure exists; the
 backpressure is already there.
+
+---
+
+## Addendum: status on this branch
+
+The findings above were verified against `main`. `feat/dmi-configurator` has
+since been merged into this branch, and it already resolves several of them.
+The record above is left as written, because it reviews a proposal that
+targeted `main`; this addendum states what is no longer true.
+
+### Resolved by the configurator
+
+| Review point | Status on this branch |
+|---|---|
+| "No model manifest exists" | Resolved. `ModelDescriptor` + `dmi describe-model`. |
+| "No YAML configuration in the repository" | Resolved. `dmi.configuration.yaml`, golden fixtures under `tests/golden/`. |
+| "No CLI exists" | Partly resolved. `dmi ui` and `dmi describe-model` ship; `dmi plan …` does not. |
+| Finding 3, per-layer selection | Partly resolved. Inclusive layer *ranges* exist and are now applied by the runtime; arbitrary layer *sets* still are not. |
+| MoE hooks grouped as `GROUP_OTHER` | Resolved. `catalog_adapter` layers a presentation grouping over catalog groups. |
+| Availability reasons in the UI | Resolved. Derived from `select_hook_specs`, not reimplemented. |
+
+### Resolved by this branch
+
+**Finding 3, runtime application.** A layer range authored in the configurator
+was previously never applied: `attach_model` had no way to receive it. It now
+takes a keyword `layers` argument and applies `filter_by_layers` between
+`apply_hook_selection` and the PP/TP filters, driven from a `DMIConfig` by
+`dmi.configuration.attach_config`. This closes a silent over-promise -- the
+policy control in the UI was honestly disclaimed, but layer selection, the
+UI's central feature, was not.
+
+**Findings 6 and 7, made usable.** `dmi.configuration.estimate` reports the
+peak single step against `min(payload, pinned)` effective capacity and names
+the worst rank, rather than reporting only a rate or a model-wide average. The
+configurator shows both. It reuses `compute_hook_shape` and `plan_step`'s
+alignment so the estimate cannot drift from what `prepare_step` enforces.
+
+### Unchanged
+
+Every blocking finding that bears on *policy* still stands:
+
+* **Finding 1.** `CaptureSchedule` is still enforced by no shipped adapter. The
+  configurator authors a schedule; nothing applies it. This remains the
+  prerequisite for any policy that claims to change sampling.
+* **Finding 2.** The transport still blocks losslessly and still has no drop
+  path. `block` is the status quo; `drop` and `fail` are the new work.
+* **Findings 4, 5, 8, 9.** Untouched -- they concern the policy module, which
+  is deliberately deferred.
+
+The resequencing above therefore holds, with its first item now half done:
+layer selection is wired, schedule enforcement is not.

--- a/docs/capture-policy-review.md
+++ b/docs/capture-policy-review.md
@@ -1,0 +1,247 @@
+# Optimization policy capture plan: design review
+
+Status: Review of a proposed design; no implementation accepted
+
+This document reviews a proposed design that would make optimization policy a
+first-class part of the capture plan. The proposal introduces user-facing
+policies (fastest / balanced / complete / budget / custom), per-selection
+importance levels, a `dmi/v1 CapturePlan` YAML, a deterministic policy
+resolver under `src/dmi/planning/`, native pressure semantics, and an eight-
+phase delivery plan.
+
+The review holds the proposal against the code as it exists on `main`. The
+architecture is sound. Several of its premises about DMI's current runtime are
+not, and the corrections change the phase ordering.
+
+## Verdict
+
+The core principle is right:
+
+> The user states intent and constraints; the configurator resolves them into
+> explicit capture, sampling, buffering, and persistence settings.
+
+So is the `PolicyIntent` / `EffectiveCapturePlan` split, and the requirement
+that the serialized plan — not hidden UI logic — is what the runtime consumes.
+
+The problem is sequencing. The proposal repeatedly assumes runtime machinery
+DMI does not have, and it inverts the pressure behavior DMI does have. Its
+recommended first milestone — "Balanced, Fastest, and Custom using DMI's
+existing schedule and buffer controls" — cannot be built as written, because
+none of those three rest on controls that are wired up.
+
+## Findings
+
+| # | Finding | Severity |
+|---|---|---|
+| 1 | `CaptureSchedule` is dead config; no adapter enforces it | Blocking |
+| 2 | Pressure model is inverted: DMI already blocks, cannot drop | Blocking |
+| 3 | Per-layer capture selection does not exist | Blocking |
+| 4 | `layers.overrides` encodes catalog-derived facts as user input | Design |
+| 5 | Pressure is two domains, and a vocabulary already exists | Design |
+| 6 | Binding constraint is per-step bytes, not MiB/s | Design |
+| 7 | Estimator must be rank-aware; budget units are ambiguous | Design |
+| 8 | `register_preset` breaks the determinism acceptance criterion | Design |
+| 9 | Runtime adaptation has one lever, and it needs quiescence | Design |
+
+### 1. `CaptureSchedule` is dead config
+
+`src/dmi/config.py` defines `should_capture_request` and
+`should_capture_step`. Across the whole repository the only callers are
+`tests/test_config.py` and the documentation. `src/dmi/engine.py` assigns
+`self.config = config` and never reads it again. `docs/integration-api-v1.md`
+states the contract plainly:
+
+> concrete adaptors decide whether and how to apply it; the engine does not
+> enforce the schedule by itself.
+
+No shipped adapter applies it. `docs/vllm.md`'s configuration table exposes no
+stride knobs at all.
+
+The proposal's Phase 4 ("Map effective schedules into `CaptureSchedule`") is
+therefore not a mapping task; it is implementing schedule enforcement in the
+adapters. Until that exists, a resolver emitting `step: {stride: 2}` produces a
+YAML that does not describe what DMI executes — which violates the proposal's
+own acceptance criterion.
+
+### 2. The pressure model is inverted
+
+`RingEnginePy::prepare_step` in `native/csrc/ring/ring_engine_py.cu` is a
+pre-forward host-side capacity check. The fast path reserves and returns. When
+the ring is full it synchronizes the main stream, calls
+`force_flush_and_wait()`, reserves, and returns `STEP_RING_FLUSHED`. That is
+lossless blocking backpressure at step granularity. `ring/ring_state.h` records
+the invariant:
+
+> Space is guaranteed by the pre-forward capacity check before kernel launch.
+
+There is no drop path anywhere in the transport. Two consequences:
+
+- The proposal hedges that complete capture may be "unavailable" pending
+  lossless backpressure. Block is what already exists. Complete is closer to
+  shippable than assumed — what it lacks is *accounting*, not mechanism.
+- The proposal's Fastest preset requires "never introduce blocking behavior."
+  **Fastest is the policy that is unimplementable today**, because every
+  capture path blocks on a full ring. Its only honest current form is: size the
+  rings so blocking is unlikely, and use null mode as the kill switch.
+
+Phase 6 should be reordered on this basis. `drop` and `fail` are the new work;
+`block` is the status quo.
+
+### 3. Per-layer capture selection does not exist
+
+`resolve_hook_selection` in `src/dmi/hooks/selection.py` unions comma-separated
+tokens into a set of hook *types*. There is no layer dimension in selection,
+in `CaptureSchedule`, or in the vLLM knobs.
+
+So `capture.layers.default: [0, 8, 16, 24, 31]` and `capture.layers.overrides`
+have no runtime counterpart, and the proposal's own decision-trace example —
+"Selected five representative transformer layers" — is currently
+inexpressible.
+
+Layer sampling is also the highest-leverage byte-reduction lever every preset
+depends on: Fastest's "representative layers for optional per-layer hooks" and
+Budget's "layer sampling before removing high-value global signals" both reduce
+to it. It is Phase 1 work, not an assumption.
+
+### 4. `layers.overrides` encodes catalog facts as user input
+
+`final_logits: global` and `token_ids: global` are not user choices.
+`src/dmi/hooks/catalog.py` sets `per_layer=False` for both, as it does for
+`embed`, `pos_embed`, `final_ln`, and `resid_final`.
+
+Derive scope from `HOOK_DEFS`. A per-layer override on a global hook should be
+a validation error, not an accepted key. The same applies to pipeline placement
+(`PP_FIRST` / `PP_LAST`) and tensor-parallel sharding — all catalog-derived.
+
+### 5. Pressure is two domains, and a vocabulary already exists
+
+DMI has two distinct pressure stages that fail differently and on different
+timescales:
+
+| Stage | Current behavior | Telemetry |
+|---|---|---|
+| GPU ring transport | Block only (`prepare_step`) | None |
+| Host storage spool | `BLOCK` or `DROP_NEWEST` | Loss counters and peak occupancy |
+
+`src/dmi/storage/capture/pipeline.py` already defines `OverloadPolicy` and
+`AdmissionResult{ACCEPTED, DROPPED, TIMED_OUT, TOO_LARGE, CLOSED}`.
+`src/dmi/storage/capture/record_adapter.py` already tracks a `_LOSS_COUNTERS`
+tuple covering dropped, timed-out, oversized, duplicate, and rejected records
+plus failures. `QueueSnapshot` tracks `peak_records` and `peak_bytes` — the
+proposal's `high_watermark_bytes`, implemented one layer up.
+
+Do not introduce a third parallel `PressureStrategy` enum. Extend this
+vocabulary, and make `pressure:` a per-stage mapping (`transport:`, `spool:`,
+`persistence:`) instead of one global block. A single `exhausted_action` cannot
+describe a system where one stage blocks and another drops.
+
+### 6. The binding constraint is per-step bytes, not MiB/s
+
+When `step_total_bytes > min(payload_cap, staging_cap)`, `prepare_step` returns
+`STEP_OVERSIZED` and the adapter falls back to `force_eager` plus CPU-direct
+dispatch. That is a large, quiet performance cliff — not data loss.
+
+The resolver must validate peak single-step bytes against *effective* capacity
+(`min(payload, pinned)`, already exposed as `RingCapacities.effective_bytes` in
+`src/dmi/engine.py`). Prefill dominates that peak because `q_len` is large. The
+proposal treats `phases: {prefill, decode}` as booleans, but max-prefill-step
+sizing is what decides whether a plan silently degrades.
+
+The proposal's error example is right in spirit. Make it check effective
+capacity, and emit a warning with an explanation for the fallback case rather
+than only a hard error — DMI degrades rather than failing.
+
+### 7. The estimator must be rank-aware
+
+`compute_hook_shape` divides sharded hooks by `tp_size`, and `filter_by_tp_rank`
+keeps unsharded hooks only on rank 0. Aggregate bytes are therefore roughly
+TP-invariant, but ring pressure is not: rank 0 carries every unsharded hook plus
+its own shard, and `PP_FIRST` / `PP_LAST` skew the pipeline stages the same way.
+
+`max_capture_mib_per_second: 800` does not say whether it is per-rank or
+aggregate. Add `scope: per_rank | aggregate` to each budget constraint, and
+evaluate the ring-capacity validation against the **worst rank**, not the
+average.
+
+### 8. `register_preset` breaks the determinism criterion
+
+The acceptance criterion "the same manifest and policy always generate the same
+effective plan" is violated by `register_preset` in
+`src/dmi/hooks/selection.py`, which mutates a module-global dictionary at
+adapter import time. The resolved plan therefore depends on which adapters were
+imported.
+
+The plan fingerprint must cover the resolved hook-type set, not the preset
+string. `resolution.model_fingerprint` alone is insufficient.
+
+### 9. Runtime adaptation has one lever, and it needs quiescence
+
+`MonitoringEngine.set_capture_enabled` documents that callers "must ensure that
+no forward pass can overlap this method." The classic producer kernels in
+`native/csrc/ring/producer.cu` gate only on the device-global
+`g_ring_null_mode` — all or nothing. Only the newer record producers accept a
+per-launch `emit_gate` device pointer.
+
+So the proposal's safe adaptive sequence — raise step stride for optional
+hooks, raise request stride for optional hooks, disable optional hooks, and so
+on — assumes per-hook schedules that exist in no form. `CaptureSchedule` is
+global; hook selection is fixed at `attach_model`. Today's real lever set is one
+global schedule (unenforced), one global selection (attach-time), and one kill
+switch (quiescent).
+
+The cheap unlock is extending `emit_gate` to the classic producers. That yields
+a CUDA-graph-safe, per-hook, per-step, device-side gate, which is exactly what
+every adaptive step needs. It should be an explicit Phase 6 deliverable; the
+adaptive controller is not buildable without it.
+
+## Smaller corrections
+
+- **No metrics surface exists.** There is no Prometheus, Grafana, or exporter
+  anywhere in the repository. The telemetry section implies a surface that is
+  not there; an exporter is its own workstream, absent from the phase list.
+  Name new counters off the existing `_LOSS_COUNTERS` vocabulary so the
+  reference path and the transport path report in the same terms.
+- **No CLI exists.** `pyproject.toml` declares no `[project.scripts]`. The
+  proposed `dmi plan {validate,resolve,estimate,explain}` needs a new console
+  entry point. `pyyaml` and `pydantic` are already in `requirements.txt`, so the
+  schema layer adds no dependencies.
+- **No model manifest exists.** `llama-3.1-8b.dmi-model.yaml` is entirely new;
+  there is no YAML configuration in the repository today. `ModelShapeConfig` in
+  `src/dmi/hooks/specs.py` is the natural serialization target and covers most
+  of what the estimator needs.
+- **`persistence.finalize_mode: wait` maps cleanly.** `flush_and_wait` in
+  `src/dmi/engine.py` and the `stop_monitoring` endpoint in `docs/vllm.md` are
+  real counterparts. This part of the proposal is well grounded.
+- **Complete needs a fourth number.** Selection, transport, and persistence
+  completeness omit *schedule* completeness. Folding stride into "eligible
+  planned tensors" makes 100% completeness achievable while capturing every
+  other step — not the reading a user of "Complete" expects. The proposal
+  already forces stride 1 for complete mode; the report should also state the
+  denominator's provenance, and both figures should be scoped per session and
+  per rank.
+- **Separating instantaneous capacity from sustained bandwidth is the best idea
+  in the proposal.** It mirrors the real structure: `prepare_step` enforces
+  instantaneous capacity, while the drain thread's `drain_flush_*` thresholds
+  govern sustained drain. Keep it.
+
+## Suggested resequencing
+
+The proposal's phases are ordered by abstraction layer. They should be ordered
+by dependency.
+
+1. **Runtime prerequisites.** Enforce `CaptureSchedule` in the adapters; add
+   per-layer selection to `src/dmi/hooks/selection.py`; extend `emit_gate` to
+   the classic producers. Without these there is nothing for a resolver to
+   resolve.
+2. **Policy schema and static presets** (the proposal's Phase 1), with `custom`
+   wrapping legacy configuration.
+3. **Estimator and resolver**, made rank-aware and driven by peak-prefill-step
+   bytes against effective capacity.
+4. **Completeness accounting**, reusing the spool's existing counters.
+5. **Drop and fail transport semantics** (block already exists), then the
+   adaptive controller, then calibration.
+
+Ship **Balanced** and **Custom** first. Hold **Fastest** until `drop` exists —
+it currently promises "never blocks" over a transport that only blocks. Hold
+**Complete** until accounting exists, not until backpressure exists; the
+backpressure is already there.

--- a/docs/dmi-configurator-plan.md
+++ b/docs/dmi-configurator-plan.md
@@ -6,7 +6,14 @@ Verified against: `cb4e490`
 
 ## Running it
 
-From a checkout, with nothing installed:
+The web dependencies are needed once (`fastapi` and `uvicorn`; DMI itself does
+not have to be installed):
+
+```bash
+pip install -e ".[ui]"
+```
+
+Then, from a checkout:
 
 ```bash
 make ui

--- a/docs/dmi-configurator-plan.md
+++ b/docs/dmi-configurator-plan.md
@@ -23,10 +23,9 @@ This runs the bundled Llama-3-8B descriptor, picks a free port starting at
 8000, and opens a browser once the server is actually accepting connections.
 Override the model with `make ui MODEL=./Qwen3-8B`.
 
-Installed, it is a normal command:
+With DMI itself installed, it is a normal command:
 
 ```bash
-pip install -e ".[ui]"
 dmi ui ./Qwen3-8B
 ```
 

--- a/docs/dmi-configurator-plan.md
+++ b/docs/dmi-configurator-plan.md
@@ -626,15 +626,55 @@ The only change to existing code is additive: `filter_by_layers` and
 convention as `filter_by_pp_rank` and `filter_by_tp_rank` (disable the dropped
 spec's hook point, raise on unbound specs).
 
+### Closed since phases 1-7
+
+* **Wiring into `attach_model`.** Closed. `attach_model` now takes a keyword
+  `layers` argument and applies `filter_by_layers` between
+  `apply_hook_selection` and the PP/TP filters, and
+  `dmi.configuration.attach_config(adapter, model, config)` drives it from a
+  `DMIConfig`. A layer range authored in the UI is now applied by the runtime.
+
+  The signature takes the layer range rather than a `CompiledDMIConfig`, which
+  the original design assumed. Handing `attach_model` the spec list from
+  `compile_config` would have been wrong: `HookPoint.enabled` defaults to
+  `True`, and only `apply_hook_selection` walks the *unselected* specs to turn
+  them off, so a pre-filtered list leaves every deselected hook live.
+  `attach_model` therefore has to own selection. Keeping the parameter
+  primitive also preserves the layering -- `configuration` depends on the
+  runtime, not the reverse. See `tests/test_adapter_layer_selection.py`.
+
+* **Payload estimation.** Added as `dmi.configuration.estimate` and surfaced in
+  the UI, having been listed out of scope for the MVP. It reuses
+  `compute_hook_shape` and the same `align_up(_, 16)` rounding
+  `BackendAdapter.plan_step` uses to size a reservation, so the number the UI
+  shows and the number `prepare_step` enforces cannot drift.
+
+  Three things it deliberately does *not* do the naive way:
+
+  - Reports the **peak single step**, not just a rate. `prepare_step` compares
+    one step against `min(payload_cap, staging_cap)`; over that it returns
+    `STEP_OVERSIZED` and the adapter silently falls back to eager CPU-direct
+    dispatch. Prefill sets that peak.
+  - Reports the **worst rank**. `compute_hook_shape` divides TP-sharded hooks
+    by `tp_size` while `filter_by_tp_rank` keeps unsharded hooks on rank 0
+    only, so aggregate bytes are roughly TP-invariant but per-rank pressure is
+    not. `PP_FIRST`/`PP_LAST` skew the stages too.
+  - Carries its **assumptions and warnings** in the result. The workload is a
+    per-request input, not part of `DMIConfig`: it describes the serving the
+    capture rides along with. Nothing here predicts serving overhead, which
+    needs measurement.
+
 ### Still open
 
-* **Wiring into `attach_model`.** `compile_config` produces the filtered spec
-  list, but `BackendAdapter.attach_model(model, hook_selection: str)` has not
-  been given a way to accept a `CompiledDMIConfig`. Until it does, a layer range
-  authored in the UI is not applied by an integration that calls `attach_model`
-  directly. This is the one signature change the design calls for.
 * **Runtime policy (phase 8).** `policy.objective` round-trips and is shown in
   the UI behind an explicit notice that it does not yet change behaviour.
+
+  `docs/capture-policy-review.md` reviews a proposed design for this phase
+  against the runtime. Two findings bear directly on it: the transport already
+  provides lossless blocking backpressure through `prepare_step` and has no
+  drop path at all, so `block` is the status quo and `drop`/`fail` are the new
+  work; and `CaptureSchedule` is still not enforced by any shipped adapter,
+  which bounds what a policy can honestly claim to change.
 * **Architecture coverage.** Only `decoder_transformer` is supported.
   Encoder-decoder configs are detected and refused rather than mis-rendered;
   vision and encoder-decoder layouts are future node tables.

--- a/docs/dmi-configurator-plan.md
+++ b/docs/dmi-configurator-plan.md
@@ -6,14 +6,26 @@ Verified against: `cb4e490`
 
 ## Running it
 
+From a checkout, with nothing installed:
+
+```bash
+make ui
+```
+
+This runs the bundled Llama-3-8B descriptor, picks a free port starting at
+8000, and opens a browser once the server is actually accepting connections.
+Override the model with `make ui MODEL=./Qwen3-8B`.
+
+Installed, it is a normal command:
+
 ```bash
 pip install -e ".[ui]"
 dmi ui ./Qwen3-8B
 ```
 
-Then open <http://127.0.0.1:8000>. `dmi ui` takes the model however you have
-it — a model directory, a `config.json`, a Hugging Face model id (needs
-`transformers`), or a DMI descriptor YAML:
+`dmi ui` takes the model however you have it — a model directory, a
+`config.json`, a Hugging Face model id (needs `transformers`), or a DMI
+descriptor YAML:
 
 ```bash
 dmi ui ./Qwen3-8B/config.json
@@ -34,8 +46,12 @@ dmi describe-model ./Qwen3-8B --output qwen3-8b.yaml
 ```
 
 Without an install, `python -m dmi.cli ...` works from a checkout with `src` on
-`PYTHONPATH`. `--host` and `--port` move the bind address; the default is
-loopback only.
+`PYTHONPATH`; that is all `make ui` does.
+
+`--host` and `--port` move the bind address; the default is loopback only. An
+explicit `--port` that is busy fails rather than quietly serving somewhere
+else — only the automatic default walks forward to the next free port.
+`--no-browser` suppresses the browser.
 
 Using the configuration from Python, with no browser involved:
 

--- a/src/dmi/adapters/base.py
+++ b/src/dmi/adapters/base.py
@@ -40,12 +40,14 @@ from ..hooks.specs import (
 )
 from ..hooks.selection import (
     apply_hook_selection,
+    filter_by_layers,
     filter_by_pp_rank,
     filter_by_tp_rank,
 )
 from .types import StepContext
 
 if TYPE_CHECKING:
+    from ..configuration.schema import LayerSelection
     from ..engine import MonitoringEngine
 
 
@@ -150,8 +152,30 @@ class BackendAdapter(abc.ABC):
         return False
 
     # --- shared (subclass never overrides) -------------------------------
-    def attach_model(self, model, hook_selection: str = "full") -> None:
-        """Resolve shape, install hooks per the selection + PP/TP filters."""
+    def attach_model(
+        self,
+        model,
+        hook_selection: str = "full",
+        *,
+        layers: Optional["LayerSelection"] = None,
+    ) -> None:
+        """Resolve shape, install hooks per the selection + layer/PP/TP filters.
+
+        ``hook_selection`` decides *which kinds* of observation to capture;
+        ``layers`` decides *where*.  The two are separate because a selection
+        string cannot express a layer range -- see
+        ``dmi.configuration.compatibility``.
+
+        ``layers`` is any object exposing inclusive ``start``/``end`` bounds
+        (``dmi.configuration.schema.LayerSelection``); ``None`` keeps every
+        layer.  Global hooks (``layer_no < 0``) are never layer-restricted, so
+        a range never drops ``final_logits`` or ``token_ids``.
+
+        Layer filtering runs *after* ``apply_hook_selection`` and *before* the
+        PP/TP filters.  Order matters: ``apply_hook_selection`` is what
+        establishes the enabled/disabled state across every spec, and each
+        later filter only ever disables further.
+        """
         if self.transport is None:
             raise RuntimeError(
                 "BackendAdapter.attach_model called before "
@@ -166,6 +190,8 @@ class BackendAdapter(abc.ABC):
 
         specs = model.get_hook_specs()
         specs = apply_hook_selection(specs, hook_selection, cfg=cfg)
+        if layers is not None:
+            specs = filter_by_layers(specs, layers.start, layers.end)
         specs = filter_by_pp_rank(specs, self.is_pp_first(), self.is_pp_last())
         specs = filter_by_tp_rank(specs, tp)
 

--- a/src/dmi/adapters/huggingface/adapter.py
+++ b/src/dmi/adapters/huggingface/adapter.py
@@ -9,12 +9,15 @@ import functools
 import os
 import time
 import warnings
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import torch
 
 from ..base import BackendAdapter
 from ..types import StepContext
+
+if TYPE_CHECKING:
+    from ...configuration.schema import LayerSelection
 from ...hooks.specs import (
     HookSpec,
     ModelShapeConfig,
@@ -231,6 +234,8 @@ class HuggingFaceAdapter(BackendAdapter):
         no_strip_left_pad: Optional[bool] = None,
         no_strip_right_pad: Optional[bool] = None,
         eos_token_id: Any = None,
+        *,
+        layers: Optional["LayerSelection"] = None,
     ) -> None:
         """Resolve shape, install ring hooks, and (optionally) wrap
         ``prepare_inputs_for_generation`` so each forward pass triggers
@@ -253,13 +258,16 @@ class HuggingFaceAdapter(BackendAdapter):
         set is empty and the post-EOS strip never latches.  Accepts
         ``int``, ``list[int]``, or ``torch.Tensor``; normalised to
         ``frozenset[int]``.
+
+        ``layers``: inclusive layer range restricting per-layer hooks, as in
+        :meth:`BackendAdapter.attach_model`.  ``None`` keeps every layer.
         """
         if no_strip_left_pad is not None:
             self._no_strip_left_pad = bool(no_strip_left_pad)
         if no_strip_right_pad is not None:
             self._no_strip_right_pad = bool(no_strip_right_pad)
         self._eos_token_ids = self._resolve_eos_token_ids(model, eos_token_id)
-        super().attach_model(model, hook_selection)
+        super().attach_model(model, hook_selection, layers=layers)
 
         # Startup validation: warn if pinned staging < GPU ring.
         try:

--- a/src/dmi/cli.py
+++ b/src/dmi/cli.py
@@ -34,9 +34,12 @@ def build_parser() -> argparse.ArgumentParser:
     ui.add_argument(
         "model",
         metavar="MODEL",
+        nargs="?",
+        default=None,
         help=(
             "A model directory, a config.json, a Hugging Face model id, or a "
-            "DMI descriptor YAML."
+            "DMI descriptor YAML. Omit it to use the descriptor in the current "
+            "directory when there is exactly one."
         ),
     )
     ui.add_argument(
@@ -49,7 +52,17 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     ui.add_argument("--host", default="127.0.0.1", help="Bind address.")
-    ui.add_argument("--port", type=int, default=8000, help="Bind port.")
+    ui.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Bind port. Defaults to 8000, or the next free port after it.",
+    )
+    ui.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open a browser window.",
+    )
     ui.set_defaults(handler=_run_ui)
 
     describe = subcommands.add_parser(
@@ -82,11 +95,53 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_ui_model(model: Optional[str]) -> str:
+    """Return the model to serve, discovering one if none was named.
+
+    Discovery only succeeds when the answer is unambiguous. Picking for the
+    user among several models would be worse than asking.
+    """
+    if model is not None:
+        return model
+
+    from .ui.server import DESCRIPTOR_GLOBS, find_descriptors
+
+    found = find_descriptors(".")
+    if len(found) == 1:
+        print(f"Using {found[0]}")
+        return str(found[0])
+
+    patterns = ", ".join(DESCRIPTOR_GLOBS)
+    if not found:
+        raise ConfigurationError(
+            "No model given and no descriptor found in the current directory "
+            f"(looked for {patterns}).\n"
+            "Name a model directly:\n"
+            "    dmi ui ./my-model\n"
+            "    dmi ui Qwen/Qwen3-8B\n"
+            "or write a descriptor first:\n"
+            "    dmi describe-model ./my-model --output my-model.model.yaml"
+        )
+
+    listing = "\n".join(f"    dmi ui {path}" for path in found)
+    raise ConfigurationError(
+        f"No model given and {len(found)} descriptors are present. "
+        f"Name one:\n{listing}"
+    )
+
+
 def _run_ui(args: argparse.Namespace) -> int:
     from .ui.server import serve
 
+    model = _resolve_ui_model(args.model)
     try:
-        serve(args.model, args.config, host=args.host, port=args.port)
+        serve(
+            model,
+            args.config,
+            host=args.host,
+            port=args.port,
+            open_browser=not args.no_browser,
+        )
     except KeyboardInterrupt:
         print()  # leave the shell prompt on its own line after Ctrl-C
     return 0

--- a/src/dmi/configuration/__init__.py
+++ b/src/dmi/configuration/__init__.py
@@ -32,7 +32,21 @@ from .catalog_adapter import (
     per_layer_hook_ids,
 )
 from .compatibility import from_legacy_hook_selection, to_legacy_hook_selection
-from .compiler import CompiledDMIConfig, ModelContext, compile_config
+from .estimate import (
+    Estimate,
+    RankLoad,
+    RingFit,
+    Workload,
+    check_ring_fit,
+    estimate_config,
+    estimate_payload,
+)
+from .compiler import (
+    CompiledDMIConfig,
+    ModelContext,
+    attach_config,
+    compile_config,
+)
 from .introspect import (
     describe_model,
     descriptor_from_hf_config,
@@ -119,6 +133,15 @@ __all__ = [
     "ModelContext",
     "CompiledDMIConfig",
     "compile_config",
+    "attach_config",
+    # estimation
+    "Workload",
+    "RankLoad",
+    "Estimate",
+    "RingFit",
+    "estimate_config",
+    "check_ring_fit",
+    "estimate_payload",
     # compatibility
     "to_legacy_hook_selection",
     "from_legacy_hook_selection",

--- a/src/dmi/configuration/compiler.py
+++ b/src/dmi/configuration/compiler.py
@@ -84,4 +84,38 @@ def compile_config(config: DMIConfig, model_context: ModelContext) -> CompiledDM
     )
 
 
-__all__ = ["ModelContext", "CompiledDMIConfig", "compile_config"]
+def attach_config(adapter, model, config: DMIConfig) -> None:
+    """Install hooks on ``model`` according to ``config``.
+
+    This is the *executing* counterpart to :func:`compile_config`. The two are
+    deliberately different operations on the same configuration:
+
+    ``compile_config``
+        Answers "what would this configuration select?" without touching the
+        model. Pure, rank-agnostic, and safe to call while authoring -- which
+        is why it skips PP/TP filtering.
+
+    ``attach_config``
+        Actually installs the hooks, through the adapter's own
+        ``attach_model``. That path additionally applies the PP/TP filters and
+        establishes the enabled/disabled state across *every* spec, so it --
+        not a pre-filtered spec list -- has to own selection.
+
+    Handing ``attach_model`` a spec list from ``compile_config`` would look
+    tempting and be wrong: ``HookPoint.enabled`` defaults to ``True``, and only
+    ``apply_hook_selection`` walks the unselected specs to turn them off. A
+    pre-filtered list would leave every deselected hook live.
+    """
+    adapter.attach_model(
+        model,
+        to_legacy_hook_selection(config.observations),
+        layers=config.observations.layers,
+    )
+
+
+__all__ = [
+    "ModelContext",
+    "CompiledDMIConfig",
+    "compile_config",
+    "attach_config",
+]

--- a/src/dmi/configuration/compiler.py
+++ b/src/dmi/configuration/compiler.py
@@ -114,10 +114,22 @@ def attach_config(adapter, model, config: DMIConfig) -> None:
     ``apply_hook_selection`` walks the unselected specs to turn them off. A
     pre-filtered list would leave every deselected hook live.
     """
+    # Pass `layers` only when there is a range to apply. Adapters are a public
+    # extension point (see the v1 integration API), and an adapter that
+    # overrides attach_model without the keyword would otherwise raise
+    # TypeError for *every* configuration -- including the majority that set
+    # no layer range and need nothing from it. A config that does set a range
+    # still fails loudly on such an adapter, which is correct: the range would
+    # not be honoured, and silently dropping it is the outcome this whole
+    # change exists to prevent.
+    kwargs = {}
+    if config.observations.layers is not None:
+        kwargs["layers"] = config.observations.layers
+
     adapter.attach_model(
         model,
         to_legacy_hook_selection(config.observations),
-        layers=config.observations.layers,
+        **kwargs,
     )
 
 

--- a/src/dmi/configuration/compiler.py
+++ b/src/dmi/configuration/compiler.py
@@ -59,13 +59,18 @@ def compile_config(config: DMIConfig, model_context: ModelContext) -> CompiledDM
 
     1. ``select_hook_specs`` -- which *kinds* of observation, via the existing
        selection string interface, including its availability suppression.
-    2. ``filter_by_layers`` -- *where*, if a layer range was given.
+    2. ``hook_belongs_to_layers`` -- *where*, if a layer range was given.
+
+    Both stages are pure: unlike ``filter_by_layers`` (which additionally
+    disables the HookPoints it drops, and therefore belongs to
+    ``attach_model``), nothing here touches the model, so this stays safe to
+    call while authoring against a live model.
 
     PP/TP filtering is intentionally not applied here. It depends on rank
     placement the adapter owns, and ``attach_model`` already applies it after
     selection.
     """
-    from ..hooks.selection import filter_by_layers, select_hook_specs
+    from ..hooks.selection import hook_belongs_to_layers, select_hook_specs
 
     specs = select_hook_specs(
         model_context.specs,
@@ -75,7 +80,10 @@ def compile_config(config: DMIConfig, model_context: ModelContext) -> CompiledDM
 
     layers = config.observations.layers
     if layers is not None:
-        specs = filter_by_layers(specs, layers.start, layers.end)
+        specs = [
+            spec for spec in specs
+            if hook_belongs_to_layers(spec, layers.start, layers.end)
+        ]
 
     return CompiledDMIConfig(
         hook_specs=specs,

--- a/src/dmi/configuration/estimate.py
+++ b/src/dmi/configuration/estimate.py
@@ -305,6 +305,25 @@ def estimate_config(
     assumptions: list[str] = []
     warnings: list[str] = []
 
+    # A range outside the model resolves to nothing, and every per-layer hook
+    # then contributes zero bytes. Zero reads as "free" rather than "selects
+    # nothing", so say which it is. Validation reports the range as an error
+    # separately; this is what the figures themselves have to explain.
+    requested = config.observations.layers
+    if requested is not None:
+        if not layer_set:
+            warnings.append(
+                f"Layer range {requested.start}-{requested.end} selects no "
+                f"layer of this {topology.num_layers}-layer model, so "
+                "per-layer observations contribute nothing to these figures."
+            )
+        elif len(layer_set) < requested.count:
+            warnings.append(
+                f"Layer range {requested.start}-{requested.end} was clipped "
+                f"to the model: {len(layer_set)} of {requested.count} "
+                f"requested layers exist (0-{topology.num_layers - 1})."
+            )
+
     convention = "packed" if workload.packed else "batched"
     assumptions.append(
         f"{convention} tensor convention "
@@ -413,24 +432,33 @@ def estimate_config(
         multiplier = 1 if load.tp_rank == 0 else tp_size - 1
         aggregate += _peak(load) * multiplier
 
-    # Schedule reduction. step_stride thins decode steps; a request has one
-    # prefill step, so stride cannot reliably thin it -- treat prefill as
-    # captured whenever it is enabled, and say so.
-    captured_decode_steps = 0
-    if capture_decode and workload.decode_tokens:
-        captured_decode_steps = max(
-            1, workload.decode_tokens // schedule.step_stride
+    # Sampling is NOT applied, because nothing applies it. `CaptureSchedule`
+    # is authored here and serialized into the YAML, but no shipped adapter
+    # enforces it: `should_capture_step` / `should_capture_request` have no
+    # callers outside `dmi.config`, and no adapter reads
+    # `CompiledDMIConfig.schedule`. Dividing by the stride would promise a
+    # reduction the capture never delivers and under-provision storage by
+    # exactly that factor.
+    #
+    # When schedule enforcement lands, apply the stride here and drop the
+    # warning below -- the two belong together, and the warning is how a
+    # reader finds this code.
+    captured_decode_steps = workload.decode_tokens if capture_decode else 0
+
+    unenforced = [
+        f"{name}={value}"
+        for name, value in (
+            ("step_stride", schedule.step_stride),
+            ("request_stride", schedule.request_stride),
         )
-    if capture_decode and schedule.step_stride > 1:
-        assumptions.append(
-            f"step_stride={schedule.step_stride} thins decode steps to "
-            f"~{captured_decode_steps} of {workload.decode_tokens}"
-        )
-    if capture_prefill and schedule.step_stride > 1:
-        assumptions.append(
-            "prefill counted in full: step_stride gates on a global step "
-            "counter, so it cannot be assumed to skip a request's single "
-            "prefill step"
+        if value > 1
+    ]
+    if unenforced:
+        warnings.append(
+            f"{', '.join(unenforced)} is set but not enforced by any adapter, "
+            "so it does not reduce these figures. Sampling is authored into "
+            "the configuration and ignored at capture time; size for the full "
+            "volume shown here."
         )
 
     # captured_decode_steps is already 0 when decode capture is off.
@@ -449,19 +477,13 @@ def estimate_config(
             "per-request figures divide the whole-batch step totals by "
             f"batch_size={workload.batch_size}"
         )
-    if schedule.request_stride > 1:
-        assumptions.append(
-            f"request_stride={schedule.request_stride} captures one request "
-            f"in {schedule.request_stride}"
-        )
 
     sustained: Optional[float] = None
     per_day: Optional[float] = None
     if workload.decode_steps_per_second > 0:
+        # Not divided by step_stride: see the sampling note above.
         effective_rate = (
-            workload.decode_steps_per_second / schedule.step_stride
-            if capture_decode
-            else 0.0
+            workload.decode_steps_per_second if capture_decode else 0.0
         )
         sustained = decode_step_bytes * effective_rate
         per_day = sustained * SECONDS_PER_DAY

--- a/src/dmi/configuration/estimate.py
+++ b/src/dmi/configuration/estimate.py
@@ -396,10 +396,14 @@ def estimate_config(
 
     worst = max(ranks, key=_peak) if ranks else None
     peak_step_bytes = _peak(worst) if worst else 0
+    # The worst rank's decode step, not the maximum across ranks. Under
+    # pipeline parallelism the stage with the largest prefill step need not be
+    # the one with the largest decode step -- a first stage carrying many
+    # layers versus a last stage carrying final_logits -- so taking a max here
+    # would leave decode_step_bytes describing a different rank than
+    # peak_step_rank names and bytes_per_request is computed from.
     decode_step_bytes = (
-        max(load.decode_step_bytes for load in ranks)
-        if ranks and capture_decode
-        else 0
+        worst.decode_step_bytes if (worst and capture_decode) else 0
     )
 
     # Aggregate across every real rank: probes stand in for the tp ranks they

--- a/src/dmi/configuration/estimate.py
+++ b/src/dmi/configuration/estimate.py
@@ -1,0 +1,590 @@
+"""Payload size estimation for a configuration, before anything runs.
+
+The configurator's job is to let someone choose observations without
+discovering afterwards that the choice was unaffordable. This module answers
+"how many bytes will that cost?" using the *same* arithmetic the runtime uses
+to reserve ring space, so the number the UI shows and the number
+``prepare_step`` enforces cannot drift:
+
+    compute_hook_shape(...) -> elem_size * prod(shape) -> align_up(_, 16)
+
+That is ``BackendAdapter.plan_step`` (``src/dmi/adapters/base.py``) reduced to
+one spec. This module walks a synthesized spec set instead of a live one,
+because the configurator runs where no model is loaded.
+
+Three properties of DMI's transport shape the output, and each is a thing a
+naive per-model estimate gets wrong:
+
+**The binding constraint is one step, not one second.** ``prepare_step``
+compares a single step's total against ``min(payload_cap, staging_cap)``. Over
+that, capture does not fail -- it silently falls back to eager CPU-direct
+dispatch, which is a large performance cliff. Prefill sets that peak, because
+``q_len`` is at its largest.
+
+**Load is not spread evenly across ranks.** ``compute_hook_shape`` divides
+tensor-parallel-sharded hooks by ``tp_size``, and ``filter_by_tp_rank`` keeps
+*unsharded* hooks only on rank 0. Aggregate bytes are therefore roughly
+TP-invariant while per-rank pressure is not. Under pipeline parallelism the
+``PP_FIRST``/``PP_LAST`` hooks land on specific stages, and ``final_logits``
+carries a whole vocabulary. Ring capacity has to be judged against the worst
+rank, so that is what this module reports.
+
+**Estimates are estimates.** Every result carries its assumptions and any
+warnings, and nothing here claims to predict serving overhead -- that needs
+measurement on the real model, GPU, and batch distribution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..hooks.catalog import HOOK_DEFS
+from .schema import DMIConfig, LayerSelection, ModelDescriptor, ModelTopology
+
+# Mirrors ring::PAYLOAD_ALIGN. Every reservation is rounded up to this, so an
+# estimate that ignored it would under-count small tensors.
+PAYLOAD_ALIGN = 16
+
+SECONDS_PER_DAY = 86_400
+
+# Hooks whose payload is attention weights: shaped [heads, q_len, kv_dim], so
+# they scale with the square of sequence length and are only meaningful in the
+# batched (non-packed) convention.
+_ATTN_WEIGHT_HOOKS = frozenset({"attn_scores", "pattern"})
+
+# Catalog projections, by short name.
+_PER_LAYER: dict[str, bool] = {}
+_HOOK_ID: dict[str, int] = {}
+_PP_STAGE: dict[str, int] = {}
+_TP_SHARDED: dict[str, bool] = {}
+for _id, _act, _short, _pl, _grp, _tp, _sc, _pp in HOOK_DEFS:
+    _PER_LAYER[_short] = _pl
+    _HOOK_ID[_short] = _id
+    _PP_STAGE[_short] = _pp
+    _TP_SHARDED[_short] = _tp
+
+_PP_ANY, _PP_FIRST, _PP_LAST = 0, 1, 2
+
+
+@dataclass(frozen=True)
+class Workload:
+    """The traffic an estimate is computed against.
+
+    None of this belongs in a ``DMIConfig``: it describes the *serving* the
+    capture rides along with, not the capture itself. Two identical
+    configurations cost different amounts under different traffic.
+
+    ``packed`` selects the tensor convention. vLLM concatenates every active
+    request's rows into dim 0 with no batch dimension (packed); Hugging Face
+    ``generate()`` keeps a leading batch dimension (batched). The distinction
+    changes both the shapes and which hooks are meaningful.
+    """
+
+    batch_size: int = 8
+    prompt_tokens: int = 2048
+    decode_tokens: int = 256
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    packed: bool = True
+    dtype: str = "float16"
+    decode_steps_per_second: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}.")
+        if self.prompt_tokens < 1:
+            raise ValueError(
+                f"prompt_tokens must be >= 1, got {self.prompt_tokens}."
+            )
+        if self.decode_tokens < 0:
+            raise ValueError(
+                f"decode_tokens must be >= 0, got {self.decode_tokens}."
+            )
+        if self.tensor_parallel_size < 1:
+            raise ValueError(
+                "tensor_parallel_size must be >= 1, got "
+                f"{self.tensor_parallel_size}."
+            )
+        if self.pipeline_parallel_size < 1:
+            raise ValueError(
+                "pipeline_parallel_size must be >= 1, got "
+                f"{self.pipeline_parallel_size}."
+            )
+        if self.decode_steps_per_second < 0:
+            raise ValueError(
+                "decode_steps_per_second must be >= 0, got "
+                f"{self.decode_steps_per_second}."
+            )
+
+
+@dataclass(frozen=True)
+class RankLoad:
+    """What one (pipeline stage, tensor-parallel rank) pair carries."""
+
+    label: str
+    pp_stage: int
+    tp_rank: int
+    prefill_step_bytes: int
+    decode_step_bytes: int
+    prefill_hooks: int
+    decode_hooks: int
+
+
+@dataclass(frozen=True)
+class Estimate:
+    """Byte estimates for one configuration under one workload."""
+
+    peak_step_bytes: int
+    peak_step_rank: str
+    decode_step_bytes: int
+    bytes_per_request: int
+    aggregate_prefill_step_bytes: int
+    sustained_bytes_per_second: Optional[float]
+    bytes_per_day: Optional[float]
+    ranks: tuple[RankLoad, ...] = ()
+    assumptions: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RingFit:
+    """How an estimate sits against a ring configuration."""
+
+    effective_bytes: int
+    peak_step_bytes: int
+    fits: bool
+    occupancy_percent: float
+    detail: str
+
+
+def _resolve_dtype(dtype_name: str):
+    """Look up a torch dtype by name, raising ``ValueError`` on a bad name.
+
+    Torch itself raises ``AttributeError`` for an unknown attribute, which
+    would surface as an internal error rather than the configuration error it
+    actually is. Imported lazily to keep torch off the descriptor and
+    validation paths.
+    """
+    import torch
+
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(f"Unknown dtype: {dtype_name!r}")
+    return dtype
+
+
+def _element_size(dtype_name: str) -> int:
+    import torch
+
+    return torch._utils._element_size(_resolve_dtype(dtype_name))
+
+
+def _stage_layers(num_layers: int, pp_size: int, stage: int) -> range:
+    """Contiguous even split of layers across pipeline stages."""
+    start = stage * num_layers // pp_size
+    end = (stage + 1) * num_layers // pp_size
+    return range(start, end)
+
+
+def _hook_on_stage(short: str, stage: int, pp_size: int) -> bool:
+    placement = _PP_STAGE.get(short, _PP_ANY)
+    if placement == _PP_FIRST:
+        return stage == 0
+    if placement == _PP_LAST:
+        return stage == pp_size - 1
+    return True
+
+
+def _hook_on_tp_rank(short: str, tp_rank: int) -> bool:
+    """Mirror ``filter_by_tp_rank``: rank 0 keeps all, others keep sharded."""
+    return tp_rank == 0 or _TP_SHARDED.get(short, False)
+
+
+def _selected_layers(
+    layers: Optional[LayerSelection], topology: ModelTopology
+) -> set[int]:
+    if layers is None:
+        return set(range(topology.num_layers))
+    return {
+        layer
+        for layer in range(topology.num_layers)
+        if layers.contains(layer)
+    }
+
+
+def _step_bytes(
+    hooks: list[str],
+    layer_set: set[int],
+    topology: ModelTopology,
+    workload: Workload,
+    *,
+    stage: int,
+    tp_rank: int,
+    q_len: int,
+    batch: int,
+    kv_dim: int,
+    logits_to_keep: int,
+) -> tuple[int, int]:
+    """Total aligned bytes and firing-hook count for one step on one rank.
+
+    Deliberately identical in structure to ``BackendAdapter.plan_step``: a
+    hook whose ``compute_hook_shape`` comes back empty does not fire and does
+    not count, which is how unavailable observations (``mlp_post`` with no
+    ``intermediate_size``, MoE hooks on a dense model) drop out for free.
+    """
+    from ..hooks.specs import align_up_py, compute_hook_shape
+
+    from .manifest import to_model_shape_config
+
+    cfg = to_model_shape_config(
+        topology,
+        dtype=_resolve_dtype(workload.dtype),
+        tp_size=workload.tensor_parallel_size,
+        tp_rank=tp_rank,
+    )
+    model_elem = _element_size(workload.dtype)
+    # ring.py overrides only token_ids' dtype, from the framework's input_ids.
+    token_ids_elem = _element_size("int64")
+
+    stage_layers = set(_stage_layers(
+        topology.num_layers, workload.pipeline_parallel_size, stage
+    ))
+
+    total = 0
+    count = 0
+    for short in hooks:
+        hook_type = _HOOK_ID.get(short)
+        if hook_type is None:
+            continue
+        if not _hook_on_stage(short, stage, workload.pipeline_parallel_size):
+            continue
+        if not _hook_on_tp_rank(short, tp_rank):
+            continue
+
+        if _PER_LAYER.get(short, False):
+            instances = len(layer_set & stage_layers)
+        else:
+            instances = 1
+        if instances == 0:
+            continue
+
+        shape = compute_hook_shape(
+            hook_type, cfg, batch, q_len, kv_dim,
+            logits_to_keep=logits_to_keep,
+        )
+        if not shape:
+            continue
+
+        elem = token_ids_elem if short == "token_ids" else model_elem
+        nbytes = elem
+        for dim in shape:
+            nbytes *= dim
+        total += align_up_py(nbytes, PAYLOAD_ALIGN) * instances
+        count += instances
+
+    return total, count
+
+
+def estimate_config(
+    config: DMIConfig,
+    descriptor: ModelDescriptor,
+    workload: Optional[Workload] = None,
+) -> Estimate:
+    """Estimate the payload cost of ``config`` on ``descriptor``'s model.
+
+    Reports the worst rank, because that is the one whose ring fills first.
+    """
+    workload = workload or Workload()
+    topology = descriptor.topology
+    hooks = list(dict.fromkeys(config.observations.hooks))
+    layer_set = _selected_layers(config.observations.layers, topology)
+
+    assumptions: list[str] = []
+    warnings: list[str] = []
+
+    convention = "packed" if workload.packed else "batched"
+    assumptions.append(
+        f"{convention} tensor convention "
+        f"({'vLLM' if workload.packed else 'Hugging Face generate()'})"
+    )
+
+    if workload.packed:
+        # No batch dimension; every active request's rows share dim 0.
+        prefill_batch, decode_batch = 0, 0
+        prefill_q = workload.batch_size * workload.prompt_tokens
+        decode_q = workload.batch_size
+        # One logit row per request per step.
+        prefill_logits = workload.batch_size
+        decode_logits = workload.batch_size
+    else:
+        prefill_batch = decode_batch = workload.batch_size
+        prefill_q = workload.prompt_tokens
+        decode_q = 1
+        # logits_to_keep=0 means "every q_len row". Backends that materialize
+        # only the last-token logits per request cost far less, so this is an
+        # upper bound on final_logits rather than a prediction.
+        prefill_logits = decode_logits = 0
+        if "final_logits" in hooks:
+            assumptions.append(
+                "final_logits counted for every prefill position "
+                "(logits_to_keep=0); a backend that keeps only last-token "
+                "logits costs much less"
+            )
+
+    # Attention weights span the whole KV window. Decode peaks at the end of
+    # generation, which is the step that has to fit.
+    prefill_kv = workload.prompt_tokens
+    decode_kv = workload.prompt_tokens + workload.decode_tokens
+
+    selected_attn_weights = sorted(set(hooks) & _ATTN_WEIGHT_HOOKS)
+    if selected_attn_weights and workload.packed:
+        warnings.append(
+            f"{', '.join(selected_attn_weights)} "
+            "cannot be shaped in the packed convention -- attention weights "
+            "are per-request. Serving backends exclude them (the vllm-full "
+            "preset is full minus attn_scores/pattern); this estimate treats "
+            "them as not firing."
+        )
+        hooks = [h for h in hooks if h not in _ATTN_WEIGHT_HOOKS]
+
+    pp_size = workload.pipeline_parallel_size
+    tp_size = workload.tensor_parallel_size
+
+    # tp ranks are symmetric apart from rank 0, which additionally carries
+    # every unsharded hook. Probing rank 0 and one non-zero rank is enough.
+    tp_probes = [0] if tp_size == 1 else [0, 1]
+
+    ranks: list[RankLoad] = []
+    for stage in range(pp_size):
+        for tp_rank in tp_probes:
+            prefill_bytes, prefill_hooks = _step_bytes(
+                hooks, layer_set, topology, workload,
+                stage=stage, tp_rank=tp_rank,
+                q_len=prefill_q, batch=prefill_batch,
+                kv_dim=prefill_kv, logits_to_keep=prefill_logits,
+            )
+            decode_bytes, decode_hooks = _step_bytes(
+                hooks, layer_set, topology, workload,
+                stage=stage, tp_rank=tp_rank,
+                q_len=decode_q, batch=decode_batch,
+                kv_dim=decode_kv, logits_to_keep=decode_logits,
+            )
+            ranks.append(RankLoad(
+                label=f"pp{stage}/tp{tp_rank}",
+                pp_stage=stage,
+                tp_rank=tp_rank,
+                prefill_step_bytes=prefill_bytes,
+                decode_step_bytes=decode_bytes,
+                prefill_hooks=prefill_hooks,
+                decode_hooks=decode_hooks,
+            ))
+
+    schedule = config.schedule
+    capture_prefill = schedule.capture_prefill
+    capture_decode = schedule.capture_decode
+
+    def _peak(load: RankLoad) -> int:
+        candidates = []
+        if capture_prefill:
+            candidates.append(load.prefill_step_bytes)
+        if capture_decode:
+            candidates.append(load.decode_step_bytes)
+        return max(candidates) if candidates else 0
+
+    worst = max(ranks, key=_peak) if ranks else None
+    peak_step_bytes = _peak(worst) if worst else 0
+    decode_step_bytes = (
+        max(load.decode_step_bytes for load in ranks)
+        if ranks and capture_decode
+        else 0
+    )
+
+    # Aggregate across every real rank: probes stand in for the tp ranks they
+    # represent, so a non-zero probe counts (tp_size - 1) times.
+    aggregate = 0
+    for load in ranks:
+        multiplier = 1 if load.tp_rank == 0 else tp_size - 1
+        aggregate += _peak(load) * multiplier
+
+    # Schedule reduction. step_stride thins decode steps; a request has one
+    # prefill step, so stride cannot reliably thin it -- treat prefill as
+    # captured whenever it is enabled, and say so.
+    captured_decode_steps = 0
+    if capture_decode and workload.decode_tokens:
+        captured_decode_steps = max(
+            1, workload.decode_tokens // schedule.step_stride
+        )
+    if capture_decode and schedule.step_stride > 1:
+        assumptions.append(
+            f"step_stride={schedule.step_stride} thins decode steps to "
+            f"~{captured_decode_steps} of {workload.decode_tokens}"
+        )
+    if capture_prefill and schedule.step_stride > 1:
+        assumptions.append(
+            "prefill counted in full: step_stride gates on a global step "
+            "counter, so it cannot be assumed to skip a request's single "
+            "prefill step"
+        )
+
+    # captured_decode_steps is already 0 when decode capture is off.
+    per_request_prefill = (
+        worst.prefill_step_bytes if (worst and capture_prefill) else 0
+    )
+    per_request_decode = (
+        worst.decode_step_bytes * captured_decode_steps if worst else 0
+    )
+    per_request = per_request_prefill + per_request_decode
+    # A packed prefill step already covers the whole batch.
+    if workload.packed and workload.batch_size > 1:
+        per_request = per_request // workload.batch_size
+        assumptions.append(
+            "per-request figures divide the packed batch total by "
+            f"batch_size={workload.batch_size}"
+        )
+    if schedule.request_stride > 1:
+        assumptions.append(
+            f"request_stride={schedule.request_stride} captures one request "
+            f"in {schedule.request_stride}"
+        )
+
+    sustained: Optional[float] = None
+    per_day: Optional[float] = None
+    if workload.decode_steps_per_second > 0:
+        effective_rate = (
+            workload.decode_steps_per_second / schedule.step_stride
+            if capture_decode
+            else 0.0
+        )
+        sustained = decode_step_bytes * effective_rate
+        per_day = sustained * SECONDS_PER_DAY
+        assumptions.append(
+            "sustained rate covers decode only; prefill arrives in bursts "
+            "that the peak-step figure bounds"
+        )
+    else:
+        warnings.append(
+            "No sustained rate: set decode_steps_per_second to estimate "
+            "bandwidth and per-day volume."
+        )
+
+    if not capture_prefill and not capture_decode:
+        warnings.append(
+            "Both prefill and decode capture are disabled -- this "
+            "configuration captures nothing."
+        )
+    if not hooks:
+        warnings.append("No observations selected.")
+
+    if tp_size > 1:
+        assumptions.append(
+            f"tensor_parallel_size={tp_size}: sharded hooks are divided "
+            "across ranks, unsharded hooks are captured on rank 0 only, so "
+            "rank 0 is the busiest"
+        )
+    if pp_size > 1:
+        assumptions.append(
+            f"pipeline_parallel_size={pp_size}: layers split evenly and "
+            "contiguously across stages"
+        )
+
+    return Estimate(
+        peak_step_bytes=peak_step_bytes,
+        peak_step_rank=worst.label if worst else "",
+        decode_step_bytes=decode_step_bytes,
+        bytes_per_request=per_request,
+        aggregate_prefill_step_bytes=aggregate,
+        sustained_bytes_per_second=sustained,
+        bytes_per_day=per_day,
+        ranks=tuple(ranks),
+        assumptions=tuple(assumptions),
+        warnings=tuple(warnings),
+    )
+
+
+def check_ring_fit(
+    estimate: Estimate,
+    payload_bytes: int,
+    pinned_bytes: int = 0,
+) -> RingFit:
+    """Judge a peak step against ring capacity.
+
+    ``prepare_step`` compares a step against ``min(payload_cap, staging_cap)``,
+    so the smaller of the two rings is the real ceiling -- a generous payload
+    ring paired with a small pinned ring buys nothing.
+    """
+    if payload_bytes < 1:
+        raise ValueError(f"payload_bytes must be >= 1, got {payload_bytes}.")
+    effective = min(payload_bytes, pinned_bytes) if pinned_bytes else payload_bytes
+    peak = estimate.peak_step_bytes
+    fits = peak <= effective
+    occupancy = (peak / effective * 100.0) if effective else 0.0
+
+    if fits:
+        detail = (
+            f"Peak step uses {occupancy:.1f}% of the {_mib(effective)} "
+            "effective ring."
+        )
+    else:
+        detail = (
+            f"Peak step ({_mib(peak)}) exceeds the {_mib(effective)} "
+            "effective ring. prepare_step will return STEP_OVERSIZED and the "
+            "adapter falls back to eager CPU-direct dispatch -- capture keeps "
+            "working, but the serving path pays for it."
+        )
+    if pinned_bytes and pinned_bytes < payload_bytes:
+        detail += (
+            f" Pinned staging ({_mib(pinned_bytes)}) is the binding limit, "
+            f"not the payload ring ({_mib(payload_bytes)})."
+        )
+
+    return RingFit(
+        effective_bytes=effective,
+        peak_step_bytes=peak,
+        fits=fits,
+        occupancy_percent=occupancy,
+        detail=detail,
+    )
+
+
+def _mib(nbytes: int) -> str:
+    return f"{nbytes / (1024 * 1024):.1f} MiB"
+
+
+def estimate_payload(estimate: Estimate) -> dict:
+    """Render an estimate as JSON-safe data for the configurator API."""
+    return {
+        "peak_step_bytes": estimate.peak_step_bytes,
+        "peak_step_rank": estimate.peak_step_rank,
+        "decode_step_bytes": estimate.decode_step_bytes,
+        "bytes_per_request": estimate.bytes_per_request,
+        "aggregate_prefill_step_bytes": estimate.aggregate_prefill_step_bytes,
+        "sustained_bytes_per_second": estimate.sustained_bytes_per_second,
+        "bytes_per_day": estimate.bytes_per_day,
+        "ranks": [
+            {
+                "label": load.label,
+                "pp_stage": load.pp_stage,
+                "tp_rank": load.tp_rank,
+                "prefill_step_bytes": load.prefill_step_bytes,
+                "decode_step_bytes": load.decode_step_bytes,
+                "prefill_hooks": load.prefill_hooks,
+                "decode_hooks": load.decode_hooks,
+            }
+            for load in estimate.ranks
+        ],
+        "assumptions": list(estimate.assumptions),
+        "warnings": list(estimate.warnings),
+    }
+
+
+__all__ = [
+    "PAYLOAD_ALIGN",
+    "Workload",
+    "RankLoad",
+    "Estimate",
+    "RingFit",
+    "estimate_config",
+    "check_ring_fit",
+    "estimate_payload",
+]

--- a/src/dmi/configuration/estimate.py
+++ b/src/dmi/configuration/estimate.py
@@ -139,7 +139,9 @@ class Estimate:
     peak_step_rank: str
     decode_step_bytes: int
     bytes_per_request: int
-    aggregate_prefill_step_bytes: int
+    # Sum of every rank's peak step (prefill or decode, whichever is enabled
+    # and larger) -- the cluster-wide burst, not a prefill-only figure.
+    aggregate_peak_step_bytes: int
     sustained_bytes_per_second: Optional[float]
     bytes_per_day: Optional[float]
     ranks: tuple[RankLoad, ...] = ()
@@ -435,11 +437,12 @@ def estimate_config(
         worst.decode_step_bytes * captured_decode_steps if worst else 0
     )
     per_request = per_request_prefill + per_request_decode
-    # A packed prefill step already covers the whole batch.
-    if workload.packed and workload.batch_size > 1:
+    # A step covers the whole batch in either convention: packed rows share
+    # dim 0, batched shapes carry the leading batch dimension.
+    if workload.batch_size > 1:
         per_request = per_request // workload.batch_size
         assumptions.append(
-            "per-request figures divide the packed batch total by "
+            "per-request figures divide the whole-batch step totals by "
             f"batch_size={workload.batch_size}"
         )
     if schedule.request_stride > 1:
@@ -493,7 +496,7 @@ def estimate_config(
         peak_step_rank=worst.label if worst else "",
         decode_step_bytes=decode_step_bytes,
         bytes_per_request=per_request,
-        aggregate_prefill_step_bytes=aggregate,
+        aggregate_peak_step_bytes=aggregate,
         sustained_bytes_per_second=sustained,
         bytes_per_day=per_day,
         ranks=tuple(ranks),
@@ -558,7 +561,7 @@ def estimate_payload(estimate: Estimate) -> dict:
         "peak_step_rank": estimate.peak_step_rank,
         "decode_step_bytes": estimate.decode_step_bytes,
         "bytes_per_request": estimate.bytes_per_request,
-        "aggregate_prefill_step_bytes": estimate.aggregate_prefill_step_bytes,
+        "aggregate_peak_step_bytes": estimate.aggregate_peak_step_bytes,
         "sustained_bytes_per_second": estimate.sustained_bytes_per_second,
         "bytes_per_day": estimate.bytes_per_day,
         "ranks": [

--- a/src/dmi/configuration/introspect.py
+++ b/src/dmi/configuration/introspect.py
@@ -105,12 +105,20 @@ def descriptor_from_hf_config(
     except ValueError as exc:
         raise DescriptorError(f"Config for {model_id!r} is inconsistent: {exc}") from exc
 
-    return ModelDescriptor(
-        model=ModelIdentity(
+    try:
+        identity = ModelIdentity(
             id=_slug(model_id),
             name=name or model_id.rstrip("/").split("/")[-1],
             architecture="decoder_transformer",
-        ),
+        )
+    except ValueError as exc:
+        # _slug of a degenerate id ("/" and friends) leaves nothing usable.
+        raise DescriptorError(
+            f"Could not derive a usable model id from {model_id!r}: {exc}"
+        ) from exc
+
+    return ModelDescriptor(
+        model=identity,
         topology=topology,
         schema_version=DESCRIPTOR_SCHEMA_VERSION,
     )

--- a/src/dmi/configuration/introspect.py
+++ b/src/dmi/configuration/introspect.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional
 
-from ..api.v1.model_shape import make_model_shape_from_hf_config
 from .errors import DescriptorError
 from .manifest import load_descriptor
 from .schema import (
@@ -65,6 +64,11 @@ def descriptor_from_hf_config(
     The object need not be a Transformers class; only the standard attributes
     are read, so a ``SimpleNamespace`` over a parsed ``config.json`` works.
     """
+    # Lazy: the extractor's module imports torch, and this package promises
+    # torch-free descriptor and validation paths (estimate.py and manifest.py
+    # defer their torch imports for the same reason).
+    from ..api.v1.model_shape import make_model_shape_from_hf_config
+
     if getattr(hf_config, "is_encoder_decoder", False):
         raise DescriptorError(
             f"{model_id!r} is an encoder-decoder model. DMI-configurator v1 "

--- a/src/dmi/configuration/schema.py
+++ b/src/dmi/configuration/schema.py
@@ -102,9 +102,30 @@ class ObservationConfig:
 
 @dataclass
 class ModelIdentity:
+    """Who the model is.
+
+    ``id`` is used as a filename stem -- the configurator writes
+    ``<id>.dmi.yaml`` beside the model. It must therefore be a single safe
+    path segment. Descriptors derived from a framework config always are
+    (``introspect._slug`` reduces ``Qwen/Qwen3-8B`` to ``qwen3-8b``), but a
+    hand-written descriptor is not checked by anything else, and a separator
+    there would move the write outside the directory the user named on the
+    command line -- the one guarantee ``dmi.ui.app`` makes about where it
+    writes.
+    """
+
     id: str
     name: str
     architecture: str
+
+    def __post_init__(self) -> None:
+        if not self.id or not self.id.strip():
+            raise ValueError("model id must not be empty.")
+        if self.id in (".", "..") or any(sep in self.id for sep in ("/", "\\")):
+            raise ValueError(
+                f"model id must be a single path segment, got {self.id!r}. "
+                f"It names the configuration file written beside the model."
+            )
 
 
 @dataclass

--- a/src/dmi/hooks/__init__.py
+++ b/src/dmi/hooks/__init__.py
@@ -1,16 +1,42 @@
-"""Hook definitions, dispatch, selection policy, and model hook points."""
+"""Hook definitions, dispatch, selection policy, and model hook points.
 
-from .dispatch import install_ring_hooks
-from .point import HookPoint, HookedRootModule, set_monitoring_debug
-from .specs import HookRowBasis, HookSpec, ModelShapeConfig, compute_hook_shape
+Re-exports resolve lazily (PEP 562): :mod:`dmi.hooks.catalog` is deliberately
+torch-free so descriptor and validation paths can import it, and an eager
+``from .dispatch import ...`` here would pull torch into every one of them.
+"""
 
-__all__ = [
-    "HookPoint",
-    "HookRowBasis",
-    "HookSpec",
-    "HookedRootModule",
-    "ModelShapeConfig",
-    "compute_hook_shape",
-    "install_ring_hooks",
-    "set_monitoring_debug",
-]
+from typing import TYPE_CHECKING
+
+_EXPORTS = {
+    "HookPoint": "point",
+    "HookedRootModule": "point",
+    "set_monitoring_debug": "point",
+    "HookRowBasis": "specs",
+    "HookSpec": "specs",
+    "ModelShapeConfig": "specs",
+    "compute_hook_shape": "specs",
+    "install_ring_hooks": "dispatch",
+}
+
+__all__ = sorted(_EXPORTS)
+
+if TYPE_CHECKING:
+    from .dispatch import install_ring_hooks
+    from .point import HookPoint, HookedRootModule, set_monitoring_debug
+    from .specs import (
+        HookRowBasis,
+        HookSpec,
+        ModelShapeConfig,
+        compute_hook_shape,
+    )
+
+
+def __getattr__(name: str):
+    submodule = _EXPORTS.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    value = getattr(importlib.import_module(f".{submodule}", __name__), name)
+    globals()[name] = value
+    return value

--- a/src/dmi/ui/app.py
+++ b/src/dmi/ui/app.py
@@ -194,9 +194,22 @@ def create_app(
 
         body = estimate_payload(estimate)
 
-        ring = payload.get("ring") or {}
+        # Type-check the raw value: `or {}` alone would let a truthy
+        # non-mapping such as a list or string through to `.get`, which raises
+        # AttributeError and surfaces as a 500 instead of a 400.
+        ring_raw = payload.get("ring")
+        if ring_raw is not None and not isinstance(ring_raw, dict):
+            raise HTTPException(
+                400,
+                f"'ring' must be a mapping, got {type(ring_raw).__name__}.",
+            )
+        ring = ring_raw or {}
+        # `is not None`, not truthiness: payload_bytes=0 is a client error that
+        # check_ring_fit rejects with a clear message, and treating it as
+        # "absent" would silently drop the ring-fit result the caller asked
+        # for.
         payload_bytes = ring.get("payload_bytes")
-        if payload_bytes:
+        if payload_bytes is not None:
             try:
                 fit = check_ring_fit(
                     estimate,

--- a/src/dmi/ui/app.py
+++ b/src/dmi/ui/app.py
@@ -18,10 +18,14 @@ from ..configuration import (
     ConfigurationError,
     DMIConfig,
     ModelDescriptor,
+    Workload,
     catalog_payload,
+    check_ring_fit,
     resolve_descriptor,
     config_to_dict,
     dump_config,
+    estimate_config,
+    estimate_payload,
     load_config,
     parse_config,
     save_config,
@@ -142,6 +146,47 @@ def create_app(source: str | Path, config_path: Optional[str | Path] = None):
             "valid": not any(issue.is_error for issue in issues),
             "issues": [issue.to_dict() for issue in issues],
         }
+
+    @app.post("/api/estimate")
+    def post_estimate(payload: dict):
+        """Byte estimates for a configuration under a stated workload.
+
+        The workload is supplied per request rather than held in server state:
+        it describes the traffic the capture rides along with, not the capture,
+        so the same configuration legitimately has several answers.
+        """
+        config = _parse(payload)
+        try:
+            workload = Workload(**(payload.get("workload") or {}))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(400, f"Invalid workload: {exc}") from exc
+
+        try:
+            estimate = estimate_config(config, state.descriptor, workload)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+
+        body = estimate_payload(estimate)
+
+        ring = payload.get("ring") or {}
+        payload_bytes = ring.get("payload_bytes")
+        if payload_bytes:
+            try:
+                fit = check_ring_fit(
+                    estimate,
+                    int(payload_bytes),
+                    int(ring.get("pinned_bytes") or 0),
+                )
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(400, f"Invalid ring sizes: {exc}") from exc
+            body["ring_fit"] = {
+                "effective_bytes": fit.effective_bytes,
+                "peak_step_bytes": fit.peak_step_bytes,
+                "fits": fit.fits,
+                "occupancy_percent": fit.occupancy_percent,
+                "detail": fit.detail,
+            }
+        return body
 
     @app.post("/api/config/serialize")
     def post_serialize(payload: dict):

--- a/src/dmi/ui/app.py
+++ b/src/dmi/ui/app.py
@@ -78,12 +78,14 @@ def build_state(
     """
     descriptor = resolve_descriptor(source)
 
-    initial = None
+    # The save path doubles as the startup config: relaunching the
+    # configurator picks up the file the previous session saved, whether or
+    # not --config named it explicitly, so Save never silently clobbers an
+    # authored configuration with a blank default.
     save_path = default_save_path(source, descriptor)
     if config_path is not None:
         save_path = Path(config_path)
-        if save_path.exists():
-            initial = load_config(save_path)
+    initial = load_config(save_path) if save_path.exists() else None
 
     return UIState(
         descriptor=descriptor,
@@ -93,18 +95,42 @@ def build_state(
     )
 
 
-def create_app(source: str | Path, config_path: Optional[str | Path] = None):
-    """Build the FastAPI application."""
+# Host names a browser legitimately reaches a loopback bind under. Anything
+# else in the Host header means the request came through a name we never
+# served -- the DNS-rebinding pattern -- and is rejected before any endpoint
+# runs.
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1", "[::1]")
+
+
+def create_app(
+    source: str | Path,
+    config_path: Optional[str | Path] = None,
+    bind_host: str = "127.0.0.1",
+):
+    """Build the FastAPI application.
+
+    ``bind_host`` is the address the server will listen on. For a loopback
+    bind (the default), requests whose ``Host`` header is not a loopback name
+    are rejected: a DNS-rebinding page resolves its own hostname to 127.0.0.1
+    and would otherwise be same-origin for the file-writing endpoints. A
+    non-loopback bind is an explicit choice to serve the network, where the
+    valid names cannot be enumerated, so no Host filter is applied.
+    """
     try:
         from fastapi import FastAPI, HTTPException
         from fastapi.responses import FileResponse
         from fastapi.staticfiles import StaticFiles
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
     except ImportError as exc:  # pragma: no cover - exercised by install state
         raise RuntimeError(_FASTAPI_MISSING) from exc
 
     state = build_state(source, config_path)
 
     app = FastAPI(title="DMI-configurator", docs_url=None, redoc_url=None)
+    if bind_host in _LOOPBACK_HOSTS:
+        app.add_middleware(
+            TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS)
+        )
     app.state.ui = state
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 

--- a/src/dmi/ui/server.py
+++ b/src/dmi/ui/server.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import socket
+import threading
+import webbrowser
 from pathlib import Path
 from typing import Optional
 
@@ -10,12 +13,86 @@ from .app import create_app
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8000
 
+# How many ports past the default to try before giving up. Only used when the
+# caller did not name a port: an explicit --port that is busy should fail
+# loudly rather than quietly serving somewhere else.
+PORT_SEARCH_RANGE = 20
+
+# Descriptor filename patterns, in the order they are offered.
+DESCRIPTOR_GLOBS = ("*.model.yaml", "*.model.yml", "*.dmi-model.yaml")
+
+
+def find_descriptors(directory: str | Path = ".") -> list[Path]:
+    """Return descriptor files in ``directory``, sorted, without duplicates.
+
+    Used when no model is named on the command line. Deliberately shallow and
+    pattern-based: guessing which of several models someone meant is worse
+    than listing them.
+    """
+    base = Path(directory)
+    found: list[Path] = []
+    for pattern in DESCRIPTOR_GLOBS:
+        for path in sorted(base.glob(pattern)):
+            if path.is_file() and path not in found:
+                found.append(path)
+    return found
+
+
+def port_is_free(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            probe.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def resolve_port(host: str, port: Optional[int]) -> int:
+    """Pick a port to bind.
+
+    An explicit ``port`` is returned unchanged -- if it is busy, uvicorn should
+    say so. ``None`` means "the usual one, or the next free one after it", so
+    that a second configurator does not fail with an address-in-use trace.
+    """
+    if port is not None:
+        return port
+    for candidate in range(DEFAULT_PORT, DEFAULT_PORT + PORT_SEARCH_RANGE):
+        if port_is_free(host, candidate):
+            return candidate
+    return DEFAULT_PORT  # let uvicorn report the real failure
+
+
+def _open_when_ready(url: str, host: str, port: int, timeout: float = 20.0) -> None:
+    """Open a browser once the server accepts connections.
+
+    Polls rather than sleeping a fixed interval, so a slow first import does
+    not open a browser on a page that is not being served yet.
+    """
+    deadline = threading.Event()
+
+    def wait_and_open() -> None:
+        step = 0.1
+        waited = 0.0
+        while waited < timeout and not deadline.is_set():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.settimeout(step)
+                if probe.connect_ex((host, port)) == 0:
+                    webbrowser.open(url)
+                    return
+            deadline.wait(step)
+            waited += step
+
+    thread = threading.Thread(target=wait_and_open, name="dmi-ui-open", daemon=True)
+    thread.start()
+
 
 def serve(
     source: str | Path,
     config_path: Optional[str | Path] = None,
     host: str = DEFAULT_HOST,
-    port: int = DEFAULT_PORT,
+    port: Optional[int] = None,
+    open_browser: bool = True,
 ) -> None:
     """Run the configurator until interrupted.
 
@@ -32,11 +109,38 @@ def serve(
 
     app = create_app(source, config_path)
     ui = app.state.ui
-    print(f"DMI-configurator  ·  {ui.descriptor.model.name}")
-    print(f"  model from : {ui.source}")
-    print(f"  saves to   : {ui.save_path}")
-    print(f"  serving    : http://{host}:{port}")
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    bound_port = resolve_port(host, port)
+    url = f"http://{host}:{bound_port}"
+
+    topology = ui.descriptor.topology
+    lines = [
+        f"DMI-configurator  ·  {ui.descriptor.model.name}",
+        f"  model      : {topology.num_layers} layers, "
+        f"hidden {topology.hidden_size}"
+        + (f", {topology.num_experts} experts" if topology.is_moe else ""),
+        f"  read from  : {ui.source}",
+        f"  saves to   : {ui.save_path}",
+        f"  serving    : {url}",
+    ]
+    if port is None and bound_port != DEFAULT_PORT:
+        lines.append(f"  (port {DEFAULT_PORT} was busy)")
+    lines.append("  Ctrl-C to stop.")
+    # Flushed explicitly: this banner carries the URL, and a piped or
+    # make-wrapped stdout would otherwise hold it until the server exits.
+    print("\n".join(lines), flush=True)
+
+    if open_browser:
+        _open_when_ready(url, host, bound_port)
+
+    uvicorn.run(app, host=host, port=bound_port, log_level="warning")
 
 
-__all__ = ["serve", "DEFAULT_HOST", "DEFAULT_PORT"]
+__all__ = [
+    "serve",
+    "find_descriptors",
+    "port_is_free",
+    "resolve_port",
+    "DEFAULT_HOST",
+    "DEFAULT_PORT",
+    "DESCRIPTOR_GLOBS",
+]

--- a/src/dmi/ui/server.py
+++ b/src/dmi/ui/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import socket
 import threading
+import time
 import webbrowser
 from pathlib import Path
 from typing import Optional
@@ -69,19 +70,20 @@ def _open_when_ready(url: str, host: str, port: int, timeout: float = 20.0) -> N
     Polls rather than sleeping a fixed interval, so a slow first import does
     not open a browser on a page that is not being served yet.
     """
-    deadline = threading.Event()
 
     def wait_and_open() -> None:
         step = 0.1
-        waited = 0.0
-        while waited < timeout and not deadline.is_set():
+        # Wall-clock deadline: each iteration spends real time in both the
+        # connect probe and the sleep, so counting iterations would stretch
+        # the stated timeout to roughly double.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
                 probe.settimeout(step)
                 if probe.connect_ex((host, port)) == 0:
                     webbrowser.open(url)
                     return
-            deadline.wait(step)
-            waited += step
+            time.sleep(step)
 
     thread = threading.Thread(target=wait_and_open, name="dmi-ui-open", daemon=True)
     thread.start()
@@ -107,7 +109,7 @@ def serve(
             'with:\n    pip install "DMI[ui]"'
         ) from exc
 
-    app = create_app(source, config_path)
+    app = create_app(source, config_path, bind_host=host)
     ui = app.state.ui
     bound_port = resolve_port(host, port)
     url = f"http://{host}:{bound_port}"

--- a/src/dmi/ui/static/app.js
+++ b/src/dmi/ui/static/app.js
@@ -526,7 +526,11 @@
     };
     Object.keys(numeric).forEach(function (id) {
       dom[id].addEventListener("input", function () {
-        var value = parseInt(dom[id].value, 10);
+        // The decode rate is a float on the server (0.5 steps/s is valid);
+        // everything else is a count.
+        var value = id === "wl-rate"
+          ? parseFloat(dom[id].value)
+          : parseInt(dom[id].value, 10);
         if (Number.isNaN(value)) return;
         workload[numeric[id]] = value;
         scheduleEstimate();
@@ -591,10 +595,16 @@
       chip.addEventListener("click", function () {
         var total = layout.num_layers;
         var third = Math.max(1, Math.floor(total / 3));
+        // Clamp so tiny models (1-2 layers) never produce start > end,
+        // which LayerSelection rejects.
+        var middleStart = Math.min(third, total - 1);
         var presets = {
           all: null,
           first: { start: 0, end: third - 1 },
-          middle: { start: third, end: Math.min(total - 1, 2 * third - 1) },
+          middle: {
+            start: middleStart,
+            end: Math.max(middleStart, Math.min(total - 1, 2 * third - 1))
+          },
           last: { start: Math.max(0, total - third), end: total - 1 }
         };
         setLayers(presets[chip.dataset.layers]);

--- a/src/dmi/ui/static/app.js
+++ b/src/dmi/ui/static/app.js
@@ -427,7 +427,15 @@
     updateTimer = setTimeout(refreshOutput, 140);
   }
 
+  // Same stale-response guard as refreshEstimate. Two of these can be in
+  // flight at once -- the debounce shortens the window but does not close it
+  // -- and without a stamp a slow earlier reply paints last, leaving the YAML
+  // preview and Issues tab describing a configuration the user has already
+  // changed away from.
+  var outputRequestId = 0;
+
   async function refreshOutput() {
+    var requestId = (outputRequestId += 1);
     try {
       var results = await Promise.all([
         api("/api/config/serialize", {
@@ -441,9 +449,11 @@
           body: JSON.stringify({ config: state })
         })
       ]);
+      if (requestId !== outputRequestId) return;
       dom["yaml-preview"].textContent = results[0].yaml;
       renderIssues(results[1].issues);
     } catch (error) {
+      if (requestId !== outputRequestId) return;
       dom.status.dataset.state = "invalid";
       dom.status.textContent = "Error";
       renderIssues([{ severity: "error", field: "request", message: error.message }]);

--- a/src/dmi/ui/static/app.js
+++ b/src/dmi/ui/static/app.js
@@ -453,7 +453,14 @@
     refreshEstimate();
   }
 
+  // Responses are not guaranteed to arrive in the order they were sent, and
+  // the estimate endpoint walks every rank, so a slow earlier request can
+  // land after a newer one and paint figures for a workload the user has
+  // already changed. Stamp each request and drop anything but the latest.
+  var estimateRequestId = 0;
+
   async function refreshEstimate() {
+    var requestId = (estimateRequestId += 1);
     try {
       var payload = await api("/api/estimate", {
         method: "POST",
@@ -467,8 +474,10 @@
           }
         })
       });
+      if (requestId !== estimateRequestId) return;
       renderEstimate(payload);
     } catch (error) {
+      if (requestId !== estimateRequestId) return;
       clearEstimate("Could not estimate: " + error.message);
     }
   }

--- a/src/dmi/ui/static/app.js
+++ b/src/dmi/ui/static/app.js
@@ -15,6 +15,23 @@
   var focusedNode = null;
   var updateTimer = null;
 
+  /* Workload and ring sizes are UI-local on purpose. They describe the
+   * serving traffic and the transport, not the capture, and DMIConfig has no
+   * runtime block -- exposing a subset of RingConfig through the saved YAML
+   * would imply a support contract that does not exist. */
+  var workload = {
+    batch_size: 8,
+    prompt_tokens: 2048,
+    decode_tokens: 256,
+    decode_steps_per_second: 0,
+    tensor_parallel_size: 1,
+    pipeline_parallel_size: 1,
+    dtype: "float16",
+    packed: true
+  };
+
+  var ring = { payload_mib: 4096, pinned_mib: 4096 };
+
   var dom = {};
 
   function $(id) { return document.getElementById(id); }
@@ -25,9 +42,37 @@
      "issues", "issue-count", "toast", "file-input", "step-stride",
      "request-stride", "capture-prefill", "capture-decode", "step-offset",
      "warmup-steps", "request-offset", "warmup-requests", "policy",
-     "btn-open", "btn-save", "btn-copy"].forEach(function (id) {
+     "btn-open", "btn-save", "btn-copy",
+     "wl-batch", "wl-prompt", "wl-decode", "wl-rate", "wl-tp", "wl-pp",
+     "wl-dtype", "wl-packed", "ring-payload", "ring-pinned", "ring-meter",
+     "ring-fill", "ring-detail", "est-rank", "est-ranks", "est-ranks-wrap",
+     "est-notes", "fig-peak", "fig-decode", "fig-request", "fig-sustained",
+     "fig-day"].forEach(function (id) {
       dom[id] = $(id);
     });
+  }
+
+  var MIB = 1024 * 1024;
+
+  /* Binary units throughout: DMI sizes its rings in MiB. */
+  function formatBytes(value) {
+    if (value === null || value === undefined) return "—";
+    if (!value) return "0 B";
+    var units = ["B", "KiB", "MiB", "GiB", "TiB"];
+    var scaled = value;
+    var index = 0;
+    while (scaled >= 1024 && index < units.length - 1) {
+      scaled /= 1024;
+      index += 1;
+    }
+    var digits = index === 0 || scaled >= 100 ? 0 : (scaled >= 10 ? 1 : 2);
+    return scaled.toFixed(digits) + " " + units[index];
+  }
+
+  function formatRate(value) {
+    return value === null || value === undefined
+      ? "—"
+      : formatBytes(value) + "/s";
   }
 
   function toast(message) {
@@ -71,6 +116,16 @@
   /* ---------- rendering ---------- */
 
   function renderArchitecture() {
+    // The renderer replaces the whole SVG, which drops keyboard focus. Note
+    // which node held it and put it back, so tabbing to a block and pressing
+    // Enter does not dump the user back at the top of the document.
+    var active = document.activeElement;
+    var refocus =
+      active && dom.architecture.contains(active)
+        ? active.closest("[data-node-id]")
+        : null;
+    var refocusId = refocus ? refocus.dataset.nodeId : null;
+
     DMIArchitecture.render(dom.architecture, layout, {
       selected: selectedHooks(),
       focused: focusedNode,
@@ -80,6 +135,13 @@
         renderDetail();
       }
     });
+
+    if (refocusId) {
+      var restored = dom.architecture.querySelector(
+        '[data-node-id="' + refocusId + '"]'
+      );
+      if (restored) restored.focus();
+    }
   }
 
   function findNode(nodeId) {
@@ -194,6 +256,110 @@
     dom["warmup-requests"].value = state.schedule.warmup_requests;
   }
 
+  function renderEstimate(payload) {
+    dom["fig-peak"].textContent = formatBytes(payload.peak_step_bytes);
+    dom["fig-decode"].textContent = formatBytes(payload.decode_step_bytes);
+    dom["fig-request"].textContent = formatBytes(payload.bytes_per_request);
+    dom["fig-sustained"].textContent = formatRate(
+      payload.sustained_bytes_per_second
+    );
+    dom["fig-day"].textContent = formatBytes(payload.bytes_per_day);
+
+    dom["est-rank"].textContent = payload.peak_step_rank
+      ? "peak on " + payload.peak_step_rank
+      : "";
+
+    renderRingFit(payload.ring_fit);
+    renderRanks(payload);
+    renderNotes(payload);
+  }
+
+  function renderRingFit(fit) {
+    if (!fit) {
+      dom["ring-fill"].style.width = "0%";
+      dom["ring-meter"].removeAttribute("data-tone");
+      dom["ring-detail"].textContent = "—";
+      dom["ring-detail"].removeAttribute("data-tone");
+      return;
+    }
+
+    var percent = Math.max(0, Math.min(100, fit.occupancy_percent));
+    dom["ring-fill"].style.width = percent + "%";
+    dom["ring-meter"].setAttribute(
+      "aria-label",
+      "Ring occupancy " + fit.occupancy_percent.toFixed(0) + " percent"
+    );
+
+    var tone = null;
+    if (!fit.fits) tone = "over";
+    else if (fit.occupancy_percent >= 50) tone = "warning";
+
+    if (tone) dom["ring-meter"].dataset.tone = tone;
+    else dom["ring-meter"].removeAttribute("data-tone");
+
+    dom["ring-detail"].textContent = fit.detail;
+    if (fit.fits) dom["ring-detail"].removeAttribute("data-tone");
+    else dom["ring-detail"].dataset.tone = "over";
+  }
+
+  function renderRanks(payload) {
+    var ranks = payload.ranks || [];
+    // One rank is the single-GPU case; the breakdown says nothing extra.
+    var interesting = ranks.length > 1;
+    dom["est-ranks-wrap"].hidden = !interesting;
+    if (!interesting) return;
+
+    var frag = document.createDocumentFragment();
+    ranks.forEach(function (rank) {
+      var row = document.createElement("tr");
+      if (rank.label === payload.peak_step_rank) row.dataset.worst = "true";
+      [
+        rank.label,
+        formatBytes(rank.prefill_step_bytes),
+        formatBytes(rank.decode_step_bytes),
+        String(rank.prefill_hooks)
+      ].forEach(function (value) {
+        var cell = document.createElement("td");
+        cell.textContent = value;
+        row.append(cell);
+      });
+      frag.append(row);
+    });
+    dom["est-ranks"].replaceChildren(frag);
+  }
+
+  function renderNotes(payload) {
+    var frag = document.createDocumentFragment();
+    (payload.warnings || []).forEach(function (message) {
+      frag.append(noteElement(message, "warning"));
+    });
+    (payload.assumptions || []).forEach(function (message) {
+      frag.append(noteElement(message, "assumption"));
+    });
+    dom["est-notes"].replaceChildren(frag);
+  }
+
+  function noteElement(message, kind) {
+    var note = document.createElement("p");
+    note.className = "est-note";
+    note.dataset.kind = kind;
+    var body = document.createElement("span");
+    body.textContent = message;
+    note.append(body);
+    return note;
+  }
+
+  function clearEstimate(message) {
+    ["fig-peak", "fig-decode", "fig-request", "fig-sustained", "fig-day"]
+      .forEach(function (id) { dom[id].textContent = "—"; });
+    dom["est-rank"].textContent = "";
+    dom["est-ranks-wrap"].hidden = true;
+    renderRingFit(null);
+    dom["est-notes"].replaceChildren(
+      noteElement(message, "warning")
+    );
+  }
+
   function renderIssues(issues) {
     var errors = issues.filter(function (i) { return i.severity === "error"; });
     var warnings = issues.filter(function (i) { return i.severity === "warning"; });
@@ -282,6 +448,29 @@
       dom.status.textContent = "Error";
       renderIssues([{ severity: "error", field: "request", message: error.message }]);
     }
+    // Estimated separately: a workload the estimator rejects should not blank
+    // the YAML preview, and an unserializable config should not blank this.
+    refreshEstimate();
+  }
+
+  async function refreshEstimate() {
+    try {
+      var payload = await api("/api/estimate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: state,
+          workload: workload,
+          ring: {
+            payload_bytes: ring.payload_mib * MIB,
+            pinned_bytes: ring.pinned_mib * MIB
+          }
+        })
+      });
+      renderEstimate(payload);
+    } catch (error) {
+      clearEstimate("Could not estimate: " + error.message);
+    }
   }
 
   function applyState(next) {
@@ -324,6 +513,51 @@
       state.schedule.capture_decode = dom["capture-decode"].checked;
       scheduleUpdate();
     });
+  }
+
+  function bindWorkload() {
+    var numeric = {
+      "wl-batch": "batch_size",
+      "wl-prompt": "prompt_tokens",
+      "wl-decode": "decode_tokens",
+      "wl-rate": "decode_steps_per_second",
+      "wl-tp": "tensor_parallel_size",
+      "wl-pp": "pipeline_parallel_size"
+    };
+    Object.keys(numeric).forEach(function (id) {
+      dom[id].addEventListener("input", function () {
+        var value = parseInt(dom[id].value, 10);
+        if (Number.isNaN(value)) return;
+        workload[numeric[id]] = value;
+        scheduleEstimate();
+      });
+    });
+
+    dom["wl-dtype"].addEventListener("change", function () {
+      workload.dtype = dom["wl-dtype"].value;
+      scheduleEstimate();
+    });
+    dom["wl-packed"].addEventListener("change", function () {
+      workload.packed = dom["wl-packed"].value === "packed";
+      scheduleEstimate();
+    });
+
+    var ringInputs = { "ring-payload": "payload_mib", "ring-pinned": "pinned_mib" };
+    Object.keys(ringInputs).forEach(function (id) {
+      dom[id].addEventListener("input", function () {
+        var value = parseInt(dom[id].value, 10);
+        if (Number.isNaN(value) || value < 0) return;
+        ring[ringInputs[id]] = value;
+        scheduleEstimate();
+      });
+    });
+  }
+
+  var estimateTimer = null;
+
+  function scheduleEstimate() {
+    clearTimeout(estimateTimer);
+    estimateTimer = setTimeout(refreshEstimate, 140);
   }
 
   function bindLayers() {
@@ -438,6 +672,7 @@
   async function boot() {
     cacheDom();
     bindSchedule();
+    bindWorkload();
     bindLayers();
     bindTabs();
     bindPolicy();

--- a/src/dmi/ui/static/index.html
+++ b/src/dmi/ui/static/index.html
@@ -105,7 +105,7 @@
         <label>Batch size <input type="number" id="wl-batch" min="1" step="1" value="8"></label>
         <label>Prompt tokens <input type="number" id="wl-prompt" min="1" step="1" value="2048"></label>
         <label>Decode tokens <input type="number" id="wl-decode" min="0" step="1" value="256"></label>
-        <label>Decode rate <input type="number" id="wl-rate" min="0" step="1" value="0"> steps/s</label>
+        <label>Decode rate <input type="number" id="wl-rate" min="0" step="any" value="0"> steps/s</label>
         <label>Tensor parallel <input type="number" id="wl-tp" min="1" step="1" value="1"></label>
         <label>Pipeline parallel <input type="number" id="wl-pp" min="1" step="1" value="1"></label>
         <label>Activation dtype

--- a/src/dmi/ui/static/index.html
+++ b/src/dmi/ui/static/index.html
@@ -94,6 +94,103 @@
     </p>
   </section>
 
+  <section class="panel estimate" aria-label="Estimated payload">
+    <div class="output-head">
+      <h2 class="panel-title">Estimated payload</h2>
+      <span class="est-rank" id="est-rank"></span>
+    </div>
+
+    <div class="workload">
+      <div class="field-grid">
+        <label>Batch size <input type="number" id="wl-batch" min="1" step="1" value="8"></label>
+        <label>Prompt tokens <input type="number" id="wl-prompt" min="1" step="1" value="2048"></label>
+        <label>Decode tokens <input type="number" id="wl-decode" min="0" step="1" value="256"></label>
+        <label>Decode rate <input type="number" id="wl-rate" min="0" step="1" value="0"> steps/s</label>
+        <label>Tensor parallel <input type="number" id="wl-tp" min="1" step="1" value="1"></label>
+        <label>Pipeline parallel <input type="number" id="wl-pp" min="1" step="1" value="1"></label>
+        <label>Activation dtype
+          <select id="wl-dtype">
+            <option value="float16" selected>float16</option>
+            <option value="bfloat16">bfloat16</option>
+            <option value="float32">float32</option>
+            <option value="float8_e4m3fn">float8_e4m3fn</option>
+          </select>
+        </label>
+        <label>Tensor layout
+          <select id="wl-packed">
+            <option value="packed" selected>Packed (vLLM)</option>
+            <option value="batched">Batched (HF generate)</option>
+          </select>
+        </label>
+      </div>
+      <p class="hint">
+        Describes the traffic capture rides along with, not the capture itself.
+        Not written to the configuration file.
+      </p>
+    </div>
+
+    <dl class="figures" id="figures">
+      <div class="figure is-peak">
+        <dt>Peak step</dt>
+        <dd id="fig-peak">&mdash;</dd>
+        <span class="figure-note">Sets ring sizing</span>
+      </div>
+      <div class="figure">
+        <dt>Decode step</dt>
+        <dd id="fig-decode">&mdash;</dd>
+        <span class="figure-note">Per captured step</span>
+      </div>
+      <div class="figure">
+        <dt>Per request</dt>
+        <dd id="fig-request">&mdash;</dd>
+        <span class="figure-note">Schedule applied</span>
+      </div>
+      <div class="figure">
+        <dt>Sustained</dt>
+        <dd id="fig-sustained">&mdash;</dd>
+        <span class="figure-note">Decode only</span>
+      </div>
+      <div class="figure">
+        <dt>Per day</dt>
+        <dd id="fig-day">&mdash;</dd>
+        <span class="figure-note">At that rate</span>
+      </div>
+    </dl>
+
+    <div class="ring">
+      <div class="ring-head">
+        <h3 class="section-title">Ring capacity</h3>
+        <div class="ring-inputs">
+          <label>Payload <input type="number" id="ring-payload" min="1" step="1" value="4096"> MiB</label>
+          <label>Pinned <input type="number" id="ring-pinned" min="0" step="1" value="4096"> MiB</label>
+        </div>
+      </div>
+      <div class="meter" id="ring-meter" role="img" aria-label="Ring occupancy">
+        <span class="meter-fill" id="ring-fill"></span>
+      </div>
+      <p class="ring-detail" id="ring-detail">&mdash;</p>
+    </div>
+
+    <details class="advanced" id="est-ranks-wrap" hidden>
+      <summary>Per-rank load</summary>
+      <div class="table-scroll">
+        <table class="ranks">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Prefill step</th>
+              <th scope="col">Decode step</th>
+              <th scope="col">Hooks</th>
+            </tr>
+          </thead>
+          <tbody id="est-ranks"></tbody>
+        </table>
+      </div>
+    </details>
+
+    <div class="est-notes" id="est-notes"></div>
+  </section>
+
   <section class="panel output" aria-label="Configuration output">
     <div class="output-head">
       <h2 class="panel-title">Configuration</h2>

--- a/src/dmi/ui/static/index.html
+++ b/src/dmi/ui/static/index.html
@@ -73,6 +73,13 @@
       </div>
     </details>
 
+    <p class="notice">
+      Strides, offsets and warmup are written to the configuration file but are
+      <strong>not enforced</strong> by any adapter yet, so they do not reduce
+      what DMI captures. Prefill and decode are honoured. The estimate below
+      reports the full volume for that reason.
+    </p>
+
     <h2 class="panel-title spaced">System objective</h2>
     <div class="policy" id="policy">
       <label class="radio">

--- a/src/dmi/ui/static/styles.css
+++ b/src/dmi/ui/static/styles.css
@@ -129,7 +129,8 @@ body {
   grid-template-columns: minmax(0, 1.35fr) minmax(300px, .95fr);
   grid-template-areas:
     "architecture detail"
-    "capture      output";
+    "capture      output"
+    "estimate     estimate";
   gap: 16px;
   padding: 16px 22px 32px;
   max-width: 1400px;
@@ -141,11 +142,12 @@ body {
 .detail { grid-area: detail; }
 .capture { grid-area: capture; }
 .output { grid-area: output; }
+.estimate { grid-area: estimate; }
 
 @media (max-width: 940px) {
   .layout {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas: "architecture" "detail" "capture" "output";
+    grid-template-areas: "architecture" "detail" "capture" "estimate" "output";
   }
 }
 
@@ -411,4 +413,217 @@ input[type="number"] {
   font-size: 13px;
   box-shadow: var(--shadow-lift);
   z-index: 50;
+}
+
+/* ---------------------------------------------------------------------------
+   Estimated payload
+   --------------------------------------------------------------------------- */
+
+.workload { margin-bottom: 16px; }
+
+.workload .field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px 14px;
+}
+
+.workload select {
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface-sunken);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+  min-width: 0;
+}
+
+.est-rank {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: .04em;
+}
+
+.figures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 10px;
+  margin: 0 0 18px;
+  padding: 0;
+}
+
+.figure {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  min-width: 0;
+}
+
+.figure dt {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.figure dd {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.figure.is-peak {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.figure.is-peak dd { color: var(--accent-ink); }
+
+.figure-note {
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+
+/* Ring occupancy */
+
+.ring { margin-bottom: 14px; }
+
+.ring-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 12px;
+  margin-bottom: 8px;
+}
+
+.ring-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+}
+
+.meter {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--line);
+  overflow: hidden;
+}
+
+.meter-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--ok);
+  transition: width .18s ease, background .18s ease;
+}
+
+.meter[data-tone="warning"] .meter-fill { background: var(--warn); }
+.meter[data-tone="over"] .meter-fill { background: var(--err); }
+
+.ring-detail {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+.ring-detail[data-tone="over"] { color: var(--err); }
+
+/* Per-rank table */
+
+.table-scroll { overflow-x: auto; }
+
+table.ranks {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 24rem;
+  font-size: 12px;
+}
+
+table.ranks th {
+  text-align: left;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+table.ranks td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-soft);
+}
+
+table.ranks tr:last-child td { border-bottom: none; }
+table.ranks tr[data-worst="true"] td { color: var(--accent-ink); }
+
+/* Assumptions and warnings */
+
+.est-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.est-note {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+.est-note::before {
+  content: "";
+  flex: none;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--line);
+}
+
+.est-note[data-kind="warning"] { color: var(--ink); }
+.est-note[data-kind="warning"]::before { background: var(--warn); }
+
+/* ---------------------------------------------------------------------------
+   Focus and motion
+   --------------------------------------------------------------------------- */
+
+/* The architecture nodes carry tabindex, so they need a visible focus ring;
+   SVG does not inherit the document outline reliably, so style the box too. */
+:where(a, button, input, select, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.node:focus { outline: none; }
+
+.node:focus-visible .node-box {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/tests/test_adapter_layer_selection.py
+++ b/tests/test_adapter_layer_selection.py
@@ -360,3 +360,57 @@ def test_compile_config_accepts_unbound_authoring_time_specs():
     compiled = compile_config(config, ModelContext(specs=specs))
 
     assert compiled.selected_layers == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# attach_config against an adapter that does not know about layers
+# ---------------------------------------------------------------------------
+
+
+class LegacyAdapter(StubAdapter):
+    """A third-party adapter written before `layers` existed.
+
+    Adapters are a public extension point, so one overriding attach_model
+    without the keyword has to keep working for every configuration that does
+    not ask for a layer range.
+    """
+
+    def attach_model(self, model, hook_selection: str = "full") -> None:
+        self.received_selection = hook_selection
+        return BackendAdapter.attach_model(self, model, hook_selection)
+
+
+def test_attach_config_does_not_pass_layers_when_no_range_is_set():
+    adapter, model = _make_adapter(num_layers=4)
+    legacy = LegacyAdapter(adapter.engine)
+    config = DMIConfig(
+        observations=ObservationConfig(hooks=["resid_pre"], layers=None)
+    )
+
+    attach_config(legacy, model, config)
+
+    assert legacy.received_selection == "resid_pre"
+    assert _layers_of(legacy.active_specs) == set(range(4))
+
+
+def test_attach_config_fails_loudly_when_a_range_cannot_be_applied():
+    """Silently dropping the range is the outcome this wiring prevents."""
+    adapter, model = _make_adapter(num_layers=4)
+    legacy = LegacyAdapter(adapter.engine)
+    config = DMIConfig(
+        observations=ObservationConfig(
+            hooks=["resid_pre"], layers=LayerSelection(1, 2)
+        )
+    )
+
+    with pytest.raises(TypeError, match="layers"):
+        attach_config(legacy, model, config)
+
+
+def test_the_shipped_hf_adapter_accepts_layers():
+    """The concrete adapter must support the keyword end to end."""
+    import inspect
+
+    from dmi.adapters.huggingface.adapter import HuggingFaceAdapter
+
+    assert "layers" in inspect.signature(HuggingFaceAdapter.attach_model).parameters

--- a/tests/test_adapter_layer_selection.py
+++ b/tests/test_adapter_layer_selection.py
@@ -257,3 +257,106 @@ def test_attach_config_disables_hooks_the_config_did_not_select():
     for spec in model.specs:
         if spec.hook_type == HOOK_TYPE_Q:
             assert spec.module.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# The shipped concrete adapter must accept the same wiring
+# ---------------------------------------------------------------------------
+
+
+class FakeHFModel(FakeModel):
+    """A FakeModel that also quacks like a Hugging Face model."""
+
+    def __init__(self, num_layers: int = 8) -> None:
+        super().__init__(num_layers=num_layers)
+        from types import SimpleNamespace
+
+        self.config = SimpleNamespace(
+            hidden_size=512,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            vocab_size=32000,
+            intermediate_size=1376,
+        )
+
+
+def test_hf_adapter_forwards_the_layer_range():
+    """attach_config drives the real HuggingFaceAdapter, so its attach_model
+    override must accept and forward ``layers`` -- a stub subclassing
+    BackendAdapter directly would not catch a dropped kwarg."""
+    from dmi.adapters.huggingface.adapter import HuggingFaceAdapter
+
+    adapter = HuggingFaceAdapter(FakeEngine(), "test_model")
+    model = FakeHFModel(num_layers=8)
+
+    adapter.attach_model(
+        model, "resid_pre,q",
+        install_prepare_wrapper=False,
+        layers=LayerSelection(2, 4),
+    )
+
+    assert _layers_of(adapter.active_specs) == {2, 3, 4}
+
+
+def test_attach_config_works_through_the_hf_adapter():
+    from dmi.adapters.huggingface.adapter import HuggingFaceAdapter
+
+    adapter = HuggingFaceAdapter(FakeEngine(), "test_model")
+    model = FakeHFModel(num_layers=8)
+    config = DMIConfig(
+        observations=ObservationConfig(
+            hooks=["resid_pre"], layers=LayerSelection(4, 6)
+        )
+    )
+
+    attach_config(adapter, model, config)
+
+    assert _layers_of(adapter.active_specs) == {4, 5, 6}
+
+
+# ---------------------------------------------------------------------------
+# compile_config stays pure
+# ---------------------------------------------------------------------------
+
+
+def test_compile_config_with_a_layer_range_does_not_touch_the_model():
+    """compile_config answers "what would this select?"; asking must never
+    disable hook points on a live model the way attach_model does."""
+    from dmi.configuration.compiler import ModelContext, compile_config
+
+    adapter, model = _make_adapter(num_layers=8)
+    adapter.attach_model(model, "full")
+    assert all(spec.module.enabled for spec in model.specs)
+
+    config = DMIConfig(
+        observations=ObservationConfig(
+            hooks=["resid_pre"], layers=LayerSelection(2, 4)
+        )
+    )
+    compiled = compile_config(
+        config, ModelContext(specs=model.get_hook_specs())
+    )
+
+    assert compiled.selected_layers == [2, 3, 4]
+    assert all(spec.module.enabled for spec in model.specs), (
+        "compile_config disabled live hook points"
+    )
+
+
+def test_compile_config_accepts_unbound_authoring_time_specs():
+    """Specs without a bound module (authoring time, no model) must compile."""
+    from dmi.configuration.compiler import ModelContext, compile_config
+
+    specs = [
+        HookSpec(hook_type=HOOK_TYPE_RESID_PRE, module=None, layer_no=layer)
+        for layer in range(6)
+    ]
+    config = DMIConfig(
+        observations=ObservationConfig(
+            hooks=["resid_pre"], layers=LayerSelection(1, 2)
+        )
+    )
+
+    compiled = compile_config(config, ModelContext(specs=specs))
+
+    assert compiled.selected_layers == [1, 2]

--- a/tests/test_adapter_layer_selection.py
+++ b/tests/test_adapter_layer_selection.py
@@ -1,0 +1,259 @@
+"""Layer-range filtering through ``BackendAdapter.attach_model``.
+
+The configurator lets a user author a layer range, but a range only means
+something if it survives the trip into the runtime.  These tests pin the
+wiring: ``attach_model(..., layers=...)`` applies the range, disables the
+hook points it drops, and leaves global observations alone.
+
+No GPU, no compiled backend: ``install_ring_hooks`` is attribute assignment
+and accepts ``ring_payload=None``, so this belongs in the CPU gate.
+"""
+from __future__ import annotations
+
+import pytest
+
+from dmi.adapters.base import BackendAdapter
+from dmi.configuration import DMIConfig, LayerSelection, ObservationConfig
+from dmi.configuration.compiler import attach_config
+from dmi.hooks.point import HookPoint
+from dmi.hooks.specs import (
+    HOOK_TYPE_FINAL_LOGITS,
+    HOOK_TYPE_Q,
+    HOOK_TYPE_RESID_PRE,
+    HOOK_TYPE_TOKEN_IDS,
+    HookSpec,
+    ModelShapeConfig,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.null_offload = False
+        self.force_eager = False
+        self._active_specs: list = []
+        self._using_forward_hooks = False
+        self._ring_payload = None
+        self._model_cfg = None
+
+    def set_model_cfg(self, cfg):
+        self._model_cfg = cfg
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self._ring_transport = FakeTransport()
+        self._ring_engine = None
+
+
+class FakeModel:
+    """A model that self-describes per-layer and global hooks."""
+
+    def __init__(self, num_layers: int = 8) -> None:
+        self.specs: list[HookSpec] = []
+        for layer_no in range(num_layers):
+            for hook_type in (HOOK_TYPE_RESID_PRE, HOOK_TYPE_Q):
+                self.specs.append(
+                    HookSpec(
+                        hook_type=hook_type,
+                        module=HookPoint(),
+                        layer_no=layer_no,
+                    )
+                )
+        # Global hooks carry layer_no == -1.
+        for hook_type in (HOOK_TYPE_TOKEN_IDS, HOOK_TYPE_FINAL_LOGITS):
+            self.specs.append(
+                HookSpec(hook_type=hook_type, module=HookPoint(), layer_no=-1)
+            )
+
+    def get_hook_specs(self) -> list[HookSpec]:
+        return list(self.specs)
+
+
+class StubAdapter(BackendAdapter):
+    """Single-rank adapter with a fixed model shape."""
+
+    def __init__(self, engine, model_id="test_model", shape=None):
+        super().__init__(engine, model_id)
+        self._shape = shape or _make_shape()
+
+    def detect_model_shape(self, model):
+        return self._shape
+
+    def detect_parallel_ranks(self):
+        return (0, 0, 0, 0)
+
+    def is_pp_first(self):
+        return True
+
+    def is_pp_last(self):
+        return True
+
+    def build_step_context(self, *raw):
+        raise NotImplementedError
+
+    def on_capacity_exceeded(self, ctx):
+        raise NotImplementedError
+
+
+def _make_shape() -> ModelShapeConfig:
+    import torch
+
+    return ModelShapeConfig(
+        hidden_dim=512,
+        num_heads=8,
+        num_kv_heads=8,
+        head_dim=64,
+        dtype=torch.float16,
+        vocab_size=32000,
+        intermediate_dim=1376,
+    )
+
+
+def _make_adapter(num_layers: int = 8):
+    engine = FakeEngine()
+    adapter = StubAdapter(engine)
+    return adapter, FakeModel(num_layers=num_layers)
+
+
+def _layers_of(specs) -> set[int]:
+    return {spec.layer_no for spec in specs if spec.layer_no >= 0}
+
+
+# ---------------------------------------------------------------------------
+# attach_model(layers=...)
+# ---------------------------------------------------------------------------
+
+
+def test_no_layers_argument_keeps_every_layer():
+    adapter, model = _make_adapter(num_layers=8)
+
+    adapter.attach_model(model, "resid_pre,q")
+
+    assert _layers_of(adapter.active_specs) == set(range(8))
+
+
+def test_layer_range_keeps_only_the_selected_layers():
+    adapter, model = _make_adapter(num_layers=8)
+
+    adapter.attach_model(model, "resid_pre,q", layers=LayerSelection(2, 4))
+
+    assert _layers_of(adapter.active_specs) == {2, 3, 4}
+
+
+def test_layer_range_is_inclusive_of_both_bounds():
+    adapter, model = _make_adapter(num_layers=8)
+
+    adapter.attach_model(model, "resid_pre", layers=LayerSelection(3, 3))
+
+    assert _layers_of(adapter.active_specs) == {3}
+
+
+def test_layer_range_never_drops_global_observations():
+    adapter, model = _make_adapter(num_layers=8)
+
+    adapter.attach_model(
+        model, "resid_pre,token_ids,final_logits", layers=LayerSelection(0, 1)
+    )
+
+    kept = {spec.hook_type for spec in adapter.active_specs}
+    assert HOOK_TYPE_TOKEN_IDS in kept
+    assert HOOK_TYPE_FINAL_LOGITS in kept
+
+
+def test_dropped_layers_have_their_hook_points_disabled():
+    """A filtered spec must be inert, not merely absent from active_specs.
+
+    ``HookPoint.enabled`` defaults to True, so a filter that only shortened
+    the list would leave the dropped hooks firing.
+    """
+    adapter, model = _make_adapter(num_layers=6)
+
+    adapter.attach_model(model, "resid_pre,q", layers=LayerSelection(1, 2))
+
+    kept = {id(spec) for spec in adapter.active_specs}
+    for spec in model.specs:
+        if spec.layer_no < 0:
+            continue
+        expected = id(spec) in kept
+        assert spec.module.enabled is expected, (
+            f"layer {spec.layer_no} hook_type {spec.hook_type} "
+            f"enabled={spec.module.enabled}, expected {expected}"
+        )
+
+
+def test_layer_filter_composes_with_hook_selection():
+    """Selection decides which kinds; the range decides where."""
+    adapter, model = _make_adapter(num_layers=8)
+
+    adapter.attach_model(model, "q", layers=LayerSelection(5, 6))
+
+    assert {spec.hook_type for spec in adapter.active_specs} == {HOOK_TYPE_Q}
+    assert _layers_of(adapter.active_specs) == {5, 6}
+
+
+def test_installed_specs_are_published_to_the_transport():
+    adapter, model = _make_adapter(num_layers=4)
+
+    adapter.attach_model(model, "resid_pre", layers=LayerSelection(0, 1))
+
+    assert adapter.transport._active_specs == adapter.active_specs
+    assert adapter.transport._using_forward_hooks is True
+
+
+def test_inverted_range_is_rejected_at_construction():
+    with pytest.raises(ValueError, match="layer end must be >= start"):
+        LayerSelection(5, 2)
+
+
+# ---------------------------------------------------------------------------
+# attach_config: DMIConfig -> attach_model
+# ---------------------------------------------------------------------------
+
+
+def test_attach_config_applies_hooks_and_layers_from_a_config():
+    adapter, model = _make_adapter(num_layers=8)
+    config = DMIConfig(
+        observations=ObservationConfig(
+            hooks=["resid_pre", "q"], layers=LayerSelection(4, 6)
+        )
+    )
+
+    attach_config(adapter, model, config)
+
+    assert _layers_of(adapter.active_specs) == {4, 5, 6}
+    assert {spec.hook_type for spec in adapter.active_specs} == {
+        HOOK_TYPE_RESID_PRE,
+        HOOK_TYPE_Q,
+    }
+
+
+def test_attach_config_without_a_layer_range_keeps_every_layer():
+    adapter, model = _make_adapter(num_layers=5)
+    config = DMIConfig(
+        observations=ObservationConfig(hooks=["resid_pre"], layers=None)
+    )
+
+    attach_config(adapter, model, config)
+
+    assert _layers_of(adapter.active_specs) == set(range(5))
+
+
+def test_attach_config_disables_hooks_the_config_did_not_select():
+    """The regression the docstring in attach_config warns about."""
+    adapter, model = _make_adapter(num_layers=4)
+    config = DMIConfig(
+        observations=ObservationConfig(hooks=["resid_pre"], layers=None)
+    )
+
+    attach_config(adapter, model, config)
+
+    for spec in model.specs:
+        if spec.hook_type == HOOK_TYPE_Q:
+            assert spec.module.enabled is False

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -1,0 +1,343 @@
+"""``dmi ui`` argument handling, descriptor discovery, and port selection.
+
+None of this starts a server. The pieces that decide *what* to serve and
+*where* are separated from ``serve()`` precisely so they can be tested without
+binding a socket or importing uvicorn.
+"""
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from dmi.cli import _resolve_ui_model, build_parser
+from dmi.configuration.errors import ConfigurationError
+from dmi.ui.server import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    find_descriptors,
+    port_is_free,
+    resolve_port,
+)
+
+pytestmark = pytest.mark.cpu
+
+REPO = Path(__file__).resolve().parents[1]
+EXAMPLE = REPO / "examples" / "model_descriptors" / "llama3-8b.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def test_model_is_optional():
+    args = build_parser().parse_args(["ui"])
+
+    assert args.model is None
+
+
+def test_model_is_taken_positionally_when_given():
+    args = build_parser().parse_args(["ui", "./some-model"])
+
+    assert args.model == "./some-model"
+
+
+def test_port_defaults_to_none_so_it_can_fall_back():
+    """An explicit port must be distinguishable from no port at all."""
+    args = build_parser().parse_args(["ui"])
+
+    assert args.port is None
+
+
+def test_explicit_port_is_preserved():
+    args = build_parser().parse_args(["ui", "--port", "9001"])
+
+    assert args.port == 9001
+
+
+def test_browser_opens_by_default():
+    args = build_parser().parse_args(["ui"])
+
+    assert args.no_browser is False
+
+
+def test_no_browser_can_be_disabled():
+    args = build_parser().parse_args(["ui", "--no-browser"])
+
+    assert args.no_browser is True
+
+
+# ---------------------------------------------------------------------------
+# Descriptor discovery
+# ---------------------------------------------------------------------------
+
+
+def test_no_descriptors_found_in_an_empty_directory(tmp_path):
+    assert find_descriptors(tmp_path) == []
+
+
+def test_descriptor_is_found_by_its_suffix(tmp_path):
+    target = tmp_path / "qwen3.model.yaml"
+    target.write_text("schema_version: 1\n")
+
+    assert find_descriptors(tmp_path) == [target]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["a.model.yaml", "a.model.yml", "a.dmi-model.yaml"],
+)
+def test_every_supported_descriptor_suffix_is_discovered(tmp_path, name):
+    (tmp_path / name).write_text("schema_version: 1\n")
+
+    assert len(find_descriptors(tmp_path)) == 1
+
+
+def test_unrelated_yaml_is_not_treated_as_a_descriptor(tmp_path):
+    (tmp_path / "config.yaml").write_text("nope: true\n")
+    (tmp_path / "attention-debug.dmi.yaml").write_text("version: 1\n")
+
+    assert find_descriptors(tmp_path) == []
+
+
+def test_discovery_is_sorted_and_deduplicated(tmp_path):
+    for name in ["b.model.yaml", "a.model.yaml"]:
+        (tmp_path / name).write_text("schema_version: 1\n")
+
+    found = find_descriptors(tmp_path)
+
+    assert [path.name for path in found] == ["a.model.yaml", "b.model.yaml"]
+
+
+def test_a_directory_is_not_mistaken_for_a_descriptor(tmp_path):
+    (tmp_path / "weird.model.yaml").mkdir()
+
+    assert find_descriptors(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+
+def test_an_explicit_model_is_returned_unchanged():
+    assert _resolve_ui_model("Qwen/Qwen3-8B") == "Qwen/Qwen3-8B"
+
+
+def test_a_lone_descriptor_is_used_without_being_named(tmp_path, monkeypatch):
+    target = tmp_path / "solo.model.yaml"
+    target.write_text("schema_version: 1\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert _resolve_ui_model(None) == str(Path("solo.model.yaml"))
+
+
+def test_no_descriptor_explains_how_to_make_one(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        _resolve_ui_model(None)
+
+    message = str(excinfo.value)
+    assert "No model given" in message
+    assert "describe-model" in message
+
+
+def test_several_descriptors_ask_rather_than_guess(tmp_path, monkeypatch):
+    for name in ["one.model.yaml", "two.model.yaml"]:
+        (tmp_path / name).write_text("schema_version: 1\n")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        _resolve_ui_model(None)
+
+    message = str(excinfo.value)
+    assert "2 descriptors" in message
+    # Both candidates offered as runnable commands.
+    assert "one.model.yaml" in message
+    assert "two.model.yaml" in message
+
+
+# ---------------------------------------------------------------------------
+# Port selection
+# ---------------------------------------------------------------------------
+
+
+def _fake_availability(monkeypatch, busy: set[int]):
+    """Drive resolve_port's branching without binding a real socket.
+
+    Binding is the wrong dependency for a unit test: a sandboxed or otherwise
+    restricted CI environment refuses it, and the logic worth pinning here is
+    which port gets chosen, not whether the kernel hands out sockets.
+    """
+    monkeypatch.setattr(
+        "dmi.ui.server.port_is_free",
+        lambda host, port: port not in busy,
+    )
+
+
+def test_an_explicit_port_is_never_moved(monkeypatch):
+    """A named port that is busy must fail loudly, not serve elsewhere."""
+    _fake_availability(monkeypatch, busy={9001})
+
+    assert resolve_port(DEFAULT_HOST, 9001) == 9001
+
+
+def test_an_explicit_port_is_not_probed_at_all(monkeypatch):
+    """Nothing should touch the network when the caller named a port."""
+    calls = []
+
+    def tripwire(host, port):
+        calls.append(port)
+        return True
+
+    monkeypatch.setattr("dmi.ui.server.port_is_free", tripwire)
+
+    assert resolve_port(DEFAULT_HOST, 9001) == 9001
+    assert calls == []
+
+
+def test_automatic_port_prefers_the_default_when_it_is_free(monkeypatch):
+    _fake_availability(monkeypatch, busy=set())
+
+    assert resolve_port(DEFAULT_HOST, None) == DEFAULT_PORT
+
+
+def test_automatic_port_skips_the_default_when_it_is_taken(monkeypatch):
+    _fake_availability(monkeypatch, busy={DEFAULT_PORT})
+
+    assert resolve_port(DEFAULT_HOST, None) == DEFAULT_PORT + 1
+
+
+def test_automatic_port_walks_past_a_run_of_busy_ports(monkeypatch):
+    _fake_availability(
+        monkeypatch, busy=set(range(DEFAULT_PORT, DEFAULT_PORT + 5))
+    )
+
+    assert resolve_port(DEFAULT_HOST, None) == DEFAULT_PORT + 5
+
+
+def test_automatic_port_falls_back_to_the_default_when_none_are_free(monkeypatch):
+    """Exhausting the search hands the real failure to uvicorn to report."""
+    _fake_availability(
+        monkeypatch, busy=set(range(DEFAULT_PORT, DEFAULT_PORT + 10_000))
+    )
+
+    assert resolve_port(DEFAULT_HOST, None) == DEFAULT_PORT
+
+
+def test_port_is_free_reports_a_boolean(monkeypatch):
+    """The probe answers a question; it must not leak an OSError upward."""
+
+    class RefusingSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def setsockopt(self, *args):
+            pass
+
+        def bind(self, address):
+            raise OSError("address in use")
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: RefusingSocket())
+
+    assert port_is_free(DEFAULT_HOST, 8000) is False
+
+
+def test_the_documented_default_port_is_unchanged():
+    """Docs and the launch config name 8000; keep them honest."""
+    assert DEFAULT_PORT == 8000
+
+
+# ---------------------------------------------------------------------------
+# Browser opening
+# ---------------------------------------------------------------------------
+
+
+def _patch_connect(monkeypatch, results):
+    """Fake connect_ex, returning each queued result in turn (0 == connected)."""
+    queue = list(results)
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def settimeout(self, _seconds):
+            pass
+
+        def connect_ex(self, _address):
+            return queue.pop(0) if queue else 111
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSocket())
+
+
+def test_browser_opens_once_the_port_accepts(monkeypatch):
+    from dmi.ui import server
+
+    opened = []
+    monkeypatch.setattr(server.webbrowser, "open", opened.append)
+    _patch_connect(monkeypatch, [0])
+
+    server._open_when_ready("http://127.0.0.1:8000", DEFAULT_HOST, 8000, timeout=2.0)
+    _join_opener()
+
+    assert opened == ["http://127.0.0.1:8000"]
+
+
+def test_browser_waits_for_the_server_before_opening(monkeypatch):
+    """A slow first import must not open a browser on a dead port."""
+    from dmi.ui import server
+
+    opened = []
+    monkeypatch.setattr(server.webbrowser, "open", opened.append)
+    # Refused twice, then accepted.
+    _patch_connect(monkeypatch, [111, 111, 0])
+
+    server._open_when_ready("http://127.0.0.1:8000", DEFAULT_HOST, 8000, timeout=5.0)
+    _join_opener()
+
+    assert opened == ["http://127.0.0.1:8000"]
+
+
+def test_browser_gives_up_instead_of_hanging(monkeypatch):
+    from dmi.ui import server
+
+    opened = []
+    monkeypatch.setattr(server.webbrowser, "open", opened.append)
+    _patch_connect(monkeypatch, [])  # always refused
+
+    server._open_when_ready("http://127.0.0.1:8000", DEFAULT_HOST, 8000, timeout=0.3)
+    _join_opener()
+
+    assert opened == []
+
+
+def test_the_opener_thread_does_not_outlive_the_process():
+    from dmi.ui import server
+
+    import threading as _threading
+
+    before = {t.name for t in _threading.enumerate()}
+    server._open_when_ready("http://127.0.0.1:1", DEFAULT_HOST, 1, timeout=0.2)
+    opener = [t for t in _threading.enumerate() if t.name == "dmi-ui-open"]
+
+    assert opener, "opener thread was not started"
+    assert opener[0].daemon is True, "a non-daemon thread would block exit"
+    _join_opener()
+    assert "dmi-ui-open" not in before
+
+
+def _join_opener(timeout: float = 5.0) -> None:
+    import threading as _threading
+
+    for thread in _threading.enumerate():
+        if thread.name == "dmi-ui-open":
+            thread.join(timeout)

--- a/tests/test_configuration_estimate.py
+++ b/tests/test_configuration_estimate.py
@@ -294,7 +294,14 @@ def test_rank_report_covers_every_pipeline_stage():
 # ---------------------------------------------------------------------------
 
 
-def test_step_stride_thins_the_sustained_rate():
+def test_step_stride_does_not_thin_the_sustained_rate():
+    """This test previously asserted the opposite, and was wrong.
+
+    It encoded the defect: the estimate divided by ``step_stride`` while no
+    adapter enforced the schedule, so it under-reported volume by exactly the
+    stride factor. See ``tests/test_estimate_runtime_fidelity.py`` for the
+    full reproduction suite and the reasoning.
+    """
     dense = estimate_config(
         _config(["resid_pre"], step_stride=1),
         _descriptor(),
@@ -307,7 +314,7 @@ def test_step_stride_thins_the_sustained_rate():
     )
 
     assert strided.sustained_bytes_per_second == pytest.approx(
-        dense.sustained_bytes_per_second / 4
+        dense.sustained_bytes_per_second
     )
 
 

--- a/tests/test_configuration_estimate.py
+++ b/tests/test_configuration_estimate.py
@@ -489,6 +489,23 @@ def test_unknown_dtype_is_rejected():
         )
 
 
+def test_decode_step_comes_from_the_same_rank_as_the_peak():
+    """One result must not describe two different ranks.
+
+    Taking a max over ranks for decode while choosing the reported rank by
+    peak lets the two disagree whenever the prefill-heaviest stage is not the
+    decode-heaviest one.
+    """
+    estimate = estimate_config(
+        _config(["resid_pre", "final_logits"]),
+        _descriptor(),
+        _workload(decode_tokens=32, pipeline_parallel_size=2),
+    )
+
+    worst = [r for r in estimate.ranks if r.label == estimate.peak_step_rank][0]
+    assert estimate.decode_step_bytes == worst.decode_step_bytes
+
+
 def test_payload_is_json_safe():
     import json
 

--- a/tests/test_configuration_estimate.py
+++ b/tests/test_configuration_estimate.py
@@ -511,3 +511,53 @@ def test_estimate_is_immutable():
     assert isinstance(estimate, Estimate)
     with pytest.raises(Exception):
         estimate.peak_step_bytes = 0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Per-request accounting
+# ---------------------------------------------------------------------------
+
+
+def test_per_request_bytes_are_per_sequence_in_the_packed_convention():
+    single = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(batch_size=1)
+    )
+    batch = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(batch_size=8)
+    )
+
+    assert batch.bytes_per_request == single.bytes_per_request
+
+
+def test_per_request_bytes_are_per_sequence_in_the_batched_convention():
+    """Batched shapes carry the leading batch dimension, so the whole-batch
+    step total divides by batch_size exactly like the packed convention --
+    8 identical sequences must not report 8x the cost of one."""
+    single = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(packed=False, batch_size=1),
+    )
+    batch = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(packed=False, batch_size=8),
+    )
+
+    assert batch.bytes_per_request == single.bytes_per_request
+
+
+def test_aggregate_peak_follows_the_enabled_phases():
+    """The aggregate sums each rank's peak step over whichever phases are
+    enabled; with prefill capture off it is a decode figure, and the field is
+    named for that."""
+    estimate = estimate_config(
+        _config(["resid_pre"], capture_prefill=False),
+        _descriptor(),
+        _workload(prompt_tokens=2048, decode_tokens=128),
+    )
+
+    assert estimate.aggregate_peak_step_bytes == estimate.decode_step_bytes
+    assert estimate_payload(estimate)["aggregate_peak_step_bytes"] == (
+        estimate.decode_step_bytes
+    )

--- a/tests/test_configuration_estimate.py
+++ b/tests/test_configuration_estimate.py
@@ -1,0 +1,513 @@
+"""Payload estimation.
+
+The estimator's whole value is that it agrees with what the runtime reserves,
+so most of these tests are hand-computed byte counts rather than golden
+values: ``elem_size * prod(compute_hook_shape(...))`` rounded up to
+``PAYLOAD_ALIGN``, summed over firing hooks.
+
+The rank tests matter as much as the totals. Aggregate bytes are roughly
+TP-invariant while per-rank pressure is not, and it is per-rank pressure that
+decides whether ``prepare_step`` falls off its fast path.
+"""
+from __future__ import annotations
+
+import pytest
+
+from dmi.configuration import (
+    DMIConfig,
+    LayerSelection,
+    ModelDescriptor,
+    ModelIdentity,
+    ModelTopology,
+    ObservationConfig,
+)
+from dmi.configuration.estimate import (
+    PAYLOAD_ALIGN,
+    Estimate,
+    Workload,
+    check_ring_fit,
+    estimate_config,
+    estimate_payload,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+NUM_LAYERS = 4
+HIDDEN = 512
+HEADS = 8
+HEAD_DIM = 64
+VOCAB = 32000
+INTERMEDIATE = 1376
+FP16 = 2
+INT64 = 8
+
+
+def _descriptor(**overrides) -> ModelDescriptor:
+    topology = dict(
+        num_layers=NUM_LAYERS,
+        hidden_size=HIDDEN,
+        num_attention_heads=HEADS,
+        num_kv_heads=HEADS,
+        head_dim=HEAD_DIM,
+        vocab_size=VOCAB,
+        intermediate_size=INTERMEDIATE,
+    )
+    topology.update(overrides)
+    return ModelDescriptor(
+        model=ModelIdentity(
+            id="test", name="Test", architecture="decoder_transformer"
+        ),
+        topology=ModelTopology(**topology),
+    )
+
+
+def _config(hooks, layers=None, **schedule_kwargs) -> DMIConfig:
+    from dmi.config import CaptureSchedule
+
+    return DMIConfig(
+        observations=ObservationConfig(hooks=list(hooks), layers=layers),
+        schedule=CaptureSchedule(**schedule_kwargs),
+    )
+
+
+def _workload(**overrides) -> Workload:
+    base = dict(batch_size=1, prompt_tokens=128, decode_tokens=0, packed=True)
+    base.update(overrides)
+    return Workload(**base)
+
+
+# ---------------------------------------------------------------------------
+# Byte totals against hand computation
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_state_hook_matches_hand_computed_bytes():
+    """resid_pre packs to [q_len, hidden] on every selected layer."""
+    estimate = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload()
+    )
+
+    assert estimate.peak_step_bytes == 128 * HIDDEN * FP16 * NUM_LAYERS
+
+
+def test_layer_range_scales_the_estimate_linearly():
+    full = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+    half = estimate_config(
+        _config(["resid_pre"], layers=LayerSelection(0, 1)),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert half.peak_step_bytes == full.peak_step_bytes // 2
+
+
+def test_global_hook_is_counted_once_not_per_layer():
+    estimate = estimate_config(
+        _config(["final_logits"]), _descriptor(), _workload()
+    )
+
+    # Packed: one logit row per request, so [num_reqs, vocab].
+    assert estimate.peak_step_bytes == 1 * VOCAB * FP16
+
+
+def test_token_ids_uses_int64_not_the_model_dtype():
+    """ring.py overrides token_ids' dtype from the framework's input_ids."""
+    estimate = estimate_config(
+        _config(["token_ids"]), _descriptor(), _workload()
+    )
+
+    assert estimate.peak_step_bytes == 128 * INT64
+
+
+def test_layer_range_does_not_reduce_a_global_hook():
+    wide = estimate_config(
+        _config(["final_logits"]), _descriptor(), _workload()
+    )
+    narrow = estimate_config(
+        _config(["final_logits"], layers=LayerSelection(0, 0)),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert narrow.peak_step_bytes == wide.peak_step_bytes
+
+
+def test_unavailable_hook_contributes_nothing():
+    """A dense model has no router; the hook cannot fire, so it costs 0."""
+    dense = estimate_config(
+        _config(["router_logits"]), _descriptor(num_experts=0), _workload()
+    )
+
+    assert dense.peak_step_bytes == 0
+
+
+def test_moe_hook_fires_when_the_topology_supports_it():
+    moe = estimate_config(
+        _config(["router_logits"]),
+        _descriptor(num_experts=8, top_k=2),
+        _workload(),
+    )
+
+    assert moe.peak_step_bytes == 128 * 8 * FP16 * NUM_LAYERS
+
+
+def test_every_total_is_payload_aligned():
+    """Reservations are rounded up to PAYLOAD_ALIGN; estimates must be too."""
+    estimate = estimate_config(
+        _config(["resid_pre", "q", "k", "v", "token_ids", "final_logits"]),
+        _descriptor(),
+        _workload(prompt_tokens=127),
+    )
+
+    assert estimate.peak_step_bytes % PAYLOAD_ALIGN == 0
+
+
+# ---------------------------------------------------------------------------
+# Prefill sets the peak
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_dominates_the_peak_step():
+    estimate = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(prompt_tokens=2048, decode_tokens=128),
+    )
+
+    assert estimate.peak_step_bytes > estimate.decode_step_bytes
+
+
+def test_disabling_prefill_drops_the_peak_to_decode():
+    estimate = estimate_config(
+        _config(["resid_pre"], capture_prefill=False),
+        _descriptor(),
+        _workload(prompt_tokens=2048, decode_tokens=128),
+    )
+
+    assert estimate.peak_step_bytes == estimate.decode_step_bytes
+
+
+def test_capturing_nothing_is_reported_as_a_warning():
+    estimate = estimate_config(
+        _config(["resid_pre"], capture_prefill=False, capture_decode=False),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert estimate.peak_step_bytes == 0
+    assert any("captures nothing" in w for w in estimate.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Rank awareness
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_parallel_rank_zero_is_the_busiest():
+    """Rank 0 carries every unsharded hook plus its own shard."""
+    estimate = estimate_config(
+        _config(["resid_pre", "q"]),
+        _descriptor(),
+        _workload(tensor_parallel_size=2),
+    )
+
+    by_rank = {load.label: load for load in estimate.ranks}
+    assert by_rank["pp0/tp0"].prefill_step_bytes > (
+        by_rank["pp0/tp1"].prefill_step_bytes
+    )
+    assert estimate.peak_step_rank == "pp0/tp0"
+
+
+def test_sharded_hook_is_divided_across_tensor_parallel_ranks():
+    single = estimate_config(
+        _config(["q"]), _descriptor(), _workload(tensor_parallel_size=1)
+    )
+    sharded = estimate_config(
+        _config(["q"]), _descriptor(), _workload(tensor_parallel_size=2)
+    )
+
+    assert sharded.peak_step_bytes == single.peak_step_bytes // 2
+
+
+def test_unsharded_hook_is_not_divided_and_stays_on_rank_zero():
+    single = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(tensor_parallel_size=1)
+    )
+    sharded = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(tensor_parallel_size=2)
+    )
+
+    assert sharded.peak_step_bytes == single.peak_step_bytes
+    by_rank = {load.label: load for load in sharded.ranks}
+    assert by_rank["pp0/tp1"].prefill_step_bytes == 0
+
+
+def test_pp_last_hook_lands_on_the_final_stage():
+    estimate = estimate_config(
+        _config(["resid_pre", "final_logits"]),
+        _descriptor(),
+        _workload(pipeline_parallel_size=2),
+    )
+
+    by_stage = {load.pp_stage: load for load in estimate.ranks}
+    # Both stages carry two layers of resid_pre; only the last adds logits.
+    assert by_stage[1].prefill_step_bytes > by_stage[0].prefill_step_bytes
+    assert estimate.peak_step_rank == "pp1/tp0"
+
+
+def test_pp_first_hook_lands_on_the_first_stage():
+    estimate = estimate_config(
+        _config(["token_ids"]), _descriptor(), _workload(pipeline_parallel_size=2)
+    )
+
+    by_stage = {load.pp_stage: load for load in estimate.ranks}
+    assert by_stage[0].prefill_step_bytes == 128 * INT64
+    assert by_stage[1].prefill_step_bytes == 0
+
+
+def test_pipeline_stages_split_layers_between_them():
+    single = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload()
+    )
+    staged = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(pipeline_parallel_size=2)
+    )
+
+    assert staged.peak_step_bytes == single.peak_step_bytes // 2
+
+
+def test_rank_report_covers_every_pipeline_stage():
+    estimate = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(pipeline_parallel_size=4, tensor_parallel_size=2),
+    )
+
+    assert {load.pp_stage for load in estimate.ranks} == {0, 1, 2, 3}
+    # Rank 0 and one representative non-zero rank per stage.
+    assert {load.tp_rank for load in estimate.ranks} == {0, 1}
+
+
+# ---------------------------------------------------------------------------
+# Schedule and rate
+# ---------------------------------------------------------------------------
+
+
+def test_step_stride_thins_the_sustained_rate():
+    dense = estimate_config(
+        _config(["resid_pre"], step_stride=1),
+        _descriptor(),
+        _workload(decode_tokens=64, decode_steps_per_second=20.0),
+    )
+    strided = estimate_config(
+        _config(["resid_pre"], step_stride=4),
+        _descriptor(),
+        _workload(decode_tokens=64, decode_steps_per_second=20.0),
+    )
+
+    assert strided.sustained_bytes_per_second == pytest.approx(
+        dense.sustained_bytes_per_second / 4
+    )
+
+
+def test_step_stride_does_not_change_the_peak_step():
+    """Sampling fewer steps does not make any single step smaller."""
+    dense = estimate_config(
+        _config(["resid_pre"], step_stride=1), _descriptor(), _workload()
+    )
+    strided = estimate_config(
+        _config(["resid_pre"], step_stride=8), _descriptor(), _workload()
+    )
+
+    assert strided.peak_step_bytes == dense.peak_step_bytes
+
+
+def test_per_day_volume_follows_the_sustained_rate():
+    estimate = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(decode_tokens=64, decode_steps_per_second=10.0),
+    )
+
+    assert estimate.bytes_per_day == pytest.approx(
+        estimate.sustained_bytes_per_second * 86_400
+    )
+
+
+def test_missing_rate_is_reported_rather_than_guessed():
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    assert estimate.sustained_bytes_per_second is None
+    assert estimate.bytes_per_day is None
+    assert any("decode_steps_per_second" in w for w in estimate.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Convention handling
+# ---------------------------------------------------------------------------
+
+
+def test_attention_weights_are_refused_in_the_packed_convention():
+    estimate = estimate_config(
+        _config(["pattern"]), _descriptor(), _workload(packed=True)
+    )
+
+    assert estimate.peak_step_bytes == 0
+    assert any("packed convention" in w for w in estimate.warnings)
+
+
+def test_attention_weights_are_counted_in_the_batched_convention():
+    estimate = estimate_config(
+        _config(["pattern"]), _descriptor(), _workload(packed=False)
+    )
+
+    # [batch, heads, q_len, kv_dim] per layer.
+    expected = 1 * HEADS * 128 * 128 * FP16 * NUM_LAYERS
+    assert estimate.peak_step_bytes == expected
+
+
+def test_convention_is_recorded_as_an_assumption():
+    packed = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(packed=True)
+    )
+    batched = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(packed=False)
+    )
+
+    assert any("packed" in a for a in packed.assumptions)
+    assert any("batched" in a for a in batched.assumptions)
+
+
+# ---------------------------------------------------------------------------
+# Ring fit
+# ---------------------------------------------------------------------------
+
+
+def test_a_step_within_capacity_fits():
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    fit = check_ring_fit(estimate, payload_bytes=64 * 1024 * 1024)
+
+    assert fit.fits is True
+    assert fit.occupancy_percent < 100
+
+
+def test_an_oversized_step_explains_the_eager_fallback():
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    fit = check_ring_fit(estimate, payload_bytes=1024)
+
+    assert fit.fits is False
+    assert "STEP_OVERSIZED" in fit.detail
+
+
+def test_the_smaller_ring_is_the_binding_limit():
+    """prepare_step compares against min(payload_cap, staging_cap)."""
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    fit = check_ring_fit(
+        estimate, payload_bytes=64 * 1024 * 1024, pinned_bytes=1 * 1024 * 1024
+    )
+
+    assert fit.effective_bytes == 1 * 1024 * 1024
+    assert "Pinned staging" in fit.detail
+
+
+def test_zero_payload_capacity_is_rejected():
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    with pytest.raises(ValueError, match="payload_bytes must be >= 1"):
+        check_ring_fit(estimate, payload_bytes=0)
+
+
+# ---------------------------------------------------------------------------
+# Monotonicity
+# ---------------------------------------------------------------------------
+
+
+def test_adding_an_observation_never_lowers_the_estimate():
+    fewer = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+    more = estimate_config(
+        _config(["resid_pre", "q", "k", "v"]), _descriptor(), _workload()
+    )
+
+    assert more.peak_step_bytes >= fewer.peak_step_bytes
+
+
+def test_widening_a_layer_range_never_lowers_the_estimate():
+    narrow = estimate_config(
+        _config(["resid_pre"], layers=LayerSelection(0, 0)),
+        _descriptor(),
+        _workload(),
+    )
+    wide = estimate_config(
+        _config(["resid_pre"], layers=LayerSelection(0, 3)),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert wide.peak_step_bytes >= narrow.peak_step_bytes
+
+
+def test_longer_prompts_never_lower_the_estimate():
+    short = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(prompt_tokens=128)
+    )
+    long = estimate_config(
+        _config(["resid_pre"]), _descriptor(), _workload(prompt_tokens=4096)
+    )
+
+    assert long.peak_step_bytes > short.peak_step_bytes
+
+
+# ---------------------------------------------------------------------------
+# Workload validation and serialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"batch_size": 0}, "batch_size must be >= 1"),
+        ({"prompt_tokens": 0}, "prompt_tokens must be >= 1"),
+        ({"decode_tokens": -1}, "decode_tokens must be >= 0"),
+        ({"tensor_parallel_size": 0}, "tensor_parallel_size must be >= 1"),
+        ({"pipeline_parallel_size": 0}, "pipeline_parallel_size must be >= 1"),
+        ({"decode_steps_per_second": -1.0}, "decode_steps_per_second must be >= 0"),
+    ],
+)
+def test_invalid_workload_is_rejected_at_construction(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        Workload(**kwargs)
+
+
+def test_unknown_dtype_is_rejected():
+    with pytest.raises(ValueError, match="Unknown dtype"):
+        estimate_config(
+            _config(["resid_pre"]), _descriptor(), _workload(dtype="float13")
+        )
+
+
+def test_payload_is_json_safe():
+    import json
+
+    estimate = estimate_config(
+        _config(["resid_pre"]),
+        _descriptor(),
+        _workload(tensor_parallel_size=2, decode_steps_per_second=10.0),
+    )
+
+    payload = estimate_payload(estimate)
+
+    json.dumps(payload)  # must not raise
+    assert payload["peak_step_rank"] == "pp0/tp0"
+    assert len(payload["ranks"]) == len(estimate.ranks)
+
+
+def test_estimate_is_immutable():
+    estimate = estimate_config(_config(["resid_pre"]), _descriptor(), _workload())
+
+    assert isinstance(estimate, Estimate)
+    with pytest.raises(Exception):
+        estimate.peak_step_bytes = 0  # type: ignore[misc]

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -10,6 +10,7 @@ from dmi.configuration import (
     CONFIG_VERSION,
     DMIConfig,
     LayerSelection,
+    ModelIdentity,
     ModelTopology,
     ObservationConfig,
     RuntimePolicy,
@@ -116,3 +117,33 @@ class TestDMIConfig:
         )
         assert isinstance(config.observations.layers, LayerSelection)
         assert config.observations.layers.start == 8
+
+
+class TestModelIdentity:
+    """``id`` becomes a filename, so it must stay a single path segment.
+
+    ``dmi.ui.app`` promises the browser cannot cause a write outside the
+    location named on the command line. Descriptors derived from a framework
+    config are already safe (``_slug`` reduces ``Qwen/Qwen3-8B`` to
+    ``qwen3-8b``), but a hand-written descriptor YAML reaches the same code
+    unchecked.
+    """
+
+    def test_a_plain_slug_is_accepted(self):
+        assert ModelIdentity("qwen3-8b", "Qwen3 8B", "decoder_transformer").id == "qwen3-8b"
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "meta-llama/Llama-3-8B",  # the natural thing to hand-type
+            "../../etc/pwned",  # escapes the directory the user named
+            "a/b",
+            "..",
+            ".",
+            "",
+            "   ",
+        ],
+    )
+    def test_an_id_that_is_not_one_path_segment_is_rejected(self, bad_id):
+        with pytest.raises(ValueError):
+            ModelIdentity(bad_id, "M", "decoder_transformer")

--- a/tests/test_configuration_validation.py
+++ b/tests/test_configuration_validation.py
@@ -23,6 +23,9 @@ from dmi.configuration import (
     per_layer_hook_ids,
     validate_config,
 )
+from dmi.configuration import catalog_adapter
+from dmi.configuration.architecture import architecture_payload
+from dmi.hooks.catalog import GROUP_OTHER, HOOK_DEFS, PP_ANY, SHAPE_HIDDEN
 
 pytestmark = pytest.mark.cpu
 
@@ -292,3 +295,46 @@ class TestCatalogAdapter:
                     "available",
                     "reason",
                 }
+
+
+class TestArchitectureLayout:
+    """The diagram must stay reachable from the catalog.
+
+    ``architecture.py`` promises that "extending ``HOOK_DEFS`` can never make
+    an observation unreachable from the UI". That promise rests entirely on the
+    trailing "Other observations" node, which no fixture exercises: today every
+    catalog hook is assigned to a real block, so the fallback branch never runs
+    and could rot unnoticed until the day someone adds a hook.
+    """
+
+    def test_every_catalog_hook_is_reachable_from_some_node(self):
+        nodes = architecture_payload(DENSE)["nodes"]
+        placed = {hook["id"] for node in nodes for hook in node["hooks"]}
+        assert placed == set(hook_ids())
+
+    def test_a_hook_with_no_assigned_block_lands_in_other_observations(
+        self, monkeypatch
+    ):
+        # A hook the node list has never heard of -- exactly what adding an
+        # entry to HOOK_DEFS without touching architecture.py produces.
+        newcomer = (
+            99,
+            "hook_brand_new",
+            "brand_new",
+            True,
+            GROUP_OTHER,
+            False,
+            SHAPE_HIDDEN,
+            PP_ANY,
+        )
+        monkeypatch.setattr(
+            catalog_adapter, "HOOK_DEFS", HOOK_DEFS + (newcomer,)
+        )
+
+        nodes = architecture_payload(DENSE)["nodes"]
+        other = [node for node in nodes if node["id"] == "other"]
+        assert other, "an unassigned hook must not disappear from the diagram"
+        assert [hook["id"] for hook in other[0]["hooks"]] == ["brand_new"]
+        # and it is still reachable overall, which is the actual guarantee
+        placed = {hook["id"] for node in nodes for hook in node["hooks"]}
+        assert "brand_new" in placed

--- a/tests/test_configurator_api.py
+++ b/tests/test_configurator_api.py
@@ -254,3 +254,137 @@ class TestServerState:
         state = build_state(DENSE, tmp_path / "not-created-yet.yaml")
         assert state.initial_config is None
         assert state.save_path == tmp_path / "not-created-yet.yaml"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/estimate
+# ---------------------------------------------------------------------------
+
+
+def _estimate(client, config=None, **body):
+    request = {"config": config or VALID_CONFIG}
+    request.update(body)
+    return client.post("/api/estimate", json=request)
+
+
+def test_estimate_returns_a_peak_step_and_the_rank_that_carries_it():
+    with TestClient(create_app(DENSE)) as client:
+        response = _estimate(client)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["peak_step_bytes"] > 0
+    assert body["peak_step_rank"] == "pp0/tp0"
+    assert body["assumptions"]
+
+
+def test_estimate_defaults_the_workload_when_none_is_given():
+    with TestClient(create_app(DENSE)) as client:
+        response = _estimate(client)
+
+    assert response.status_code == 200
+    assert response.json()["peak_step_bytes"] > 0
+
+
+def test_estimate_honours_a_supplied_workload():
+    with TestClient(create_app(DENSE)) as client:
+        short = _estimate(client, workload={"prompt_tokens": 128}).json()
+        long = _estimate(client, workload={"prompt_tokens": 4096}).json()
+
+    assert long["peak_step_bytes"] > short["peak_step_bytes"]
+
+
+def test_estimate_reports_every_rank_under_tensor_parallelism():
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(client, workload={"tensor_parallel_size": 4}).json()
+
+    labels = {rank["label"] for rank in body["ranks"]}
+    assert labels == {"pp0/tp0", "pp0/tp1"}
+    by_label = {rank["label"]: rank for rank in body["ranks"]}
+    assert (
+        by_label["pp0/tp0"]["prefill_step_bytes"]
+        >= by_label["pp0/tp1"]["prefill_step_bytes"]
+    )
+
+
+def test_estimate_rejects_an_invalid_workload():
+    with TestClient(create_app(DENSE)) as client:
+        response = _estimate(client, workload={"batch_size": 0})
+
+    assert response.status_code == 400
+    assert "Invalid workload" in response.json()["detail"]
+
+
+def test_estimate_rejects_an_unknown_dtype():
+    with TestClient(create_app(DENSE)) as client:
+        response = _estimate(client, workload={"dtype": "float13"})
+
+    assert response.status_code == 400
+    assert "Unknown dtype" in response.json()["detail"]
+
+
+def test_estimate_rejects_a_malformed_body():
+    with TestClient(create_app(DENSE)) as client:
+        response = client.post("/api/estimate", json={"nope": 1})
+
+    assert response.status_code == 400
+
+
+def test_estimate_omits_ring_fit_when_no_ring_size_is_given():
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(client).json()
+
+    assert "ring_fit" not in body
+
+
+def test_estimate_includes_ring_fit_when_a_ring_size_is_given():
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(
+            client, ring={"payload_bytes": 4096 * 1024 * 1024}
+        ).json()
+
+    assert body["ring_fit"]["fits"] is True
+    assert body["ring_fit"]["occupancy_percent"] >= 0
+
+
+def test_estimate_flags_a_step_that_will_not_fit_the_ring():
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(client, ring={"payload_bytes": 1024}).json()
+
+    assert body["ring_fit"]["fits"] is False
+    assert "STEP_OVERSIZED" in body["ring_fit"]["detail"]
+
+
+def test_estimate_uses_the_smaller_of_payload_and_pinned():
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(
+            client,
+            ring={
+                "payload_bytes": 4096 * 1024 * 1024,
+                "pinned_bytes": 64 * 1024 * 1024,
+            },
+        ).json()
+
+    assert body["ring_fit"]["effective_bytes"] == 64 * 1024 * 1024
+
+
+def test_estimate_rejects_a_zero_ring_size():
+    with TestClient(create_app(DENSE)) as client:
+        response = _estimate(client, ring={"payload_bytes": -5})
+
+    assert response.status_code == 400
+
+
+def test_estimate_matches_the_library_for_the_same_inputs():
+    """The UI must not be able to disagree with the Python API."""
+    from dmi.configuration import Workload, estimate_config, load_descriptor
+
+    descriptor = load_descriptor(DENSE)
+    config = parse_config(VALID_CONFIG)
+    direct = estimate_config(config, descriptor, Workload(prompt_tokens=512))
+
+    with TestClient(create_app(DENSE)) as client:
+        body = _estimate(client, workload={"prompt_tokens": 512}).json()
+
+    assert body["peak_step_bytes"] == direct.peak_step_bytes
+    assert body["decode_step_bytes"] == direct.decode_step_bytes

--- a/tests/test_configurator_api.py
+++ b/tests/test_configurator_api.py
@@ -369,10 +369,28 @@ def test_estimate_uses_the_smaller_of_payload_and_pinned():
 
 
 def test_estimate_rejects_a_zero_ring_size():
+    """0 must be rejected, not silently treated as "no ring given"."""
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
+        response = _estimate(client, ring={"payload_bytes": 0})
+
+    assert response.status_code == 400
+
+
+def test_estimate_rejects_a_negative_ring_size():
     with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client, ring={"payload_bytes": -5})
 
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize("bad", [[], [4096], "4096", 4096])
+def test_estimate_rejects_a_ring_that_is_not_a_mapping(bad):
+    """A malformed body is a 400, not an AttributeError behind a 500."""
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
+        response = _estimate(client, ring=bad)
+
+    assert response.status_code == 400
+    assert "must be a mapping" in response.json()["detail"]
 
 
 def test_estimate_matches_the_library_for_the_same_inputs():

--- a/tests/test_configurator_api.py
+++ b/tests/test_configurator_api.py
@@ -45,12 +45,12 @@ VALID_CONFIG = {
 
 @pytest.fixture
 def client():
-    return TestClient(create_app(DENSE))
+    return TestClient(create_app(DENSE), base_url="http://127.0.0.1")
 
 
 @pytest.fixture
 def moe_client():
-    return TestClient(create_app(MOE))
+    return TestClient(create_app(MOE), base_url="http://127.0.0.1")
 
 
 class TestStaticSurface:
@@ -209,13 +209,13 @@ class TestConfigLoadAndSave:
             (REPO / "tests" / "golden" / "qwen3-attention.yaml").read_text(),
             encoding="utf-8",
         )
-        client = TestClient(create_app(DENSE, target))
+        client = TestClient(create_app(DENSE, target), base_url="http://127.0.0.1")
         payload = client.get("/api/config").json()
         assert payload["config"]["observations"]["layers"] == {"start": 8, "end": 15}
 
     def test_save_writes_to_the_server_side_path(self, tmp_path):
         target = tmp_path / "out.dmi.yaml"
-        client = TestClient(create_app(DENSE, target))
+        client = TestClient(create_app(DENSE, target), base_url="http://127.0.0.1")
         response = client.post("/api/config/save", json={"config": VALID_CONFIG})
         assert response.status_code == 200
         assert response.json()["path"] == str(target)
@@ -226,7 +226,7 @@ class TestConfigLoadAndSave:
         # The browser gets no filesystem access; a path in the body is ignored.
         target = tmp_path / "allowed.yaml"
         attacker = tmp_path / "elsewhere.yaml"
-        client = TestClient(create_app(DENSE, target))
+        client = TestClient(create_app(DENSE, target), base_url="http://127.0.0.1")
         client.post(
             "/api/config/save",
             json={"config": VALID_CONFIG, "path": str(attacker)},
@@ -236,7 +236,7 @@ class TestConfigLoadAndSave:
 
     def test_saved_file_reloads_through_open(self, tmp_path):
         target = tmp_path / "cycle.dmi.yaml"
-        client = TestClient(create_app(DENSE, target))
+        client = TestClient(create_app(DENSE, target), base_url="http://127.0.0.1")
         client.post("/api/config/save", json={"config": VALID_CONFIG})
         reopened = client.post(
             "/api/config/parse", json={"yaml": target.read_text()}
@@ -268,7 +268,7 @@ def _estimate(client, config=None, **body):
 
 
 def test_estimate_returns_a_peak_step_and_the_rank_that_carries_it():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client)
 
     assert response.status_code == 200
@@ -279,7 +279,7 @@ def test_estimate_returns_a_peak_step_and_the_rank_that_carries_it():
 
 
 def test_estimate_defaults_the_workload_when_none_is_given():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client)
 
     assert response.status_code == 200
@@ -287,7 +287,7 @@ def test_estimate_defaults_the_workload_when_none_is_given():
 
 
 def test_estimate_honours_a_supplied_workload():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         short = _estimate(client, workload={"prompt_tokens": 128}).json()
         long = _estimate(client, workload={"prompt_tokens": 4096}).json()
 
@@ -295,7 +295,7 @@ def test_estimate_honours_a_supplied_workload():
 
 
 def test_estimate_reports_every_rank_under_tensor_parallelism():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(client, workload={"tensor_parallel_size": 4}).json()
 
     labels = {rank["label"] for rank in body["ranks"]}
@@ -308,7 +308,7 @@ def test_estimate_reports_every_rank_under_tensor_parallelism():
 
 
 def test_estimate_rejects_an_invalid_workload():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client, workload={"batch_size": 0})
 
     assert response.status_code == 400
@@ -316,7 +316,7 @@ def test_estimate_rejects_an_invalid_workload():
 
 
 def test_estimate_rejects_an_unknown_dtype():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client, workload={"dtype": "float13"})
 
     assert response.status_code == 400
@@ -324,21 +324,21 @@ def test_estimate_rejects_an_unknown_dtype():
 
 
 def test_estimate_rejects_a_malformed_body():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = client.post("/api/estimate", json={"nope": 1})
 
     assert response.status_code == 400
 
 
 def test_estimate_omits_ring_fit_when_no_ring_size_is_given():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(client).json()
 
     assert "ring_fit" not in body
 
 
 def test_estimate_includes_ring_fit_when_a_ring_size_is_given():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(
             client, ring={"payload_bytes": 4096 * 1024 * 1024}
         ).json()
@@ -348,7 +348,7 @@ def test_estimate_includes_ring_fit_when_a_ring_size_is_given():
 
 
 def test_estimate_flags_a_step_that_will_not_fit_the_ring():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(client, ring={"payload_bytes": 1024}).json()
 
     assert body["ring_fit"]["fits"] is False
@@ -356,7 +356,7 @@ def test_estimate_flags_a_step_that_will_not_fit_the_ring():
 
 
 def test_estimate_uses_the_smaller_of_payload_and_pinned():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(
             client,
             ring={
@@ -369,7 +369,7 @@ def test_estimate_uses_the_smaller_of_payload_and_pinned():
 
 
 def test_estimate_rejects_a_zero_ring_size():
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         response = _estimate(client, ring={"payload_bytes": -5})
 
     assert response.status_code == 400
@@ -383,8 +383,71 @@ def test_estimate_matches_the_library_for_the_same_inputs():
     config = parse_config(VALID_CONFIG)
     direct = estimate_config(config, descriptor, Workload(prompt_tokens=512))
 
-    with TestClient(create_app(DENSE)) as client:
+    with TestClient(create_app(DENSE), base_url="http://127.0.0.1") as client:
         body = _estimate(client, workload={"prompt_tokens": 512}).json()
 
     assert body["peak_step_bytes"] == direct.peak_step_bytes
     assert body["decode_step_bytes"] == direct.decode_step_bytes
+
+
+class TestHostValidation:
+    """DNS-rebinding guard: a loopback server answers loopback names only."""
+
+    def test_loopback_hosts_are_served(self, client):
+        assert client.get("/api/model").status_code == 200
+
+    def test_localhost_is_served(self):
+        client = TestClient(create_app(DENSE), base_url="http://localhost")
+        assert client.get("/api/model").status_code == 200
+
+    def test_a_rebound_hostname_is_rejected(self):
+        client = TestClient(
+            create_app(DENSE), base_url="http://rebound.attacker.example"
+        )
+        response = client.get("/api/model")
+        assert response.status_code == 400
+
+    def test_a_rebound_hostname_cannot_save(self, tmp_path):
+        target = tmp_path / "victim.dmi.yaml"
+        client = TestClient(
+            create_app(DENSE, target),
+            base_url="http://rebound.attacker.example",
+        )
+        response = client.post(
+            "/api/config/save", json={"config": VALID_CONFIG}
+        )
+        assert response.status_code == 400
+        assert not target.exists()
+
+    def test_a_non_loopback_bind_serves_any_host(self):
+        # Serving the network is an explicit choice; the valid names cannot
+        # be enumerated, so the Host filter only guards loopback binds.
+        client = TestClient(
+            create_app(DENSE, bind_host="0.0.0.0"),
+            base_url="http://some.internal.name",
+        )
+        assert client.get("/api/model").status_code == 200
+
+
+class TestRelaunch:
+    def test_relaunch_without_config_reloads_the_saved_file(self, tmp_path):
+        """A second `dmi ui MODEL` must reopen what the first session saved,
+        not a blank default that Save would clobber it with."""
+        import shutil
+
+        descriptor = tmp_path / "llama3-8b.yaml"
+        shutil.copyfile(DENSE, descriptor)
+
+        first = TestClient(create_app(descriptor), base_url="http://127.0.0.1")
+        saved_to = Path(
+            first.post(
+                "/api/config/save", json={"config": VALID_CONFIG}
+            ).json()["path"]
+        )
+        assert saved_to.parent == tmp_path
+
+        state = build_state(descriptor)
+        assert state.initial_config is not None
+        assert state.initial_config == normalize_config(
+            parse_config(VALID_CONFIG)
+        )

--- a/tests/test_estimate_runtime_fidelity.py
+++ b/tests/test_estimate_runtime_fidelity.py
@@ -1,0 +1,219 @@
+"""The estimate must describe what the runtime will actually do.
+
+Reproduction suite for two ways the payload estimate could mislead:
+
+**An unenforced schedule.** ``CaptureSchedule`` is authored by the
+configurator and serialized into the YAML, but no shipped adapter applies it:
+``should_capture_step`` / ``should_capture_request`` have no callers outside
+``dmi.config`` itself, and nothing in ``dmi.adapters`` reads
+``CompiledDMIConfig.schedule``. An estimate that divided its figures by
+``step_stride`` would therefore promise a reduction the capture never
+delivers, and someone sizing storage from it would under-provision by exactly
+that factor. Silence is worse than a wrong number here: the stride control
+looks like it works.
+
+**A layer range that selects nothing.** A range outside the model's layers
+resolves to an empty set, and the estimate for per-layer hooks collapses to
+zero bytes. Zero reads as "this is free" rather than "this selects nothing",
+so the panel has to say which it means.
+
+These are small tests: pure arithmetic over a synthesized descriptor, no I/O.
+"""
+from __future__ import annotations
+
+import pytest
+
+from dmi.config import CaptureSchedule
+from dmi.configuration import (
+    DMIConfig,
+    LayerSelection,
+    ModelDescriptor,
+    ModelIdentity,
+    ModelTopology,
+    ObservationConfig,
+)
+from dmi.configuration.estimate import Workload, estimate_config
+
+pytestmark = pytest.mark.cpu
+
+NUM_LAYERS = 8
+
+
+def _descriptor(num_layers: int = NUM_LAYERS) -> ModelDescriptor:
+    return ModelDescriptor(
+        model=ModelIdentity(
+            id="fidelity-test", name="Fidelity Test", architecture="decoder_transformer"
+        ),
+        topology=ModelTopology(
+            num_layers=num_layers,
+            hidden_size=512,
+            num_attention_heads=8,
+            num_kv_heads=8,
+            head_dim=64,
+            intermediate_size=1376,
+            vocab_size=32000,
+        ),
+    )
+
+
+def _workload(**overrides) -> Workload:
+    base = dict(
+        batch_size=1,
+        prompt_tokens=128,
+        decode_tokens=64,
+        decode_steps_per_second=10.0,
+        packed=True,
+    )
+    base.update(overrides)
+    return Workload(**base)
+
+
+def _config(hooks=("resid_pre",), layers=None, **schedule) -> DMIConfig:
+    return DMIConfig(
+        observations=ObservationConfig(hooks=list(hooks), layers=layers),
+        schedule=CaptureSchedule(**schedule),
+    )
+
+
+def _notes(estimate) -> str:
+    return " ".join(estimate.warnings + estimate.assumptions).lower()
+
+
+# ---------------------------------------------------------------------------
+# An unenforced schedule must not shrink the estimate
+# ---------------------------------------------------------------------------
+
+
+def test_step_stride_does_not_shrink_the_sustained_rate():
+    """No adapter enforces the stride, so the bytes still arrive."""
+    dense = estimate_config(_config(step_stride=1), _descriptor(), _workload())
+    strided = estimate_config(_config(step_stride=4), _descriptor(), _workload())
+
+    assert strided.sustained_bytes_per_second == dense.sustained_bytes_per_second
+
+
+def test_step_stride_does_not_shrink_the_daily_volume():
+    dense = estimate_config(_config(step_stride=1), _descriptor(), _workload())
+    strided = estimate_config(_config(step_stride=8), _descriptor(), _workload())
+
+    assert strided.bytes_per_day == dense.bytes_per_day
+
+
+def test_step_stride_does_not_shrink_the_per_request_total():
+    dense = estimate_config(_config(step_stride=1), _descriptor(), _workload())
+    strided = estimate_config(_config(step_stride=4), _descriptor(), _workload())
+
+    assert strided.bytes_per_request == dense.bytes_per_request
+
+
+def test_a_large_stride_still_reports_the_full_volume():
+    """The pathological case: stride 1000 previously reported ~0.1% of reality."""
+    dense = estimate_config(_config(step_stride=1), _descriptor(), _workload())
+    strided = estimate_config(_config(step_stride=1000), _descriptor(), _workload())
+
+    assert strided.sustained_bytes_per_second == dense.sustained_bytes_per_second
+
+
+def test_a_set_step_stride_says_it_is_not_enforced():
+    """The control looks functional; the estimate has to say it is not."""
+    estimate = estimate_config(_config(step_stride=4), _descriptor(), _workload())
+
+    assert "not enforced" in _notes(estimate)
+
+
+def test_a_set_request_stride_says_it_is_not_enforced():
+    estimate = estimate_config(_config(request_stride=4), _descriptor(), _workload())
+
+    assert "not enforced" in _notes(estimate)
+
+
+def test_a_default_schedule_is_not_warned_about():
+    """Nothing was asked for, so there is nothing to disclaim."""
+    estimate = estimate_config(_config(), _descriptor(), _workload())
+
+    assert "not enforced" not in _notes(estimate)
+
+
+def test_prefill_and_decode_toggles_keep_working():
+    """Only the sampling knobs are unenforced; the phase toggles gate shapes."""
+    both = estimate_config(_config(), _descriptor(), _workload())
+    decode_only = estimate_config(
+        _config(capture_prefill=False), _descriptor(), _workload()
+    )
+
+    assert decode_only.peak_step_bytes < both.peak_step_bytes
+
+
+# ---------------------------------------------------------------------------
+# A layer range that selects nothing must say so
+# ---------------------------------------------------------------------------
+
+
+def test_a_layer_range_beyond_the_model_reports_zero_with_a_reason():
+    estimate = estimate_config(
+        _config(layers=LayerSelection(40, 50)), _descriptor(), _workload()
+    )
+
+    assert estimate.peak_step_bytes == 0
+    assert "selects no layer" in _notes(estimate)
+
+
+def test_a_layer_range_clipped_by_the_model_says_what_survived():
+    """Layers 6-50 on an 8-layer model is 2 layers, not 45."""
+    estimate = estimate_config(
+        _config(layers=LayerSelection(6, 50)), _descriptor(), _workload()
+    )
+
+    notes = _notes(estimate)
+    assert "clipped" in notes
+    assert "2 of" in notes
+
+
+def test_a_layer_range_inside_the_model_is_not_warned_about():
+    estimate = estimate_config(
+        _config(layers=LayerSelection(2, 4)), _descriptor(), _workload()
+    )
+
+    notes = _notes(estimate)
+    assert "selects no layer" not in notes
+    assert "clipped" not in notes
+
+
+def test_selecting_every_layer_is_not_reported_as_clipped():
+    estimate = estimate_config(
+        _config(layers=LayerSelection(0, NUM_LAYERS - 1)),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert "clipped" not in _notes(estimate)
+
+
+def test_an_empty_layer_range_does_not_suppress_global_hooks():
+    """A global hook ignores the layer range, so it must still be counted."""
+    estimate = estimate_config(
+        _config(hooks=("resid_pre", "final_logits"), layers=LayerSelection(40, 50)),
+        _descriptor(),
+        _workload(),
+    )
+
+    assert estimate.peak_step_bytes > 0
+
+
+# ---------------------------------------------------------------------------
+# The UI must carry the same disclaimer the policy control carries
+# ---------------------------------------------------------------------------
+
+
+def test_the_capture_panel_discloses_that_sampling_is_not_enforced():
+    """Guard against the notice silently disappearing from the markup."""
+    from pathlib import Path
+
+    from dmi.ui.app import STATIC_DIR
+
+    markup = (Path(STATIC_DIR) / "index.html").read_text(encoding="utf-8")
+    capture_panel = markup.split('aria-label="Capture schedule"', 1)[-1].split(
+        "</section>", 1
+    )[0]
+
+    assert "not enforced" in capture_panel.lower()

--- a/tests/test_ui_client_invariants.py
+++ b/tests/test_ui_client_invariants.py
@@ -1,0 +1,128 @@
+"""Structural guards on the configurator's no-build-step frontend.
+
+These are deliberately weaker than unit tests, and the reason is a design
+constraint rather than an oversight: ``docs/dmi-configurator-plan.md`` gates
+the static UI on "no build process" and rules out a Node toolchain, so the
+repository has no JavaScript test runner to execute ``app.js`` against.
+
+What that leaves is a choice between no CI coverage at all and asserting on
+the source text. These tests take the second option for invariants where a
+silent regression would be expensive and invisible -- a dropped async guard
+reintroduces a race that only shows up under load, and nothing else in CI
+would notice.
+
+They assert a mechanism is *present*, not that it *works*. The behaviour is
+verified against a real browser during development; see the commit that
+introduced each guard. If a JS runner is ever added, replace these with real
+tests of the behaviour.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from dmi.ui.app import STATIC_DIR
+
+pytestmark = pytest.mark.cpu
+
+
+def _app_js() -> str:
+    return (Path(STATIC_DIR) / "app.js").read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the text of one top-level ``async function`` in app.js.
+
+    Brace-matched rather than regex-terminated, so a nested block inside the
+    function cannot truncate the body and hide a missing guard.
+    """
+    start = source.index(f"async function {name}(")
+    open_brace = source.index("{", start)
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace : index + 1]
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+# ---------------------------------------------------------------------------
+# Stale-response guards on the two async render paths
+# ---------------------------------------------------------------------------
+
+RENDER_PATHS = ("refreshOutput", "refreshEstimate")
+
+
+@pytest.mark.parametrize("function_name", RENDER_PATHS)
+def test_the_render_path_stamps_its_requests(function_name):
+    """Without a request id there is nothing to compare a late reply against."""
+    body = _function_body(_app_js(), function_name)
+
+    assert re.search(r"\bvar\s+requestId\s*=", body), (
+        f"{function_name} does not capture a request id, so it cannot tell a "
+        "stale response from the current one"
+    )
+
+
+@pytest.mark.parametrize("function_name", RENDER_PATHS)
+def test_the_render_path_drops_a_superseded_response(function_name):
+    """A later request must win; an earlier reply that lands after it is dead."""
+    body = _function_body(_app_js(), function_name)
+
+    assert re.search(r"requestId\s*!==\s*\w+RequestId", body), (
+        f"{function_name} never compares its request id before rendering, so "
+        "a slow earlier response can overwrite a newer one"
+    )
+
+
+@pytest.mark.parametrize("function_name", RENDER_PATHS)
+def test_the_render_path_guards_its_failure_branch_too(function_name):
+    """A stale *error* must not blank a panel the newer request just filled."""
+    body = _function_body(_app_js(), function_name)
+    catch_index = body.index("catch")
+
+    assert re.search(r"requestId\s*!==\s*\w+RequestId", body[catch_index:]), (
+        f"{function_name} guards its success path but not its catch block, so "
+        "a late failure can still clobber current content"
+    )
+
+
+def test_every_repeatable_fetch_path_is_covered_by_these_guards():
+    """Catch a new fetch-and-render path being added without a guard.
+
+    The distinction is whether a path can overlap itself. ``refreshOutput``
+    and ``refreshEstimate`` are fired from debounced ``setTimeout`` calls, so
+    two can be in flight at once and a late reply can lose the race. ``boot``
+    is registered once on ``DOMContentLoaded`` and never scheduled, so it
+    cannot overlap and needs no guard.
+
+    Rather than whitelisting names, this derives the exemption: a path is
+    exempt only if the source never schedules or calls it outside an
+    ``addEventListener`` registration.
+    """
+    source = _app_js()
+    fetchers = {
+        name
+        for name in re.findall(r"async function (\w+)\(", source)
+        # `api(` not `await api(`: refreshOutput awaits a Promise.all of two
+        # api() calls, so the awaited token is Promise.all, not api.
+        if "api(" in _function_body(source, name)
+    }
+
+    repeatable = set()
+    for name in fetchers:
+        scheduled = re.search(rf"setTimeout\(\s*{name}\b", source)
+        called = re.search(rf"(?<!function )(?<!addEventListener\(\"DOMContentLoaded\", ){name}\(\)", source)
+        if scheduled or called:
+            repeatable.add(name)
+
+    assert repeatable == set(RENDER_PATHS), (
+        f"repeatable api() paths changed: {sorted(repeatable)} vs guarded "
+        f"{sorted(RENDER_PATHS)}. Add a stale-response guard to any new one "
+        "and list it in RENDER_PATHS."
+    )


### PR DESCRIPTION
## What this is

Brings DMI-configurator onto `main`, applies its layer selection at runtime, adds a payload estimator, and makes the tool launchable in one command.

**Stacked on ProjectDMX/DMI#122.** This targets `feat/dmi-configurator`, not `main`, so the diff is only the follow-up work — 22 files, ~3,200 lines. Review and land #122 first; GitHub will retarget this to `main` automatically when it merges.

## What changed

### Layer selection now reaches the runtime

The configurator let you author a layer range that **nothing applied**. `attach_model` had no way to receive one, so a range picked in the UI changed nothing at capture time. That is the same defect class as the policy control, except the policy control is explicitly disclaimed in the UI and layer selection — the UI's central feature — was not.

`attach_model` now takes a keyword `layers` argument and applies `filter_by_layers` between `apply_hook_selection` and the PP/TP filters, with `dmi.configuration.attach_config` driving it from a `DMIConfig`.

This deviates from the original design, which called for `attach_model` to accept a `CompiledDMIConfig`. That would have been a live bug: `HookPoint.enabled` defaults to `True`, and only `apply_hook_selection` walks the *unselected* specs to turn them off, so handing it a pre-filtered spec list leaves every deselected hook firing. `attach_model` has to own selection. Passing the range instead also keeps `configuration` depending on the runtime rather than the reverse. There is a regression test for exactly that trap.

### Payload estimator

New `dmi.configuration.estimate`, a `POST /api/estimate` endpoint, and a UI panel. It reuses `compute_hook_shape` and `plan_step`'s `align_up(_, 16)` rounding, so the figure the UI shows and the figure `prepare_step` enforces cannot drift.

Three things it deliberately does not do the naive way:

- **Reports the peak single step**, not just a rate. `prepare_step` compares one step against `min(payload_cap, staging_cap)`; over that it returns `STEP_OVERSIZED` and the adapter silently falls back to eager CPU-direct dispatch. Prefill sets that peak.
- **Reports the worst rank.** `compute_hook_shape` divides TP-sharded hooks by `tp_size` while `filter_by_tp_rank` keeps unsharded hooks on rank 0 only, so aggregate bytes are roughly TP-invariant but per-rank pressure is not. `PP_FIRST`/`PP_LAST` skew the stages too.
- **Carries its assumptions and warnings** in the result, and predicts no serving overhead — that needs measurement.

It earns its place immediately. Default Llama-3-8B, `q,k,v` on all 32 layers, batch 8 × 2048 prompt: **6.00 GiB peak step against the default 4 GiB ring**, with the eager-fallback consequence spelled out. That cliff was previously invisible until you ran it.

Workload and ring sizes stay UI-local and out of the YAML, preserving the design decision that `DMIConfig` has no `runtime` block.

### One command to launch

Running it previously took a `PYTHONPATH` prefix, a module path, and a descriptor path you had to know, then opening a browser by hand. Now `make ui` from a checkout, with nothing installed.

- `MODEL` is optional; `dmi ui` uses the descriptor in the current directory when there is exactly one, and lists candidates or points at `describe-model` rather than guessing.
- The browser opens once the port actually accepts a connection — polled, not slept, so a slow first import cannot open a dead page. `--no-browser` opts out.
- The default port walks to the next free one. An explicit `--port` is never moved: a port you named that is busy should fail loudly.
- The startup banner is flushed, since it carries the URL and a `make`-wrapped stdout otherwise held it until exit.
- README documents the configurator for the first time.

The repo-specific default model lives in the Makefile, not in descriptor discovery, so the shipped CLI stays generic.

### UI quality

Keyboard navigation already existed on the architecture diagram, but the renderer's `replaceChildren` **destroyed focus** on every activation. Focus is now restored to the same node. Also adds the missing `:focus-visible` styles (focusable SVG nodes had no visible indicator at all) and a `prefers-reduced-motion` guard.

### Security fix

`d27b69f` closes a path-traversal hole: `model.id` becomes a filename stem, and a hand-written descriptor with `id: ../../etc/pwned` resolved outside the base directory, breaking the documented guarantee that the browser cannot cause a write outside the directory named on the command line. Now validated in `ModelIdentity.__post_init__` so every consumer is covered.

### Design review

`docs/capture-policy-review.md` reviews a proposed capture-policy design against the runtime. Findings worth a reviewer's attention because they bound what the configurator can honestly claim:

- **`CaptureSchedule` is enforced by no shipped adapter.** The UI authors a schedule; nothing applies it. Layer selection and hook selection now do take effect; strides still do not.
- **The transport already provides lossless blocking backpressure** via `prepare_step` and has no drop path at all. So `block` is the status quo and `drop`/`fail` are the new work — the reverse of what the proposal assumed.

The policy module itself is deliberately deferred; the **System objective** radios remain inert behind an explicit in-UI notice.

## Testing

1205 CPU tests pass, 95 added on this branch.

The port and browser tests drive the logic through injected seams rather than binding real sockets, which a sandboxed or restricted CI refuses. Real socket behaviour (busy port reported busy, released port reported free, 8000 busy → 8001) was verified separately.

**Pre-existing failures:** 5 fsync tests in `tests/test_capture_storage.py` and `tests/test_capture_spool.py` fail on this machine. They are untouched by this branch — neither those tests nor `src/dmi/storage/` differ from `main`.

## Reviewer notes

- `make ui` and `POST /api/estimate` were exercised end to end in a browser, including the TP/PP rank breakdown.
- This branch was rebased onto `feat/dmi-configurator` to drop the merge commit. The resulting tree is byte-identical to the pre-rebase state (`git diff` between them is empty).
