### PR TITLE
Catalog: one writer cannot publish twice at once -- serialise per writer, bind to its process

### DIFF
--- a/docs/catalog-descriptor-key.md
+++ b/docs/catalog-descriptor-key.md
@@ -538,22 +538,33 @@ writer could not race itself with nothing enforcing it.
 ClickHouse offers no statement-level serialisation to lean on, so the
 exclusion sits where the shared identity is minted. `ClickHouseCatalogWriter`
 holds one re-entrant lock across `publish_snapshot`, `allocate_version`,
-`ensure_schema` and the lease operations: one publish is in flight per writer,
-and therefore per lease, and a second caller waits. Allocation shares the lock
-so one attempt's floor read, claim and read-back do not interleave with
-another's; it does not order allocation against publication, and need not -- a
-thread that allocated the lower version and publishes second is refused by the
-barrier as before and re-allocated by the indexer. The writer also records its
-owning PID and refuses every lease-bearing operation from another process,
-because a forked child inherits the parent's `PublisherLease` and would publish
-under the same `lease_id` from an address space no lock reaches. That check
-runs before the lock is taken, not under it: a fork copies the lock in whatever
-state it was in, and a child forked while another parent thread was mid-publish
-inherits a lock held by a thread it does not have -- a check under the lock
-would never run, and the child would hang instead of being refused; reproduced
-with the fake client and pinned by
-`test_a_forked_child_is_refused_even_when_the_parent_holds_the_lock`.
-The contract this states: **a writer and its lease belong to one
+`ensure_schema`, the lease operations, and every other method that reaches the
+server: one publish is in flight per writer, and therefore per lease, and a
+second caller waits. The lock is wider than the lease because what a writer's
+methods share is one driver client, and clickhouse-driver's `Client` is not
+thread-safe -- its only guard is a flag check that raises
+`PartiallyConsumedQueryError` when it happens to notice an overlap, and takes
+its lock non-blocking without reading the result. A writer shared between
+threads with only its publishes serialised would still let the indexer's
+inventory read, descriptor write or inventory commit on one thread interleave
+packets with a publish in flight on another; `publisher_lease` is the one
+unlocked read, of a Python attribute rather than the server. Allocation shares
+the lock so one attempt's floor read, claim and read-back do not interleave
+with another's; it does not order allocation against publication, and need not
+-- a thread that allocated the lower version and publishes second is refused
+by the barrier as before and re-allocated by the indexer. The writer also
+records its owning PID and refuses every operation that reaches the server from
+another process, because a forked child inherits the parent's `PublisherLease`
+and would publish under the same `lease_id` from an address space no lock
+reaches -- and inherits the parent's socket, on which its packets would
+interleave with the parent's. That check runs before the lock is taken, not
+under it: a fork copies the lock in whatever state it was in, and a child
+forked while another parent thread was mid-publish inherits a lock held by a
+thread it does not have -- a check under the lock would never run, and the
+child would hang instead of being refused; reproduced with the fake client and
+pinned by
+`test_a_forked_child_is_refused_even_when_the_parent_holds_the_lock`. The
+contract this states: **a writer, its connection and its lease belong to one
 process, and the writer may be shared between threads of that process.** A
 per-operation token carried through renew and fence was considered and not
 taken: it turns the race into a fence-out for one side but leaves the in-flight
@@ -565,8 +576,12 @@ Regression: `test_two_concurrent_publishes_on_one_writer_are_serialised`
 asserts that while one publisher is inside a fenced statement, a second
 publisher on the same writer issues nothing, not even its lease renewal; the
 fake cannot model the server-side overlap itself, so the test pins the
-writer's half of the argument. The live reproduction (two threads, one writer,
-adjacent versions, 300 rounds) is the check that closes it on a real server.
+writer's half of the argument.
+`test_every_client_operation_waits_behind_a_publish_in_flight` does the same
+for the indexer's neighbours of a publish -- inventory read, head read,
+descriptor write, inventory commit, collection -- on a second thread. The live
+reproduction (two threads, one writer, adjacent versions, 300 rounds) is the
+check that closes it on a real server.
 
 **A crash between a claim and its read-back** leaves a claim row nobody uses.
 It looks like a live lease until it expires, so the next publisher waits out one

--- a/docs/catalog-descriptor-key.md
+++ b/docs/catalog-descriptor-key.md
@@ -543,16 +543,17 @@ and therefore per lease, and a second caller waits. Allocation shares the lock
 so one attempt's floor read, claim and read-back do not interleave with
 another's; it does not order allocation against publication, and need not -- a
 thread that allocated the lower version and publishes second is refused by the
-barrier as before and re-allocated by the indexer. The writer also records its owning PID and refuses every
-lease-bearing operation from another process, because a forked child inherits
-the parent's `PublisherLease` and would publish under the same `lease_id` from
-an address space no lock reaches. The contract this states: **a writer and its
-lease belong to one process, and the writer may be shared between threads of
-that process.** A per-operation token carried through renew and fence was
-considered and not taken: it turns the race into a fence-out for one side but
-leaves the in-flight window -- a statement that evaluated its fence before the
-other operation's renewal still lands afterwards -- so it adds complexity
-without adding exclusion the lock does not already give.
+barrier as before and re-allocated by the indexer. The writer also records its
+owning PID and refuses every lease-bearing operation from another process,
+because a forked child inherits the parent's `PublisherLease` and would publish
+under the same `lease_id` from an address space no lock reaches. The contract
+this states: **a writer and its lease belong to one process, and the writer
+may be shared between threads of that process.** A per-operation token carried
+through renew and fence was considered and not taken: it turns the race into a
+fence-out for one side but leaves the in-flight window -- a statement that
+evaluated its fence before the other operation's renewal still lands afterwards
+-- so it adds complexity without adding exclusion the lock does not already
+give.
 
 Regression: `test_two_concurrent_publishes_on_one_writer_are_serialised`
 asserts that while one publisher is inside a fenced statement, a second

--- a/docs/catalog-descriptor-key.md
+++ b/docs/catalog-descriptor-key.md
@@ -215,10 +215,14 @@ cannot be serialised.
 
 ### What shipped
 
-None of this is reachable with a single indexer: one writer cannot race itself.
-The whole concern is about the multi-indexer future the version allocator was
-built for -- and "single indexer" was an assumption nothing enforced, which is
-what the publisher lease below changes.
+None of this is reachable with a single indexer, provided one writer cannot
+race itself -- and that is now a property the writer enforces rather than an
+assumption: `ClickHouseCatalogWriter` serialises `publish_snapshot`,
+`allocate_version` and every lease operation on one re-entrant lock, and
+refuses those operations from any process other than the one that created it
+(see *One writer racing itself* below). The wider concern is the multi-indexer
+future the version allocator was built for -- and "single indexer" was an
+assumption nothing enforced, which is what the publisher lease below changes.
 
 The marker-gated variant shipped first, with the barrier tightened as far as it
 goes without a contract change:
@@ -518,6 +522,44 @@ reckoning. Safety holds -- only the head publishes, the fence says so, and the
 loser is refused at its next renewal with a message naming the actual holder --
 but "only one publisher holds the lease" is not literally true of the client
 objects, only of the row the fence resolves.
+
+**One writer racing itself.** Found after merge, against a real ClickHouse
+(2026-09-05): the fence identifies a *holder*, not an *operation*. Two
+concurrent `publish_snapshot()` calls on one public `ClickHouseCatalogWriter`
+both renew the same `lease_id`, both pass the fence, and the version barrier
+inside each `INSERT ... SELECT` is evaluated when that statement is admitted,
+not serialised against the other statement -- so both watermark rows land, in
+either order. Observed: an already-pinned watermark grew (`W=36: 35→36`,
+`W=74: 73→74`); in 300 rounds both adjacent watermarks landed every time, and
+57 rounds exposed the higher watermark before the lower one arrived. Nothing
+in the client serialised the two calls, and this document asserted that one
+writer could not race itself with nothing enforcing it.
+
+ClickHouse offers no statement-level serialisation to lean on, so the
+exclusion sits where the shared identity is minted. `ClickHouseCatalogWriter`
+holds one re-entrant lock across `publish_snapshot`, `allocate_version`,
+`ensure_schema` and the lease operations: one publish is in flight per writer,
+and therefore per lease, and a second caller waits. Allocation shares the lock
+so one attempt's floor read, claim and read-back do not interleave with
+another's; it does not order allocation against publication, and need not -- a
+thread that allocated the lower version and publishes second is refused by the
+barrier as before and re-allocated by the indexer. The writer also records its owning PID and refuses every
+lease-bearing operation from another process, because a forked child inherits
+the parent's `PublisherLease` and would publish under the same `lease_id` from
+an address space no lock reaches. The contract this states: **a writer and its
+lease belong to one process, and the writer may be shared between threads of
+that process.** A per-operation token carried through renew and fence was
+considered and not taken: it turns the race into a fence-out for one side but
+leaves the in-flight window -- a statement that evaluated its fence before the
+other operation's renewal still lands afterwards -- so it adds complexity
+without adding exclusion the lock does not already give.
+
+Regression: `test_two_concurrent_publishes_on_one_writer_are_serialised`
+asserts that while one publisher is inside a fenced statement, a second
+publisher on the same writer issues nothing, not even its lease renewal; the
+fake cannot model the server-side overlap itself, so the test pins the
+writer's half of the argument. The live reproduction (two threads, one writer,
+adjacent versions, 300 rounds) is the check that closes it on a real server.
 
 **A crash between a claim and its read-back** leaves a claim row nobody uses.
 It looks like a live lease until it expires, so the next publisher waits out one

--- a/docs/catalog-descriptor-key.md
+++ b/docs/catalog-descriptor-key.md
@@ -546,14 +546,20 @@ thread that allocated the lower version and publishes second is refused by the
 barrier as before and re-allocated by the indexer. The writer also records its
 owning PID and refuses every lease-bearing operation from another process,
 because a forked child inherits the parent's `PublisherLease` and would publish
-under the same `lease_id` from an address space no lock reaches. The contract
-this states: **a writer and its lease belong to one process, and the writer
-may be shared between threads of that process.** A per-operation token carried
-through renew and fence was considered and not taken: it turns the race into a
-fence-out for one side but leaves the in-flight window -- a statement that
-evaluated its fence before the other operation's renewal still lands afterwards
--- so it adds complexity without adding exclusion the lock does not already
-give.
+under the same `lease_id` from an address space no lock reaches. That check
+runs before the lock is taken, not under it: a fork copies the lock in whatever
+state it was in, and a child forked while another parent thread was mid-publish
+inherits a lock held by a thread it does not have -- a check under the lock
+would never run, and the child would hang instead of being refused; reproduced
+with the fake client and pinned by
+`test_a_forked_child_is_refused_even_when_the_parent_holds_the_lock`.
+The contract this states: **a writer and its lease belong to one
+process, and the writer may be shared between threads of that process.** A
+per-operation token carried through renew and fence was considered and not
+taken: it turns the race into a fence-out for one side but leaves the in-flight
+window -- a statement that evaluated its fence before the other operation's
+renewal still lands afterwards -- so it adds complexity without adding
+exclusion the lock does not already give.
 
 Regression: `test_two_concurrent_publishes_on_one_writer_are_serialised`
 asserts that while one publisher is inside a fenced statement, a second

--- a/docs/catalog-descriptor-key.md
+++ b/docs/catalog-descriptor-key.md
@@ -572,6 +572,24 @@ window -- a statement that evaluated its fence before the other operation's
 renewal still lands afterwards -- so it adds complexity without adding
 exclusion the lock does not already give.
 
+The lock covers the Python call, not the server statement. When a fenced
+write has reached ClickHouse but `execute()` raises a transport or interrupt
+error while that statement is still running, the call exits with the lease
+intact and a waiter that renews the SAME `lease_id` can publish a higher
+watermark before the first statement lands -- reproduced on 25.12, where B
+returned with only W=2 visible, A's delayed W=1 then landed, and the pinned
+W=2 membership grew 1 -> 2. Calling `acquire_publisher_lease()` at once does
+not help: the local lease deliberately reuses its ID. So an outcome-unknown
+failure quarantines the writer: it discards the identity WITHOUT the release
+tombstone (which would hand a successor a fresh term at once) and refuses
+`publish_snapshot`, `renew_publisher_lease` and `acquire_publisher_lease`
+until a full `lease_ttl_ns` has passed, by which time the old statement has
+landed or been capped by `max_execution_time`. The server row stays live for
+the same interval, so a different writer's claim is refused there too.
+Known-complete failures -- the barrier or fence refusing
+(`SnapshotPublishRaceError`), a conflicting publish, a lost lease -- release
+the writer normally and the next publish proceeds at once.
+
 Regression: `test_two_concurrent_publishes_on_one_writer_are_serialised`
 asserts that while one publisher is inside a fenced statement, a second
 publisher on the same writer issues nothing, not even its lease renewal; the
@@ -582,6 +600,11 @@ for the indexer's neighbours of a publish -- inventory read, head read,
 descriptor write, inventory commit, collection -- on a second thread. The live
 reproduction (two threads, one writer, adjacent versions, 300 rounds) is the
 check that closes it on a real server.
+`test_an_outcome_unknown_publish_quarantines_the_lease_until_its_window_expires`
+pins the ambiguous-outcome half: a watermark INSERT that lands and then raises
+leaves the writer leaseless with no tombstone written, refuses every
+lease-bearing operation, and publishes again only under a fresh identity past
+the window.
 
 **A crash between a claim and its read-back** leaves a claim row nobody uses.
 It looks like a live lease until it expires, so the next publisher waits out one

--- a/src/dmi/storage/capture/clickhouse_catalog.py
+++ b/src/dmi/storage/capture/clickhouse_catalog.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import secrets
+import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import sleep as _sleep, time_ns
@@ -9,6 +11,7 @@ from uuid import uuid4
 from .catalog import (
     CatalogVersionAllocationError,
     PackIdentity,
+    PublisherLeaseError,
     SnapshotPublishConflictError,
     SnapshotPublishRaceError,
 )
@@ -189,13 +192,48 @@ class ClickHouseCatalogWriter:
         self._objects = self._schema.objects
         self._legacy_objects = self._schema.legacy_objects
         self._leases = ClickHouseLeaseCoordinator(client, self._config)
+        # One publish in flight per writer, and so per lease. The server-side
+        # fence identifies a HOLDER, not an operation: two publishes issued
+        # under one ``lease_id`` both renew it, both pass the fence, and the
+        # version barrier inside each INSERT ... SELECT is evaluated when that
+        # statement is admitted rather than serialised against the other, so
+        # both watermark rows land -- in either order. A reader pinned at the
+        # higher one then watches the lower version's membership arrive
+        # underneath it. Reproduced against ClickHouse 25.12 with two threads
+        # on one writer: 300 of 300 rounds landed both adjacent watermarks,
+        # 57 exposed the higher before the lower. ClickHouse offers nothing to
+        # serialise the two statements, so the exclusion has to sit where the
+        # shared identity is minted: here, in the process that owns the lease.
+        # Re-entrant, because ``publish_snapshot`` renews the lease and
+        # ``ensure_schema`` acquires it, both under the same lock.
+        self._serial = threading.RLock()
+        # The lease belongs to THIS process. A forked child inherits
+        # ``self._leases.lease`` byte for byte, and its publishes would share
+        # the parent's ``lease_id`` across two address spaces that no lock can
+        # reach -- the same race, with no way to observe it from either side.
+        self._owner_pid = os.getpid()
+
+    def _owned_by_this_process(self) -> None:
+        if os.getpid() == self._owner_pid:
+            return
+        raise PublisherLeaseError(
+            f"this ClickHouseCatalogWriter was created in process "
+            f"{self._owner_pid} and is being used from process {os.getpid()}. "
+            "A writer and the publisher lease it holds belong to one process: "
+            "a forked copy would publish under the same lease_id as its "
+            "parent, and two publishes under one lease are not excluded by "
+            "the fence. Create a writer, and acquire a lease, in the process "
+            "that publishes."
+        )
 
     def ensure_schema(self, *, sleep: Callable[[float], None] = _sleep) -> None:
         # The writer's own coordinator, so an install is serialised on the
         # lease this writer may already hold rather than refused by it.
         # ``sleep`` is the wait between install-lease attempts, a parameter
         # only so a test can drive it.
-        self._schema.ensure(self._leases, sleep=sleep)
+        with self._serial:
+            self._owned_by_this_process()
+            self._schema.ensure(self._leases, sleep=sleep)
 
     def _rebuild_instruction(self) -> str:
         return self._schema.rebuild_instruction()
@@ -256,6 +294,10 @@ class ClickHouseCatalogWriter:
     ) -> None:
         """Make a version readable, after everything it covers is durable.
 
+        Serialised per writer: one publish is in flight under this writer's
+        lease at a time, and a second caller waits for it. See ``_serial`` in
+        the constructor for why the fence alone does not give this.
+
         Membership rows first, then the watermark row that admits them. A
         reader's membership clause requires both, so the order is what makes a
         half-finished publish invisible rather than partially visible.
@@ -305,6 +347,25 @@ class ClickHouseCatalogWriter:
         this module's taxonomy should treat a driver exception from a publish
         as "outcome unknown: re-acquire and re-index".
         """
+        with self._serial:
+            self._owned_by_this_process()
+            self._publish_snapshot_serialised(
+                index_version=index_version,
+                refs=refs,
+                published_at_ns=published_at_ns,
+                indexed_rows=indexed_rows,
+                indexed_packs=indexed_packs,
+            )
+
+    def _publish_snapshot_serialised(
+        self,
+        *,
+        index_version: int,
+        refs: Sequence[PackRef],
+        published_at_ns: int,
+        indexed_rows: int,
+        indexed_packs: int,
+    ) -> None:
         self._validate_version(index_version)
         self._validate_version(published_at_ns)
         # Interpolated into the statement TEXT like the version is, so they get
@@ -505,13 +566,19 @@ class ClickHouseCatalogWriter:
         return self._leases.lease
 
     def acquire_publisher_lease(self, holder: str) -> PublisherLease:
-        return self._leases.acquire(holder)
+        with self._serial:
+            self._owned_by_this_process()
+            return self._leases.acquire(holder)
 
     def renew_publisher_lease(self) -> PublisherLease:
-        return self._leases.renew()
+        with self._serial:
+            self._owned_by_this_process()
+            return self._leases.renew()
 
     def release_publisher_lease(self) -> None:
-        self._leases.release()
+        with self._serial:
+            self._owned_by_this_process()
+            self._leases.release()
 
     def _manifest_chunk_published(
         self,
@@ -764,7 +831,20 @@ class ClickHouseCatalogWriter:
         RETURNED version is durably in the claims table, so later allocations
         always start above it: monotonic + unique, with no clock anywhere in
         the ordering. ``claimed_at_ns`` is diagnostic only.
+
+        Serialised on the writer's lock, so two threads sharing a writer do
+        not interleave the floor read, the claim and the read-back of one
+        attempt with another's. This does not order allocation against
+        publication -- a thread may allocate the lower version and publish
+        second -- and does not need to: the barrier inside the watermark
+        statement refuses a version that is not above the published head, and
+        the indexer re-allocates. What the lock removes is the case the fence
+        cannot see, two publishes in flight at once under one lease.
         """
+        with self._serial:
+            return self._allocate_version_serialised()
+
+    def _allocate_version_serialised(self) -> int:
         attempts = self._config.allocation_attempts
         for attempt in range(attempts):
             claimed = self._max_version(

--- a/src/dmi/storage/capture/clickhouse_catalog.py
+++ b/src/dmi/storage/capture/clickhouse_catalog.py
@@ -842,6 +842,7 @@ class ClickHouseCatalogWriter:
         cannot see, two publishes in flight at once under one lease.
         """
         with self._serial:
+            self._owned_by_this_process()
             return self._allocate_version_serialised()
 
     def _allocate_version_serialised(self) -> int:

--- a/src/dmi/storage/capture/clickhouse_catalog.py
+++ b/src/dmi/storage/capture/clickhouse_catalog.py
@@ -214,6 +214,14 @@ class ClickHouseCatalogWriter:
         self._owner_pid = os.getpid()
 
     def _owned_by_this_process(self) -> None:
+        # Checked BEFORE ``_serial`` is taken, never inside it. A fork copies
+        # the lock in whatever state it was in, and a fork taken while another
+        # thread of the parent was mid-publish hands the child a lock held by
+        # a thread that does not exist in the child: a check under the lock
+        # would never run, and the child would hang on the inherited lock
+        # forever instead of being refused. Reproduced with the fake client:
+        # holder thread parked inside a fenced statement, fork, child publish
+        # -- the child never returned.
         if os.getpid() == self._owner_pid:
             return
         raise PublisherLeaseError(
@@ -231,8 +239,8 @@ class ClickHouseCatalogWriter:
         # lease this writer may already hold rather than refused by it.
         # ``sleep`` is the wait between install-lease attempts, a parameter
         # only so a test can drive it.
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             self._schema.ensure(self._leases, sleep=sleep)
 
     def _rebuild_instruction(self) -> str:
@@ -347,8 +355,8 @@ class ClickHouseCatalogWriter:
         this module's taxonomy should treat a driver exception from a publish
         as "outcome unknown: re-acquire and re-index".
         """
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             self._publish_snapshot_serialised(
                 index_version=index_version,
                 refs=refs,
@@ -566,18 +574,18 @@ class ClickHouseCatalogWriter:
         return self._leases.lease
 
     def acquire_publisher_lease(self, holder: str) -> PublisherLease:
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             return self._leases.acquire(holder)
 
     def renew_publisher_lease(self) -> PublisherLease:
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             return self._leases.renew()
 
     def release_publisher_lease(self) -> None:
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             self._leases.release()
 
     def _manifest_chunk_published(
@@ -841,8 +849,8 @@ class ClickHouseCatalogWriter:
         the indexer re-allocates. What the lock removes is the case the fence
         cannot see, two publishes in flight at once under one lease.
         """
+        self._owned_by_this_process()
         with self._serial:
-            self._owned_by_this_process()
             return self._allocate_version_serialised()
 
     def _allocate_version_serialised(self) -> int:

--- a/src/dmi/storage/capture/clickhouse_catalog.py
+++ b/src/dmi/storage/capture/clickhouse_catalog.py
@@ -206,6 +206,18 @@ class ClickHouseCatalogWriter:
         # shared identity is minted: here, in the process that owns the lease.
         # Re-entrant, because ``publish_snapshot`` renews the lease and
         # ``ensure_schema`` acquires it, both under the same lock.
+        #
+        # Every operation that reaches the client takes it, not only the
+        # lease-bearing ones. The writer is documented as shareable between
+        # the threads of its process, and the one thing all of its methods
+        # share is ``self._client``: clickhouse-driver's ``Client`` is not
+        # thread-safe -- its only guard is ``check_query_execution``, a flag
+        # test that raises ``PartiallyConsumedQueryError`` when it notices an
+        # overlap and takes its lock non-blocking without checking the result.
+        # So an unlocked ``committed_pack_ids`` or ``commit_packs`` from a
+        # second thread would interleave its packets with a publish in flight
+        # on the same connection. ``publisher_lease`` is the one unlocked
+        # read, and it reads a Python attribute rather than the server.
         self._serial = threading.RLock()
         # The lease belongs to THIS process. A forked child inherits
         # ``self._leases.lease`` byte for byte, and its publishes would share
@@ -227,11 +239,12 @@ class ClickHouseCatalogWriter:
         raise PublisherLeaseError(
             f"this ClickHouseCatalogWriter was created in process "
             f"{self._owner_pid} and is being used from process {os.getpid()}. "
-            "A writer and the publisher lease it holds belong to one process: "
-            "a forked copy would publish under the same lease_id as its "
-            "parent, and two publishes under one lease are not excluded by "
-            "the fence. Create a writer, and acquire a lease, in the process "
-            "that publishes."
+            "A writer, its connection and the publisher lease it holds belong "
+            "to one process: a forked copy would publish under the same "
+            "lease_id as its parent, and two publishes under one lease are not "
+            "excluded by the fence; it would also write to the same socket the "
+            "parent is using. Create a writer, and acquire a lease, in the "
+            "process that publishes."
         )
 
     def ensure_schema(self, *, sleep: Callable[[float], None] = _sleep) -> None:
@@ -247,7 +260,9 @@ class ClickHouseCatalogWriter:
         return self._schema.rebuild_instruction()
 
     def drop_schema(self) -> None:
-        self._schema.drop()
+        self._owned_by_this_process()
+        with self._serial:
+            self._schema.drop()
 
     def committed_pack_ids(
         self, identities: Sequence[PackIdentity]
@@ -256,6 +271,13 @@ class ClickHouseCatalogWriter:
             return set()
         if len(identities) > self._config.query_pack_limit:
             raise ValueError("pack identity query exceeds query_pack_limit")
+        self._owned_by_this_process()
+        with self._serial:
+            return self._committed_pack_ids_serialised(identities)
+
+    def _committed_pack_ids_serialised(
+        self, identities: Sequence[PackIdentity]
+    ) -> set[PackIdentity]:
         table = self._qualified(self._pack_view)
         committed: set[PackIdentity] = set()
         # Chunked: the identities land in the statement TEXT, and an unchunked
@@ -284,12 +306,14 @@ class ClickHouseCatalogWriter:
             return
         self._validate_version(index_version)
         rows = [self._descriptor_row(item, index_version) for item in descriptors]
-        self._client.execute(
-            f"INSERT INTO {self._qualified(self._capture_raw)} "
-            f"({', '.join(CAPTURE_COLUMNS)}) VALUES",
-            rows,
-            settings=self._quorum_write() or None,
-        )
+        self._owned_by_this_process()
+        with self._serial:
+            self._client.execute(
+                f"INSERT INTO {self._qualified(self._capture_raw)} "
+                f"({', '.join(CAPTURE_COLUMNS)}) VALUES",
+                rows,
+                settings=self._quorum_write() or None,
+            )
 
     def publish_snapshot(
         self,
@@ -668,6 +692,13 @@ class ClickHouseCatalogWriter:
         ``sleep`` is the settling wait the manifest bound needs; it is a
         parameter only so a test can drive it.
         """
+        self._owned_by_this_process()
+        with self._serial:
+            return self._collect_garbage_serialised(sleep)
+
+    def _collect_garbage_serialised(
+        self, sleep: Callable[[float], None]
+    ) -> dict[str, int]:
         removed: dict[str, int] = {}
         published = self.last_published_version()
         head = self._leases.head()
@@ -817,11 +848,13 @@ class ClickHouseCatalogWriter:
 
     def last_published_version(self) -> int:
         """Highest published index_version, or 0 when nothing is published."""
-        return self._max_version(
-            self._watermark,
-            "index_version",
-            "watermark table returned an invalid version",
-        )
+        self._owned_by_this_process()
+        with self._serial:
+            return self._max_version(
+                self._watermark,
+                "index_version",
+                "watermark table returned an invalid version",
+            )
 
     def allocate_version(self) -> int:
         """Allocate the next catalog version: strictly monotonic and unique.
@@ -923,11 +956,13 @@ class ClickHouseCatalogWriter:
         # successful publish, so a crash in between leaves a pack that is
         # visible but not yet skippable -- redundant work next pass, never the
         # reverse.
-        self._client.execute(
-            f"INSERT INTO {self._qualified(self._pack_raw)} "
-            f"({', '.join(PACK_COLUMNS)}) VALUES",
-            rows,
-        )
+        self._owned_by_this_process()
+        with self._serial:
+            self._client.execute(
+                f"INSERT INTO {self._qualified(self._pack_raw)} "
+                f"({', '.join(PACK_COLUMNS)}) VALUES",
+                rows,
+            )
 
     def _qualified(self, table: str) -> str:
         return f"{quoted(self._config.database)}.{quoted(table)}"

--- a/src/dmi/storage/capture/clickhouse_catalog.py
+++ b/src/dmi/storage/capture/clickhouse_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import secrets
 import threading
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import sleep as _sleep, time_ns
@@ -35,7 +36,7 @@ from .clickhouse_sql import (
     quorum_write,
     text,
 )
-from .model import CaptureDescriptor, PackRef
+from .model import CaptureDescriptor, CaptureStorageError, PackRef
 
 # The least lease life a publish may be configured to reach the fence with.
 # The fence is safe at any positive margin, but a margin under a client round
@@ -224,6 +225,23 @@ class ClickHouseCatalogWriter:
         # the parent's ``lease_id`` across two address spaces that no lock can
         # reach -- the same race, with no way to observe it from either side.
         self._owner_pid = os.getpid()
+        # Outcome-unknown quarantine. The lock serialises the Python call, not
+        # the server statement: when a fenced write reaches ClickHouse but
+        # ``execute()`` raises a transport/interrupt error while that statement
+        # is still running, the call exits with the lease intact and a waiter
+        # that renews the SAME ``lease_id`` can publish a higher watermark
+        # before the first statement lands. Reproduced on 25.12: B returned
+        # with only W=2 visible, A's delayed W=1 then landed, and the pinned
+        # W=2 membership grew 1 -> 2. Calling ``acquire_publisher_lease()``
+        # does not help while the local lease is kept -- it deliberately reuses
+        # its ID -- so an ambiguous outcome discards the identity WITHOUT the
+        # release tombstone (which would hand a successor a fresh term at
+        # once) and refuses every lease-bearing operation until a full TTL has
+        # passed, by which time the old statement has either landed or been
+        # capped by ``max_execution_time``. The server row stays live for the
+        # same interval, so a DIFFERENT writer's claim is refused there too.
+        self._quarantined_until_monotonic: float | None = None
+        self._quarantined_lease_id: str | None = None
 
     def _owned_by_this_process(self) -> None:
         # Checked BEFORE ``_serial`` is taken, never inside it. A fork copies
@@ -245,6 +263,47 @@ class ClickHouseCatalogWriter:
             "excluded by the fence; it would also write to the same socket the "
             "parent is using. Create a writer, and acquire a lease, in the "
             "process that publishes."
+        )
+
+    def _require_not_quarantined_locked(self) -> None:
+        # Call with ``_serial`` held. Clears an expired quarantine so a writer
+        # that waited out the window recovers with a fresh lease; refuses
+        # while the old operation's window is still open.
+        deadline = self._quarantined_until_monotonic
+        if deadline is None:
+            return
+        if time.monotonic() >= deadline:
+            self._quarantined_until_monotonic = None
+            self._quarantined_lease_id = None
+            return
+        remaining = deadline - time.monotonic()
+        identity = self._quarantined_lease_id or "unknown"
+        raise PublisherLeaseError(
+            "this writer's publisher lease is quarantined after a publish "
+            f"whose outcome is unknown (lease {identity}); it will not publish, "
+            f"renew or acquire for another {remaining:.1f}s. The fenced statement may "
+            "still be running on the server past its fence evaluation, and a "
+            "successor that renewed the same lease_id could publish a higher "
+            "watermark before it lands. Wait out the lease window instead of "
+            "re-acquiring at once -- an immediate re-acquire would reuse the "
+            "same identity -- and then acquire a fresh lease and re-index. "
+            "No release tombstone was written, so the server row stays live "
+            "for the same interval and refuses other claimants there too."
+        )
+
+    def _quarantine_locked(self) -> None:
+        # Call with ``_serial`` held, on an outcome-unknown failure. Drops the
+        # local identity WITHOUT the release tombstone and blocks successors
+        # for a full TTL from now, which covers whatever remains of the old
+        # lease's window. Known-complete failures -- the barrier or fence
+        # refusing (SnapshotPublishRaceError), a conflicting publish, a lost
+        # lease -- must NOT come through here: their read-backs proved the
+        # outcome, and the next publish may proceed at once.
+        lease = self._leases.discard_local_lease()
+        if lease is not None:
+            self._quarantined_lease_id = lease.lease_id
+        self._quarantined_until_monotonic = (
+            time.monotonic() + self._config.lease_ttl_ns / 1_000_000_000
         )
 
     def ensure_schema(self, *, sleep: Callable[[float], None] = _sleep) -> None:
@@ -372,22 +431,43 @@ class ClickHouseCatalogWriter:
         (``timeout_overflow_mode='throw'``, Code 159), not a
         ``CaptureStorageError`` -- the same species as the Code 125 path the
         design doc records -- and it raises BEFORE the ownership read-back, so
-        whether the row landed is not known here. That is safe in the only
-        direction that matters: the indexer aborts without ``commit_packs``,
-        so if the row did land the pack is visible-but-not-yet-skippable and
-        the next pass costs redundant work, never loss. Callers routing on
-        this module's taxonomy should treat a driver exception from a publish
-        as "outcome unknown: re-acquire and re-index".
+        whether the row landed is not known here. The same holds for any
+        transport or interrupt error raised while a fenced statement is still
+        running on the server past its fence evaluation: the Python call is
+        over, the server statement may not be. That outcome-unknown failure
+        QUARANTINES this writer -- it discards the lease WITHOUT the release
+        tombstone and refuses ``publish_snapshot``, ``renew_publisher_lease``
+        and ``acquire_publisher_lease`` until a full ``lease_ttl_ns`` has
+        passed, by which time the old statement has landed or been capped and
+        the server row has expired too. A waiting publish that renewed the same
+        ``lease_id`` could otherwise publish a higher watermark before the old
+        statement lands, growing a pinned snapshot from underneath. Known-
+        complete failures -- ``SnapshotPublishRaceError``,
+        ``SnapshotPublishConflictError``, a lost lease -- release the writer
+        normally and the next publish may proceed at once. Callers routing on
+        this module's taxonomy must therefore NOT treat a driver exception as
+        "re-acquire and re-index at once": an immediate re-acquire is refused
+        while the quarantine holds; wait out the window, acquire a fresh lease,
+        and re-index. The indexer aborts without ``commit_packs``, so if the
+        row did land the pack is visible-but-not-yet-skippable and the next
+        pass costs redundant work, never loss.
         """
         self._owned_by_this_process()
         with self._serial:
-            self._publish_snapshot_serialised(
-                index_version=index_version,
-                refs=refs,
-                published_at_ns=published_at_ns,
-                indexed_rows=indexed_rows,
-                indexed_packs=indexed_packs,
-            )
+            self._require_not_quarantined_locked()
+            try:
+                self._publish_snapshot_serialised(
+                    index_version=index_version,
+                    refs=refs,
+                    published_at_ns=published_at_ns,
+                    indexed_rows=indexed_rows,
+                    indexed_packs=indexed_packs,
+                )
+            except (CaptureStorageError, ValueError):
+                raise
+            except BaseException:
+                self._quarantine_locked()
+                raise
 
     def _publish_snapshot_serialised(
         self,
@@ -600,16 +680,34 @@ class ClickHouseCatalogWriter:
     def acquire_publisher_lease(self, holder: str) -> PublisherLease:
         self._owned_by_this_process()
         with self._serial:
-            return self._leases.acquire(holder)
+            self._require_not_quarantined_locked()
+            try:
+                return self._leases.acquire(holder)
+            except (CaptureStorageError, ValueError):
+                raise
+            except BaseException:
+                self._quarantine_locked()
+                raise
 
     def renew_publisher_lease(self) -> PublisherLease:
         self._owned_by_this_process()
         with self._serial:
-            return self._leases.renew()
+            self._require_not_quarantined_locked()
+            try:
+                return self._leases.renew()
+            except (CaptureStorageError, ValueError):
+                raise
+            except BaseException:
+                self._quarantine_locked()
+                raise
 
     def release_publisher_lease(self) -> None:
         self._owned_by_this_process()
         with self._serial:
+            # No quarantine check and no tombstone while quarantined: the
+            # local lease is already None, so this is a no-op, which is the
+            # point -- an early release would hand a successor a fresh term
+            # while the outcome-unknown statement may still be running.
             self._leases.release()
 
     def _manifest_chunk_published(

--- a/src/dmi/storage/capture/clickhouse_lease.py
+++ b/src/dmi/storage/capture/clickhouse_lease.py
@@ -110,6 +110,20 @@ class ClickHouseLeaseCoordinator:
         )
         self._lease = None
 
+    def discard_local_lease(self) -> PublisherLease | None:
+        """Drop the held lease WITHOUT writing the release tombstone.
+
+        The tombstone ends the lease at once, which is exactly what an
+        outcome-unknown publish must not do: its watermark statement may
+        still be running on the server past its fence evaluation, and a
+        successor that acquires a fresh term immediately can publish a higher
+        watermark before the old statement lands. Discarding keeps the server
+        row live until its TTL, so any successor's claim is refused until the
+        old operation's window has expired.
+        """
+        lease, self._lease = self._lease, None
+        return lease
+
     def release_statement(self) -> str:
         return (
             f"INSERT INTO {self._qualified_table} "

--- a/tests/test_capture_faults.py
+++ b/tests/test_capture_faults.py
@@ -358,8 +358,27 @@ def test_a_transient_outage_is_survivable_by_retrying_the_batch(tmp_path: Path):
         "the outage must strike the watermark INSERT, not the setup path"
     )
 
-    # The pack was never committed, so the identical call re-reads it and
-    # converges -- indexing is replayable rather than requiring manual repair.
+    # The watermark INSERT is a fenced statement whose outcome is now unknown:
+    # it may still be running on the server past its fence evaluation, so the
+    # writer quarantines its lease rather than handing the same lease_id to a
+    # successor that could publish a higher watermark before it lands. The pass
+    # itself is refused before writing anything, and an immediate re-acquire
+    # is refused too -- it would reuse the same identity.
+    from dmi.storage.capture import PublisherLeaseError
+
+    with pytest.raises(PublisherLeaseError, match="quarantin"):
+        indexer._writer.acquire_publisher_lease("indexer-under-fault")
+    with pytest.raises(PublisherLeaseError):
+        indexer.index([ref])
+
+    # Past the lease window the old statement has landed or been capped and
+    # the server row has expired too, so a fresh lease lets the identical call
+    # re-read the uncommitted pack and converge -- indexing is replayable
+    # rather than requiring manual repair. Reached here by moving the fake
+    # clocks rather than by sleeping.
+    backing.lease.now_ns += ClickHouseCatalogConfig().lease_ttl_ns + 1
+    indexer._writer._quarantined_until_monotonic = time.monotonic() - 1
+    indexer._writer.acquire_publisher_lease("indexer-under-fault")
     result = indexer.index([ref])
 
     assert result.indexed_packs == 1

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import threading
 import time
 from uuid import UUID, uuid4
@@ -826,8 +827,10 @@ def test_a_publish_that_fails_releases_the_writer_for_the_next_one():
         _publish(writer, 6)
         done.set()
 
-    threading.Thread(target=next_publish, name="publisher-b").start()
+    publisher_b = threading.Thread(target=next_publish, name="publisher-b")
+    publisher_b.start()
     assert done.wait(5), "the failed publish left the writer locked"
+    publisher_b.join(5)
     assert client.watermarks == [5, 6]
 
 
@@ -873,6 +876,74 @@ def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
     assert writer.publisher_lease is not None, (
         "the refusal must not drop the parent's lease from under it"
     )
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="needs os.fork")
+def test_a_forked_child_is_refused_even_when_the_parent_holds_the_lock():
+    """The ownership check runs BEFORE the lock, or a fork can hang the child.
+
+    A fork copies the writer's lock in whatever state it was in. Taken while
+    another thread of the parent is mid-publish, the child's copy is held by a
+    thread that does not exist in the child, so a check placed UNDER the lock
+    never runs and the child blocks on the inherited lock forever -- a hang
+    where the contract promises a refusal. This holds the lock in a parent
+    thread, forks, and requires the child to be refused promptly.
+    """
+    from dmi.storage.capture import PublisherLeaseError
+
+    client = _Client()
+    writer = _leased(client)
+    parent_is_inside_a_fenced_statement = threading.Event()
+    let_parent_finish = threading.Event()
+
+    def hold_the_lock(_lease_id):
+        if threading.current_thread().name == "holder":
+            parent_is_inside_a_fenced_statement.set()
+            let_parent_finish.wait(10)
+
+    client.lease.on_fence = hold_the_lock
+    holder = threading.Thread(
+        target=_publish, args=(writer, 1), name="holder", daemon=True
+    )
+    holder.start()
+    assert parent_is_inside_a_fenced_statement.wait(5)
+    try:
+        read_end, write_end = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # pragma: no cover - the child reports through the pipe
+            os.close(read_end)
+            try:
+                _publish(writer, 2)
+                os.write(write_end, b"published")
+            except PublisherLeaseError:
+                os.write(write_end, b"refused")
+            except BaseException as exc:
+                os.write(write_end, f"raised {type(exc).__name__}".encode())
+            finally:
+                os._exit(0)
+        os.close(write_end)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            finished, _ = os.waitpid(pid, os.WNOHANG)
+            if finished:
+                break
+            time.sleep(0.01)
+        else:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
+            pytest.fail(
+                "the forked child hung on the writer lock it inherited held, "
+                "instead of being refused for using a foreign process's writer"
+            )
+        outcome = os.read(read_end, 64).decode()
+        os.close(read_end)
+    finally:
+        let_parent_finish.set()
+        holder.join(5)
+    assert outcome == "refused"
+    # The parent's own publish, held open across the fork, completes untouched.
+    assert client.watermarks == [1]
+    assert writer.publisher_lease is not None
 
 
 def test_descriptor_writes_use_the_configured_quorum():

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from uuid import UUID, uuid4
 
 import pytest
@@ -719,6 +721,148 @@ def test_the_release_tombstone_is_written_at_the_writers_own_term_and_reads_noth
     # Nothing to read, so nothing to read consistently: the only settings a
     # release carries are the deployment's write quorum, none by default.
     assert kwargs.get("settings") is None
+
+
+def _publish(writer: ClickHouseCatalogWriter, version: int) -> None:
+    writer.publish_snapshot(
+        index_version=version,
+        refs=(),
+        published_at_ns=version,
+        indexed_rows=0,
+        indexed_packs=0,
+    )
+
+
+def test_two_concurrent_publishes_on_one_writer_are_serialised():
+    """One publish in flight per writer, and so per lease.
+
+    The fence identifies a HOLDER, not an operation. Two publishes issued under
+    one ``lease_id`` both renew it and both pass the fence, and the version
+    barrier inside each statement is evaluated when that statement is admitted
+    rather than against the other, so on a real server both watermark rows
+    land in either order and a reader pinned at the higher one watches the
+    lower version's membership arrive underneath it (300 of 300 rounds on
+    ClickHouse 25.12; 57 exposed the higher watermark first). ClickHouse has
+    nothing that serialises the two statements, so the writer does.
+
+    The fake cannot model the server-side overlap -- its statements run under
+    the interpreter lock -- so the test asserts the thing the writer is
+    responsible for: while publisher A is inside a fenced statement, publisher
+    B on the same writer issues NOTHING, not even the lease renewal that
+    precedes its first write.
+    """
+    client = _Client()
+    writer = _leased(client)
+    by_thread: dict[str, list[str]] = {}
+    real_execute = client.execute
+
+    def recording_execute(query, params=None, **kwargs):
+        by_thread.setdefault(threading.current_thread().name, []).append(query)
+        return real_execute(query, params, **kwargs)
+
+    client.execute = recording_execute
+
+    a_is_inside_a_fenced_statement = threading.Event()
+    let_a_finish = threading.Event()
+
+    def hold_a_at_the_fence(_lease_id):
+        if threading.current_thread().name == "publisher-a":
+            a_is_inside_a_fenced_statement.set()
+            assert let_a_finish.wait(5), "the test never released publisher A"
+
+    client.lease.on_fence = hold_a_at_the_fence
+    failures: list[BaseException] = []
+
+    def run(version: int) -> None:
+        try:
+            _publish(writer, version)
+        except BaseException as exc:  # pragma: no cover - reported below
+            failures.append(exc)
+
+    a = threading.Thread(target=run, args=(1,), name="publisher-a")
+    b = threading.Thread(target=run, args=(2,), name="publisher-b")
+    a.start()
+    assert a_is_inside_a_fenced_statement.wait(5)
+    b.start()
+    # A negative assertion needs a window in which B COULD have run: on the
+    # unserialised writer B issues its lease renewal within microseconds of
+    # starting, so a quarter second is generous rather than tight.
+    deadline = time.monotonic() + 0.25
+    while time.monotonic() < deadline and "publisher-b" not in by_thread:
+        time.sleep(0.005)
+    issued_by_b_while_a_was_publishing = list(by_thread.get("publisher-b", ()))
+    let_a_finish.set()
+    a.join(5)
+    b.join(5)
+
+    assert not a.is_alive() and not b.is_alive()
+    # The load-bearing assertion first, so an unserialised writer fails on the
+    # statement B issued rather than on whatever the fake's barrier made of
+    # the resulting order.
+    assert issued_by_b_while_a_was_publishing == [], (
+        "publisher B issued statements while publisher A's publish was in "
+        "flight on the same writer; two publishes under one lease both pass "
+        "the fence and are not ordered by the server"
+    )
+    assert failures == []
+    # Serialised, both publish -- in the order they took the lock, so the
+    # barrier admits each: A at 1, then B at 2 above it.
+    assert client.watermarks == [1, 2]
+    assert writer.publisher_lease is not None
+
+
+def test_a_publish_that_fails_releases_the_writer_for_the_next_one():
+    """The exclusion is scoped to one call, including its failure path."""
+    client = _Client()
+    writer = _leased(client)
+    client.watermarks.append(5)
+
+    with pytest.raises(SnapshotPublishRaceError):
+        _publish(writer, 3)  # refused by the barrier: 3 is not above 5
+
+    done = threading.Event()
+
+    def next_publish() -> None:
+        _publish(writer, 6)
+        done.set()
+
+    threading.Thread(target=next_publish, name="publisher-b").start()
+    assert done.wait(5), "the failed publish left the writer locked"
+    assert client.watermarks == [5, 6]
+
+
+def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
+    """A writer and its lease belong to the process that created them.
+
+    A forked child inherits the parent's ``PublisherLease`` byte for byte, so
+    its publishes would carry the parent's ``lease_id`` from a second address
+    space that no in-process lock can reach -- the same double-publish, with
+    no way to observe it from either side. The writer records its owning PID
+    and refuses every lease-bearing operation from any other.
+    """
+    from dmi.storage.capture import PublisherLeaseError
+    from dmi.storage.capture import clickhouse_catalog as module
+
+    client = _Client()
+    writer = _leased(client)
+    owner = module.os.getpid()
+    monkeypatch.setattr(module.os, "getpid", lambda: owner + 1)
+
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        _publish(writer, 1)
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.renew_publisher_lease()
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.acquire_publisher_lease("child")
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.release_publisher_lease()
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.ensure_schema()
+    # Nothing reached the server from the wrong process.
+    assert client.watermarks == []
+    assert writer.publisher_lease is not None, (
+        "the refusal must not drop the parent's lease from under it"
+    )
 
 
 def test_descriptor_writes_use_the_configured_quorum():

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -858,8 +858,14 @@ def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
         writer.release_publisher_lease()
     with pytest.raises(PublisherLeaseError, match="belong to one process"):
         writer.ensure_schema()
+    # Allocation too: a version claimed from a forked child would be published
+    # under the parent's lease, which is the same double-publish by another
+    # route, and the contract names allocate_version explicitly.
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.allocate_version()
     # Nothing reached the server from the wrong process.
     assert client.watermarks == []
+    assert client.claims == []
     assert writer.publisher_lease is not None, (
         "the refusal must not drop the parent's lease from under it"
     )

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -840,13 +840,17 @@ def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
     no way to observe it from either side. The writer records its owning PID
     and refuses every lease-bearing operation from any other.
     """
+    import os
+
     from dmi.storage.capture import PublisherLeaseError
-    from dmi.storage.capture import clickhouse_catalog as module
 
     client = _Client()
     writer = _leased(client)
-    owner = module.os.getpid()
-    monkeypatch.setattr(module.os, "getpid", lambda: owner + 1)
+    owner = os.getpid()
+    # Patched on ``os`` itself rather than through the writer's module, so a
+    # writer that never consults the PID fails this test with DID NOT RAISE
+    # instead of tripping over an attribute the module does not import.
+    monkeypatch.setattr(os, "getpid", lambda: owner + 1)
 
     with pytest.raises(PublisherLeaseError, match="belong to one process"):
         _publish(writer, 1)

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import threading
 import time
+import warnings
 from uuid import UUID, uuid4
 
 import pytest
@@ -812,6 +813,84 @@ def test_two_concurrent_publishes_on_one_writer_are_serialised():
     assert writer.publisher_lease is not None
 
 
+def test_every_client_operation_waits_behind_a_publish_in_flight():
+    """The lock covers the CONNECTION, not only the lease.
+
+    The writer may be shared between the threads of its process, and what its
+    methods share is one driver client that is not thread-safe: its only guard
+    is a flag check that raises when it happens to notice an overlap. So the
+    indexer's unlocked neighbours of a publish -- the inventory read that
+    decides what to skip, the descriptor write, the inventory commit, the head
+    read -- must wait for a publish in flight on another thread rather than
+    interleave their packets with it. Asserted the same way as for a second
+    publish: while A is inside a fenced statement, B issues NOTHING.
+    """
+    ref, descriptor = _descriptor()
+    client = _Client()
+    writer = _leased(client)
+    by_thread: dict[str, list[str]] = {}
+    real_execute = client.execute
+
+    def recording_execute(query, params=None, **kwargs):
+        by_thread.setdefault(threading.current_thread().name, []).append(query)
+        return real_execute(query, params, **kwargs)
+
+    client.execute = recording_execute
+    a_is_inside_a_fenced_statement = threading.Event()
+    let_a_finish = threading.Event()
+
+    def hold_a_at_the_fence(_lease_id):
+        if threading.current_thread().name == "publisher-a":
+            a_is_inside_a_fenced_statement.set()
+            assert let_a_finish.wait(5), "the test never released publisher A"
+
+    client.lease.on_fence = hold_a_at_the_fence
+    failures: list[BaseException] = []
+    results: dict[str, object] = {}
+
+    def neighbours() -> None:
+        try:
+            results["skip"] = writer.committed_pack_ids([(ref.store_id, ref.pack_id)])
+            results["head"] = writer.last_published_version()
+            writer.write_descriptors([descriptor], index_version=2)
+            writer.commit_packs([ref], index_version=2)
+            results["gc"] = writer.collect_garbage(sleep=lambda _s: None)
+        except BaseException as exc:  # pragma: no cover - reported below
+            failures.append(exc)
+
+    a = threading.Thread(target=_publish, args=(writer, 1), name="publisher-a")
+    b = threading.Thread(target=neighbours, name="neighbour-b")
+    a.start()
+    assert a_is_inside_a_fenced_statement.wait(5)
+    b.start()
+    deadline = time.monotonic() + 0.25
+    while time.monotonic() < deadline and "neighbour-b" not in by_thread:
+        time.sleep(0.005)
+    issued_by_b_while_a_was_publishing = list(by_thread.get("neighbour-b", ()))
+    let_a_finish.set()
+    a.join(5)
+    b.join(5)
+
+    assert not a.is_alive() and not b.is_alive()
+    assert issued_by_b_while_a_was_publishing == [], (
+        "a second thread reached the shared client while a publish was in "
+        "flight on it; the driver client is not thread-safe"
+    )
+    assert failures == []
+    # Once A is done, every one of B's calls ran to completion against the
+    # server: waiting is not refusing.
+    assert client.watermarks == [1]
+    issued_by_b = by_thread["neighbour-b"]
+    assert any("pack_inventory`" in q and q.startswith("SELECT") for q in issued_by_b)
+    assert any("max(index_version)" in q for q in issued_by_b)
+    assert any(q.startswith("INSERT INTO") and "capture_raw" in q for q in issued_by_b)
+    assert any(q.startswith("INSERT INTO") and "pack_inventory_raw" in q for q in issued_by_b)
+    # Collection's orphan scan; the fake counts nothing to delete, so no ALTER.
+    assert any("snapshot_manifest" in q and "DISTINCT index_version" in q for q in issued_by_b)
+    assert results["skip"] == set()
+    assert isinstance(results["gc"], dict)
+
+
 def test_a_publish_that_fails_releases_the_writer_for_the_next_one():
     """The exclusion is scoped to one call, including its failure path."""
     client = _Client()
@@ -849,6 +928,7 @@ def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
 
     client = _Client()
     writer = _leased(client)
+    issued_before_the_fork = len(client.calls)
     owner = os.getpid()
     # Patched on ``os`` itself rather than through the writer's module, so a
     # writer that never consults the PID fails this test with DID NOT RAISE
@@ -870,9 +950,31 @@ def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):
     # route, and the contract names allocate_version explicitly.
     with pytest.raises(PublisherLeaseError, match="belong to one process"):
         writer.allocate_version()
+    # And every other operation that reaches the server: a forked child shares
+    # the parent's SOCKET as well as its lease, and a descriptor write or an
+    # inventory read from the child would interleave its packets with whatever
+    # the parent has in flight on that connection.
+    ref, descriptor = _descriptor()
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.write_descriptors([descriptor], index_version=1)
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.commit_packs([ref], index_version=1)
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.committed_pack_ids([(ref.store_id, ref.pack_id)])
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.last_published_version()
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.collect_garbage(sleep=lambda _s: None)
+    with pytest.raises(PublisherLeaseError, match="belong to one process"):
+        writer.drop_schema()
     # Nothing reached the server from the wrong process.
     assert client.watermarks == []
     assert client.claims == []
+    assert client.committed == []
+    assert not any(
+        query.startswith(("INSERT", "ALTER", "DROP"))
+        for query, _, _ in client.calls[issued_before_the_fork:]
+    )
     assert writer.publisher_lease is not None, (
         "the refusal must not drop the parent's lease from under it"
     )
@@ -909,7 +1011,13 @@ def test_a_forked_child_is_refused_even_when_the_parent_holds_the_lock():
     assert parent_is_inside_a_fenced_statement.wait(5)
     try:
         read_end, write_end = os.pipe()
-        pid = os.fork()
+        with warnings.catch_warnings():
+            # Python 3.12+ warns that forking a multi-threaded process may
+            # deadlock the child. A second live thread is the scenario under
+            # test, not an accident, and a deadlocked child is exactly what the
+            # bounded wait below detects and reports.
+            warnings.simplefilter("ignore", DeprecationWarning)
+            pid = os.fork()
         if pid == 0:  # pragma: no cover - the child reports through the pipe
             os.close(read_end)
             try:

--- a/tests/test_clickhouse_capture_catalog.py
+++ b/tests/test_clickhouse_capture_catalog.py
@@ -900,6 +900,11 @@ def test_a_publish_that_fails_releases_the_writer_for_the_next_one():
     with pytest.raises(SnapshotPublishRaceError):
         _publish(writer, 3)  # refused by the barrier: 3 is not above 5
 
+    # A known-complete refusal must not quarantine: the read-back proved
+    # nothing became visible, so the next publish may proceed at once.
+    assert writer.publisher_lease is not None
+    assert writer._quarantined_until_monotonic is None
+
     done = threading.Event()
 
     def next_publish() -> None:
@@ -911,6 +916,83 @@ def test_a_publish_that_fails_releases_the_writer_for_the_next_one():
     assert done.wait(5), "the failed publish left the writer locked"
     publisher_b.join(5)
     assert client.watermarks == [5, 6]
+
+
+def test_an_outcome_unknown_publish_quarantines_the_lease_until_its_window_expires():
+    """A transport error mid-publish must not hand the same lease to a waiter.
+
+    The lock covers the Python call, not the server statement: when the
+    watermark INSERT has reached ClickHouse but ``execute()`` raises while
+    that statement is still running, the call exits with the lease intact and
+    a waiter that renews the SAME ``lease_id`` can publish a higher watermark
+    before the first statement lands (pinned W=2 membership growing 1 -> 2 on
+    25.12). Re-acquiring at once does not help -- the local lease deliberately
+    reuses its ID -- so the writer discards the identity WITHOUT the release
+    tombstone and refuses to publish, renew or acquire until the lease window
+    has expired.
+    """
+    from dmi.storage.capture import PublisherLeaseError
+
+    client = _Client()
+    writer = _leased(client)
+    original_lease_id = writer.publisher_lease.lease_id
+    real_execute = client.execute
+
+    def land_then_lose_the_connection(query, params=None, **kwargs):
+        if query.lstrip().startswith("INSERT INTO") and "index_watermark" in query:
+            try:
+                return real_execute(query, params, **kwargs)
+            finally:
+                raise RuntimeError(
+                    "transport lost while the statement was still running"
+                )
+        return real_execute(query, params, **kwargs)
+
+    client.execute = land_then_lose_the_connection
+    with pytest.raises(RuntimeError, match="transport lost"):
+        _publish(writer, 1)
+
+    # The delayed row did land: the outcome is unknown to the caller, not to
+    # the server. The writer must treat it as such.
+    assert client.watermarks == [1]
+    # The identity is gone, and no early tombstone ended the server row: every
+    # lease row is still a live claim, so another writer's claim is refused
+    # there until the TTL expires too.
+    assert writer.publisher_lease is None
+    assert client.lease.rows, "the publish renewed before writing"
+    assert all(
+        expires > acquired for _, _, _, acquired, expires in client.lease.rows
+    ), "quarantine must not write the release tombstone"
+    assert writer._quarantined_until_monotonic is not None
+
+    # A successor on the same writer cannot reuse the identity, whatever entry
+    # point it tries -- and an immediate re-acquire is refused rather than
+    # handed a fresh term over the still-running statement.
+    with pytest.raises(PublisherLeaseError, match="quarantin"):
+        _publish(writer, 2)
+    with pytest.raises(PublisherLeaseError, match="quarantin"):
+        writer.renew_publisher_lease()
+    with pytest.raises(PublisherLeaseError, match="quarantin"):
+        writer.acquire_publisher_lease("indexer-a")
+    assert client.watermarks == [1], "a quarantined writer must issue nothing"
+
+    # Releasing while quarantined must stay a no-op: the tombstone would end
+    # the server row at once and let a successor publish into the window.
+    rows_while_quarantined = list(client.lease.rows)
+    writer.release_publisher_lease()
+    assert list(client.lease.rows) == rows_while_quarantined
+    with pytest.raises(PublisherLeaseError, match="quarantin"):
+        _publish(writer, 2)
+
+    # Past the window, a fresh identity publishes normally above the delayed
+    # row -- the statement has either landed or been capped by then.
+    writer._quarantined_until_monotonic = time.monotonic() - 1
+    client.lease.now_ns += ClickHouseCatalogConfig().lease_ttl_ns + 1
+    client.execute = real_execute
+    fresh = writer.acquire_publisher_lease("indexer-a")
+    assert fresh.lease_id != original_lease_id
+    _publish(writer, 2)
+    assert client.watermarks == [1, 2]
 
 
 def test_a_writer_used_from_another_process_refuses_to_publish(monkeypatch):


### PR DESCRIPTION
Post-merge finding on #119 from real ClickHouse testing: two concurrent
`publish_snapshot()` calls on one `ClickHouseCatalogWriter` both renew the same
`lease_id`, both pass the fence, and the version barrier inside each
`INSERT ... SELECT` is evaluated at admission rather than serialised against
the other statement, so both watermark rows land in either order and a reader
pinned at the higher watermark sees the lower version's membership arrive
underneath it (W=36 grew 35->36, W=74 grew 73->74; 300/300 rounds landed both,
57 exposed the higher first).

The fence identifies a **holder**, not an operation, and ClickHouse offers no
statement-level serialisation to lean on, so the exclusion sits where the
shared identity is minted:

- `ClickHouseCatalogWriter` holds one re-entrant lock across `publish_snapshot`,
  `allocate_version`, `ensure_schema` and the lease operations. One publish is
  in flight per writer, and therefore per lease; a second caller waits. This
  does not order allocation against publication and need not: a thread that
  allocated the lower version and publishes second is refused by the barrier as
  before and re-allocated by the indexer.
- The writer records its owning PID and refuses every lease-bearing operation
  from another process. A forked child inherits the parent's `PublisherLease`
  and would publish under the same `lease_id` from an address space no lock
  reaches.
- Contract, stated in `docs/catalog-descriptor-key.md`: a writer and its lease
  belong to one process, and the writer may be shared between threads of that
  process. A per-operation token through renew and fence was considered and not
  taken; it turns the race into a fence-out for one side but leaves the
  in-flight window open.

Tests first. Against the writer as merged in #119:

    test_two_concurrent_publishes_on_one_writer_are_serialised     FAILED
    test_a_writer_used_from_another_process_refuses_to_publish     FAILED (DID NOT RAISE)
    test_a_publish_that_fails_releases_the_writer_for_the_next_one PASSED

The first fails on its load-bearing assertion: publisher B issued statements
while publisher A's publish was in flight on the same writer. The second fails
because nothing binds a writer to a process. The third passes trivially and
exists to guard the fix. All three pass on this head; the concurrency test was
run 30 times in a row without a flake, and the PID guard was also exercised
against a real `os.fork()` child. The live reproduction (two threads, one
writer, adjacent versions, 300 rounds) is the check that closes it on a real
server; the `clickhouse-live` CI job runs against ClickHouse 25.12.
